### PR TITLE
Phase 1: Build Configuration Standardization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,12 @@ project(
 )
 
 ##################################################
-# C++ standard requirements with graceful degradation
+# C++ standard requirements
 ##################################################
 
-# Default to C++20 but support graceful degradation to C++17
-option(FORCE_CPP17 "Force C++17 standard (disable C++20 features)" OFF)
-
-if(FORCE_CPP17)
-    set(CMAKE_CXX_STANDARD 17)
-    message(STATUS "Logger System: Forcing C++17 mode - C++20 features will be disabled")
-else()
-    set(CMAKE_CXX_STANDARD 20)
-    message(STATUS "Logger System: Using C++20 mode - Enhanced features enabled")
-endif()
+# C++20 is required (unified across all systems)
+set(CMAKE_CXX_STANDARD 20)
+message(STATUS "Logger System: Using C++20 mode - Enhanced features enabled")
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
## Summary
- Remove C++17 fallback support
- Enforce C++20 as the only supported standard
- Align with system-wide C++20 requirement

## Changes
- Removed FORCE_CPP17 option
- Removed conditional C++17/C++20 logic
- Set C++20 as required standard

## Testing
Build verification needed after merge

## Part of
Phase 1: Build Configuration Standardization - Task 1.1