### PR TITLE
refactor: standardize build flag to BUILD_WITH_COMMON_SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,14 +51,14 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(USE_LOCKFREE "Use lock-free implementation" ON)
 option(USE_THREAD_SYSTEM "Use external thread_system if available" ON)
 option(LOGGER_STANDALONE "Build in standalone mode without thread_system" OFF)
-option(USE_COMMON_SYSTEM "Enable common_system integration" ON)
+option(BUILD_WITH_COMMON_SYSTEM "Enable common_system integration" ON)
 option(NO_VCPKG "Skip vcpkg and use system libraries only" OFF)
 
-if(USE_COMMON_SYSTEM)
+if(BUILD_WITH_COMMON_SYSTEM)
     set(_LOGGER_COMMON_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include/kcenon/common/patterns/result.h")
     if(NOT EXISTS "${_LOGGER_COMMON_HEADER}")
-        message(WARNING "common_system integration requested but required headers were not found - disabling USE_COMMON_SYSTEM")
-        set(USE_COMMON_SYSTEM OFF CACHE BOOL "Enable common_system integration" FORCE)
+        message(WARNING "common_system integration requested but required headers were not found - disabling BUILD_WITH_COMMON_SYSTEM")
+        set(BUILD_WITH_COMMON_SYSTEM OFF CACHE BOOL "Enable common_system integration" FORCE)
     endif()
 endif()
 
@@ -273,13 +273,13 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
                 $<INSTALL_INTERFACE:include>
         )
 
-        if(USE_COMMON_SYSTEM)
+        if(BUILD_WITH_COMMON_SYSTEM)
             message(STATUS "Logger System: Enabling common_system integration")
             target_include_directories(LoggerSystem
                 PUBLIC
                     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include>
             )
-            target_compile_definitions(LoggerSystem PUBLIC LOGGER_USE_COMMON_SYSTEM USE_COMMON_SYSTEM)
+            target_compile_definitions(LoggerSystem PUBLIC LOGGER_BUILD_WITH_COMMON_SYSTEM BUILD_WITH_COMMON_SYSTEM)
         endif()
 
         # Add thread_system integration if available and not explicitly disabled

--- a/README.md
+++ b/README.md
@@ -814,6 +814,8 @@ cmake --build .
 - `BUILD_BENCHMARKS`: Build performance benchmarks (default: OFF)
 - `BUILD_SAMPLES`: Build example programs (default: ON)
 - `USE_LOCKFREE`: Use lock-free implementation (default: ON)
+- `BUILD_WITH_COMMON_SYSTEM`: Enable common_system integration for standardized interfaces (default: ON)
+- `USE_THREAD_SYSTEM`: Use external thread_system if available (default: ON)
 
 ## Testing
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ if(BUILD_SAMPLES)
 endif()
 
 # Advanced examples - only available in integration mode and when samples are enabled
-if(NOT LOGGER_STANDALONE_MODE AND BUILD_SAMPLES AND NOT USE_COMMON_SYSTEM)
+if(NOT LOGGER_STANDALONE_MODE AND BUILD_SAMPLES AND NOT BUILD_WITH_COMMON_SYSTEM)
     # Metrics demo sample
     add_executable(metrics_demo metrics_demo.cpp)
     target_link_libraries(metrics_demo PRIVATE LoggerSystem)
@@ -44,7 +44,7 @@ if(NOT LOGGER_STANDALONE_MODE AND BUILD_SAMPLES AND NOT USE_COMMON_SYSTEM)
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
     )
 else()
-    if(USE_COMMON_SYSTEM)
+    if(BUILD_WITH_COMMON_SYSTEM)
         message(STATUS "Advanced examples skipped when common_system integration is enabled")
     else()
         message(STATUS "Advanced examples skipped in standalone mode")

--- a/include/kcenon/logger/adapters/common_system_adapter.h
+++ b/include/kcenon/logger/adapters/common_system_adapter.h
@@ -9,7 +9,7 @@
 #include <unordered_map>
 
 // Check if common_system is available
-#ifdef USE_COMMON_SYSTEM
+#ifdef BUILD_WITH_COMMON_SYSTEM
 #include <kcenon/common/interfaces/logger_interface.h>
 #include <kcenon/common/patterns/result.h>
 #endif
@@ -19,7 +19,7 @@
 
 namespace kcenon::logger::adapters {
 
-#ifdef USE_COMMON_SYSTEM
+#ifdef BUILD_WITH_COMMON_SYSTEM
 
 /**
  * @brief Adapter to expose kcenon::logger as common::interfaces::ILogger
@@ -319,6 +319,6 @@ public:
     }
 };
 
-#endif // USE_COMMON_SYSTEM
+#endif // BUILD_WITH_COMMON_SYSTEM
 
 } // namespace kcenon::logger::adapters


### PR DESCRIPTION
## Summary
- Standardizes build configuration flag from `USE_COMMON_SYSTEM` to `BUILD_WITH_COMMON_SYSTEM`
- Maintains consistency with thread_system and other ecosystem projects
- Updates documentation to reflect the standardized build option

## Changes
- **CMakeLists.txt**: Replaced all occurrences of `USE_COMMON_SYSTEM` with `BUILD_WITH_COMMON_SYSTEM`
- **examples/CMakeLists.txt**: Updated conditional compilation checks
- **include/kcenon/logger/adapters/common_system_adapter.h**: Updated preprocessor directives
- **README.md**: Added documentation for the `BUILD_WITH_COMMON_SYSTEM` option

## Rationale
The `BUILD_` prefix follows CMake naming conventions for build-time configuration options, making it immediately clear that this is a compile-time setting rather than a runtime configuration.

## Compatibility
- Fully backward compatible at the API level
- Build scripts may need updating if they explicitly set `USE_COMMON_SYSTEM`
- The new flag maintains the same default behavior (ON)

## Testing
- Verified build with `BUILD_WITH_COMMON_SYSTEM=ON` (integrated mode)
- Verified build with `BUILD_WITH_COMMON_SYSTEM=OFF` (standalone mode)
- All existing tests pass without modification

## Related PRs
- thread_system: Similar standardization applied
- Part of ecosystem-wide build configuration alignment