### PR TITLE
Phase 2: Interface Unification (Logger)

### DIFF
--- a/NEED_TO_FIX.md
+++ b/NEED_TO_FIX.md
@@ -1,0 +1,980 @@
+# System Integration Issues and Fix Plan
+
+## Executive Summary
+
+This document outlines critical integration issues across seven systems (common_system, thread_system, logger_system, monitoring_system, container_system, database_system, network_system) and provides a phased approach to resolve them.
+
+**Overall Status**: 🟢 Good - Phase 1 completed, Phase 2 partially completed
+
+**Phase 1 Progress**: ✅ Completed (2/4 critical issues resolved)
+
+**Phase 2 Progress**: 🔄 Partially Completed (Task 2.1 ✅, Task 2.2 ✅, Task 2.3 ⏳, Task 2.4 ⏳)
+
+**Priority**: Address build configuration issues first, then interface unification, followed by adapter optimization.
+
+---
+
+## 📋 Critical Issues Overview
+
+| Issue | Severity | Impact | Systems Affected | Status |
+|-------|----------|--------|------------------|--------|
+| C++ Standard Mismatch | ~~🔴 Critical~~ | ~~Build failures in integrated mode~~ | ~~All systems~~ | ✅ FIXED |
+| Interface Duplication | ~~🔴 Critical~~ | ~~Type conversion overhead, maintenance burden~~ | ~~thread_system, logger_system~~ | ✅ PARTIALLY FIXED (Logger ✅, Executor ✅) |
+| CMake Flag Inconsistency | ~~🟠 Major~~ | ~~Integration unpredictability~~ | ~~All systems~~ | ✅ FIXED |
+| Bidirectional Adapters | 🟡 Moderate | Runtime overhead, circular conversion risk | thread_system, logger_system, monitoring_system | 🔄 Deprecated (Phase 3 removal) |
+| Dependency Detection | 🟡 Moderate | Build path issues | thread_system, monitoring_system | 🔄 Phase 2 |
+| Namespace Conflicts | 🟢 Minor | Potential symbol collisions | thread_system, monitoring_system | 🔄 Phase 4 |
+
+---
+
+## 🚀 Phase 1: Build Configuration Standardization ✅ COMPLETED
+
+**Goal**: Ensure all systems build consistently with unified settings
+
+**Priority**: 🔴 Critical - Blocking all integration work
+
+**Status**: ✅ Completed (2025-10-02)
+
+**Pull Requests**:
+- common_system: https://github.com/kcenon/common_system/pull/11
+- logger_system: https://github.com/kcenon/logger_system/pull/22
+- monitoring_system: https://github.com/kcenon/monitoring_system/pull/23
+- thread_system: https://github.com/kcenon/thread_system/pull/26
+- container_system: https://github.com/kcenon/container_system/pull/5
+- database_system: https://github.com/kcenon/database_system/pull/11
+- network_system: https://github.com/kcenon/network_system/pull/14
+
+### Task 1.1: C++ Standard Unification
+
+**Current State**:
+- common_system: C++17
+- thread_system: C++20 (REQUIRED)
+- logger_system: C++20 (with C++17 fallback)
+- container_system: Not specified
+- database_system: Not specified
+- network_system: Uses C++20 coroutines
+- monitoring_system: Not specified
+
+**Target State**: All systems use C++20 as required standard
+
+**Actions**:
+- [x] Update common_system/CMakeLists.txt ✅
+  ```cmake
+  # Changed from C++17 to C++20
+  set(CMAKE_CXX_STANDARD 20)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  ```
+- [x] container_system: C++20 already specified ✅
+- [x] database_system: C++20 already specified ✅
+- [x] monitoring_system: Removed C++17 fallback, enforced C++20 ✅
+- [x] logger_system: Removed C++17 fallback logic ✅
+- [x] All interface headers verified for C++20 consistency ✅
+
+**Verification**: ✅ PASSED
+```bash
+# All systems build successfully with C++20
+cmake -B build -S . -DCMAKE_CXX_STANDARD=20
+cmake --build build
+# ✅ Completed without standard-related errors
+```
+
+**Result**: All 7 systems now use C++20 as the required standard.
+
+**Files to Modify**:
+- `/Users/dongcheolshin/Sources/common_system/CMakeLists.txt:5-6`
+- `/Users/dongcheolshin/Sources/container_system/CMakeLists.txt`
+- `/Users/dongcheolshin/Sources/database_system/CMakeLists.txt`
+- `/Users/dongcheolshin/Sources/monitoring_system/CMakeLists.txt`
+- `/Users/dongcheolshin/Sources/logger_system/CMakeLists.txt:19-27` (remove fallback)
+
+---
+
+### Task 1.2: CMake Build Flag Standardization
+
+**Current State**:
+```cmake
+# thread_system
+option(BUILD_WITH_COMMON_SYSTEM "..." OFF)  # Optional, default OFF
+
+# logger_system
+# common_system REQUIRED (FATAL_ERROR)
+
+# database_system
+option(BUILD_WITH_COMMON_SYSTEM "..." OFF)
+option(DATABASE_USE_COMMON_SYSTEM "..." OFF)  # Deprecated duplicate
+
+# container_system
+option(BUILD_WITH_COMMON_SYSTEM "..." OFF)
+
+# monitoring_system
+# Uses BUILD_WITH_COMMON_SYSTEM but no option() statement
+
+# network_system
+# Uses USE_COMMON_SYSTEM (different flag name)
+```
+
+**Target State**: Unified flag name and default value
+
+**Actions**:
+- [x] Standardize flag name to `BUILD_WITH_COMMON_SYSTEM` across all systems ✅
+- [x] Change default value to `ON` (integration enabled by default) ✅
+- [x] Remove deprecated `DATABASE_USE_COMMON_SYSTEM` flag ✅
+- [x] Remove deprecated `USE_COMMON_SYSTEM` flag from network_system ✅
+- [x] Add explicit option() statements in monitoring_system ✅
+- [x] Update all preprocessor checks to use unified flag ✅
+- [x] Fix database module CMakeLists.txt for proper common_system integration ✅
+
+**Standard Template**:
+```cmake
+# Add to all system CMakeLists.txt
+option(BUILD_WITH_COMMON_SYSTEM "Enable common_system integration" ON)
+
+if(BUILD_WITH_COMMON_SYSTEM)
+    find_package(common_system CONFIG QUIET)
+    if(NOT common_system_FOUND)
+        # Fallback to path-based search
+        set(_COMMON_PATHS
+            "${CMAKE_CURRENT_SOURCE_DIR}/../common_system/include"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../../common_system/include"
+        )
+        foreach(_path ${_COMMON_PATHS})
+            if(EXISTS "${_path}/kcenon/common/patterns/result.h")
+                set(COMMON_SYSTEM_INCLUDE_DIR "${_path}")
+                break()
+            endif()
+        endforeach()
+
+        if(NOT DEFINED COMMON_SYSTEM_INCLUDE_DIR)
+            message(FATAL_ERROR "common_system not found")
+        endif()
+
+        target_include_directories(${PROJECT_NAME} PUBLIC ${COMMON_SYSTEM_INCLUDE_DIR})
+    endif()
+
+    target_compile_definitions(${PROJECT_NAME} PUBLIC BUILD_WITH_COMMON_SYSTEM)
+endif()
+```
+
+**Files Modified**:
+- ✅ `/Users/dongcheolshin/Sources/thread_system/CMakeLists.txt:31` - Default changed to ON
+- ✅ `/Users/dongcheolshin/Sources/database_system/CMakeLists.txt` - Removed deprecated flag
+- ✅ `/Users/dongcheolshin/Sources/database_system/database/CMakeLists.txt` - Fixed integration logic
+- ✅ `/Users/dongcheolshin/Sources/network_system/include/network_system/integration/common_system_adapter.h:8` - Changed USE_COMMON_SYSTEM → BUILD_WITH_COMMON_SYSTEM
+- ✅ `/Users/dongcheolshin/Sources/monitoring_system/CMakeLists.txt` - Added explicit option statement
+- ✅ `/Users/dongcheolshin/Sources/container_system/CMakeLists.txt` - Changed default to ON
+
+**Verification**: ✅ PASSED
+```bash
+# All systems find common_system successfully
+cmake -B build -S . -DBUILD_WITH_COMMON_SYSTEM=ON
+# ✅ All systems report "Found common_system" or "Enabling common_system integration"
+```
+
+**Result**:
+- All 7 systems use unified `BUILD_WITH_COMMON_SYSTEM` flag
+- Default value is `ON` for seamless integration
+- No deprecated flags remain in codebase
+
+---
+
+### Task 1.3: Create Unified FindCommonSystem.cmake Module
+
+**Status**: ⏸️ Deferred to Phase 2
+
+**Rationale**: Current path-based detection works adequately. This task will be combined with Phase 2 dependency optimization.
+
+**Goal**: Provide consistent common_system detection across all projects
+
+**Actions**:
+- [ ] Create `common_system/cmake/FindCommonSystem.cmake`
+- [ ] Install to standard CMake module path
+- [ ] Update all systems to use `find_package(CommonSystem REQUIRED)`
+
+**Template** (`common_system/cmake/FindCommonSystem.cmake`):
+```cmake
+#.rst:
+# FindCommonSystem
+# ----------------
+#
+# Find the common_system library
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following IMPORTED target:
+#
+# ``CommonSystem::common``
+#   The common_system library, if found
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module will set the following variables:
+#
+# ``CommonSystem_FOUND``
+#   True if common_system is found
+# ``CommonSystem_INCLUDE_DIRS``
+#   Include directories for common_system
+# ``CommonSystem_VERSION``
+#   Version of common_system
+
+include(FindPackageHandleStandardArgs)
+
+# Search paths
+set(_COMMON_SEARCH_PATHS
+    ${CommonSystem_DIR}
+    $ENV{COMMON_SYSTEM_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common_system
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../common_system
+    /usr/local
+    /usr
+)
+
+# Find include directory
+find_path(CommonSystem_INCLUDE_DIR
+    NAMES kcenon/common/patterns/result.h
+    PATH_SUFFIXES include
+    PATHS ${_COMMON_SEARCH_PATHS}
+)
+
+# Extract version
+if(EXISTS "${CommonSystem_INCLUDE_DIR}/kcenon/common/version.h")
+    file(STRINGS "${CommonSystem_INCLUDE_DIR}/kcenon/common/version.h"
+         _version_line REGEX "^#define COMMON_SYSTEM_VERSION ")
+    string(REGEX REPLACE "^#define COMMON_SYSTEM_VERSION \"(.*)\"" "\\1"
+           CommonSystem_VERSION "${_version_line}")
+endif()
+
+find_package_handle_standard_args(CommonSystem
+    REQUIRED_VARS CommonSystem_INCLUDE_DIR
+    VERSION_VAR CommonSystem_VERSION
+)
+
+if(CommonSystem_FOUND AND NOT TARGET CommonSystem::common)
+    add_library(CommonSystem::common INTERFACE IMPORTED)
+    set_target_properties(CommonSystem::common PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${CommonSystem_INCLUDE_DIR}"
+        INTERFACE_COMPILE_FEATURES cxx_std_20
+    )
+endif()
+
+mark_as_advanced(CommonSystem_INCLUDE_DIR)
+```
+
+**Files to Create**:
+- `/Users/dongcheolshin/Sources/common_system/cmake/FindCommonSystem.cmake`
+- `/Users/dongcheolshin/Sources/common_system/include/kcenon/common/version.h`
+
+**Files to Modify**:
+- All system CMakeLists.txt files to use `find_package(CommonSystem REQUIRED)`
+
+---
+
+### Task 1.4: Dependency Path Standardization
+
+**Status**: ⏸️ Deferred to Phase 2
+
+**Rationale**: Path detection is now functional in all systems. Will be refined during Phase 2 interface work.
+
+**Current Issue**: Each system uses different paths to find common_system
+
+**Actions**:
+- [ ] Standardize search paths to use consistent relative paths
+- [ ] Add environment variable support (`COMMON_SYSTEM_DIR`)
+- [ ] Document recommended project structure
+
+**Recommended Structure**:
+```
+workspace/
+├── common_system/       # Base interfaces
+├── thread_system/       # Depends on common_system
+├── logger_system/       # Depends on common_system, thread_system
+├── monitoring_system/   # Depends on common_system, thread_system
+├── container_system/    # Depends on common_system
+├── database_system/     # Depends on common_system
+└── network_system/      # Depends on common_system, thread_system
+```
+
+**Standard Search Pattern**:
+```cmake
+set(_${PROJECT_NAME}_COMMON_PATHS
+    ${COMMON_SYSTEM_DIR}                              # Explicit path
+    $ENV{COMMON_SYSTEM_DIR}                           # Environment variable
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common_system      # Sibling directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../common_system   # Parent's sibling
+)
+```
+
+---
+
+## ✅ Phase 1 Completion Summary
+
+**Completion Date**: 2025-10-02
+
+**Tasks Completed**:
+- ✅ Task 1.1: C++ Standard Unification (All systems → C++20)
+- ✅ Task 1.2: CMake Build Flag Standardization (BUILD_WITH_COMMON_SYSTEM unified)
+- ⏸️ Task 1.3: FindCommonSystem.cmake (Deferred to Phase 2)
+- ⏸️ Task 1.4: Dependency Path Standardization (Deferred to Phase 2)
+
+**Systems Updated**: 7/7
+- common_system, thread_system, logger_system, monitoring_system
+- container_system, database_system, network_system
+
+**Pull Requests Created**: 7
+- All PRs ready for review and merge
+- CI/CD build validation completed
+
+**Critical Issues Resolved**: 2/6
+- ✅ C++ Standard Mismatch
+- ✅ CMake Flag Inconsistency
+
+**Build Fixes Applied**:
+- monitoring_system: Fixed examples include paths, disabled DI examples (requires Phase 2)
+- database_system: Fixed database module common_system integration
+
+**Next Steps**:
+1. Review and merge all Phase 1 PRs (recommended order: common_system → thread_system/container_system → others)
+2. Verify CI/CD passes for all systems
+3. Begin Phase 2: Interface Unification
+
+---
+
+## 🔧 Phase 2: Interface Unification (Week 3-6) 🔄 IN PROGRESS
+
+**Goal**: Eliminate interface duplication and ensure consistent abstractions
+
+**Priority**: 🔴 Critical - Core architectural issue
+
+**Status**: 🔄 Partially Completed (2025-10-02)
+
+**Progress**: Task 2.1 ✅, Task 2.2 ✅, Task 2.3 ⏳, Task 2.4 ⏳
+
+### Task 2.1: Logger Interface Unification ✅ COMPLETED
+
+**Completion Date**: 2025-10-02
+
+**Problem**: Three different logger interfaces exist
+
+1. `common::interfaces::ILogger` (common_system)
+2. `kcenon::thread::logger_interface` (thread_system)
+3. `kcenon::logger::logger_interface` (logger_system)
+
+**Decision**: Extend `common::interfaces::ILogger` as the unified interface
+
+**Actions Completed**:
+- [x] Extended `common::interfaces::ILogger` with `ILoggerRegistry` interface ✅
+- [x] Added `logger_config` structure for advanced configuration ✅
+- [x] Enhanced `from_string()` with case-insensitive parsing and WARN/FATAL aliases ✅
+- [x] Deprecated `kcenon::thread::logger_interface` with migration guide ✅
+- [x] Deprecated `kcenon::thread::logger_registry` ✅
+- [x] Deprecated reverse adapters (`logger_from_common_adapter`) in both systems ✅
+- [x] Marked for Phase 3 removal ✅
+
+**Commits**:
+- common_system: `feat(phase2): extend ILogger interface with ILoggerRegistry`
+- thread_system: `feat(phase2): deprecate thread_system logger interfaces`
+- logger_system: `feat(phase2): deprecate logger_from_common_adapter`
+
+**Breaking Changes**:
+```cpp
+// Before (thread_system)
+#include <kcenon/thread/interfaces/logger_interface.h>
+kcenon::thread::logger_interface* logger;
+
+// After
+#include <kcenon/common/interfaces/logger_interface.h>
+common::interfaces::ILogger* logger;
+```
+
+**Files to Modify**:
+- `/Users/dongcheolshin/Sources/common_system/include/kcenon/common/interfaces/logger_interface.h`
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/interfaces/logger_interface.h` (deprecate)
+- `/Users/dongcheolshin/Sources/logger_system/include/kcenon/logger/interfaces/logger_interface.h` (move to common)
+- All adapter files
+
+**Migration Guide**:
+```cpp
+// Step 1: Add feature flags for gradual migration
+#ifdef USE_LEGACY_LOGGER_INTERFACE
+    #include <kcenon/thread/interfaces/logger_interface.h>
+    using logger_type = kcenon::thread::logger_interface;
+#else
+    #include <kcenon/common/interfaces/logger_interface.h>
+    using logger_type = common::interfaces::ILogger;
+#endif
+```
+
+**Migration Guide**:
+```cpp
+// Old: thread_system logger
+#include <kcenon/thread/interfaces/logger_interface.h>
+kcenon::thread::logger_interface* logger;
+
+// New: unified common logger
+#include <kcenon/common/interfaces/logger_interface.h>
+common::interfaces::ILogger* logger;
+```
+
+**Files Modified**:
+- `common_system/include/kcenon/common/interfaces/logger_interface.h`
+- `thread_system/include/kcenon/thread/interfaces/logger_interface.h`
+- `thread_system/include/kcenon/thread/adapters/common_system_logger_adapter.h`
+- `logger_system/include/kcenon/logger/adapters/common_system_adapter.h`
+
+---
+
+### Task 2.2: Executor Interface Unification ✅ COMPLETED
+
+**Completion Date**: 2025-10-02
+
+**Problem**: Two different execution models
+
+1. `common::interfaces::IExecutor` - Returns `std::future<void>`
+2. `kcenon::thread::executor_interface` - Returns `result_void`, accepts `job*`
+
+**Key Difference**:
+```cpp
+// common_system: Function-based
+virtual std::future<void> submit(std::function<void()> task) = 0;
+
+// thread_system: Job-based (more control)
+virtual auto execute(std::unique_ptr<job>&& work) -> result_void = 0;
+```
+
+**Solution**: Extend common_system interface with both modes
+
+**Actions Completed**:
+- [x] Extended `common::interfaces::IExecutor` with job-based execution ✅
+- [x] Added `Result<std::future<T>>` return type for consistency ✅
+- [x] Created abstract `IJob` base class in common_system ✅
+- [x] Added `execute()` and `execute_delayed()` methods ✅
+- [x] Deprecated `kcenon::thread::executor_interface` ✅
+- [x] Added migration guide and deprecation timeline ✅
+
+**Commits**:
+- common_system: `feat(phase2): extend IExecutor with job-based execution`
+- thread_system: `feat(phase2): deprecate thread_system executor_interface`
+
+**New Unified Interface**:
+```cpp
+namespace common::interfaces {
+
+// Forward declaration
+class IJob;
+
+class IExecutor {
+public:
+    virtual ~IExecutor() = default;
+
+    // Legacy function-based (keep for compatibility)
+    virtual std::future<void> submit(std::function<void()> task) = 0;
+
+    // Job-based execution (new, preferred)
+    virtual Result<std::future<void>> execute(std::unique_ptr<IJob>&& job) = 0;
+
+    // Delayed execution
+    virtual std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) = 0;
+
+    // Status queries
+    virtual size_t worker_count() const = 0;
+    virtual bool is_running() const = 0;
+    virtual size_t pending_tasks() const = 0;
+
+    // Lifecycle
+    virtual void shutdown(bool wait_for_completion = true) = 0;
+};
+
+// Abstract job interface
+class IJob {
+public:
+    virtual ~IJob() = default;
+    virtual void execute() = 0;
+    virtual std::string get_name() const { return "unnamed_job"; }
+};
+
+} // namespace common::interfaces
+```
+
+**Files to Modify**:
+- `/Users/dongcheolshin/Sources/common_system/include/kcenon/common/interfaces/executor_interface.h`
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/interfaces/executor_interface.h` (deprecate)
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/core/job.h` (move to common)
+- All executor adapters
+
+---
+
+### Task 2.3: Monitoring Interface Unification
+
+**Problem**: Different metric structures
+
+1. `common::interfaces::metric_value` - Generic name/value pairs
+2. `monitoring_interface::thread_pool_metrics` - Structured, typed metrics
+
+**Proposed Solution**: Extend common_system with typed metrics
+
+**Actions**:
+- [ ] Add metric type enum to common_system
+  ```cpp
+  enum class metric_type {
+      gauge,      // Instant value
+      counter,    // Monotonic increase
+      histogram,  // Distribution
+      summary     // Statistical summary
+  };
+  ```
+- [ ] Extend `metric_value` with type information
+- [ ] Create specialized metric structures in common_system
+- [ ] Update monitoring_system to use common types
+- [ ] Remove duplicate definitions from monitoring_interface
+
+**Extended Metric Structure**:
+```cpp
+namespace common::interfaces {
+
+struct metric_value {
+    std::string name;
+    double value;
+    metric_type type = metric_type::gauge;
+    std::chrono::system_clock::time_point timestamp;
+    std::unordered_map<std::string, std::string> tags;
+
+    // Constructor
+    metric_value(const std::string& n, double v, metric_type t = metric_type::gauge)
+        : name(n), value(v), type(t), timestamp(std::chrono::system_clock::now()) {}
+};
+
+// Specialized metrics
+struct thread_pool_metrics {
+    metric_value jobs_completed{"jobs_completed", 0, metric_type::counter};
+    metric_value jobs_pending{"jobs_pending", 0, metric_type::gauge};
+    metric_value worker_threads{"worker_threads", 0, metric_type::gauge};
+    metric_value average_latency_ns{"average_latency_ns", 0, metric_type::gauge};
+
+    std::chrono::system_clock::time_point timestamp = std::chrono::system_clock::now();
+};
+
+} // namespace common::interfaces
+```
+
+**Files to Modify**:
+- `/Users/dongcheolshin/Sources/common_system/include/kcenon/common/interfaces/monitoring_interface.h`
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/interfaces/monitoring_interface.h` (deprecate)
+- `/Users/dongcheolshin/Sources/monitoring_system/include/kcenon/monitoring/utils/metric_types.h`
+
+---
+
+### Task 2.4: Result<T> Pattern Migration
+
+**Current State**: Only some systems use Result<T>
+
+**Goal**: Ensure all public APIs use Result<T> for error handling
+
+**Actions**:
+- [ ] Audit all public interfaces for raw return types
+- [ ] Convert bool/exception-based returns to Result<T>
+- [ ] Document Result<T> usage patterns
+- [ ] Add helper macros for common patterns
+
+**Example Conversions**:
+```cpp
+// Before: Boolean return
+bool connect(const std::string& conn_str);
+
+// After: Result<T> return
+VoidResult connect(const std::string& conn_str);
+
+// Before: Exception-based
+std::vector<uint8_t> serialize() const; // throws std::runtime_error
+
+// After: Result<T> return
+Result<std::vector<uint8_t>> serialize() const noexcept;
+```
+
+**Helper Macros** (add to common_system):
+```cpp
+// Error handling helpers
+#define RETURN_IF_ERROR(expr) \
+    do { \
+        auto _result = (expr); \
+        if (common::is_error(_result)) { \
+            return common::get_error(_result); \
+        } \
+    } while(0)
+
+#define ASSIGN_OR_RETURN(var, expr) \
+    auto _temp_result_##var = (expr); \
+    if (common::is_error(_temp_result_##var)) { \
+        return common::get_error(_temp_result_##var); \
+    } \
+    var = common::get_value(std::move(_temp_result_##var))
+```
+
+**Files to Audit**:
+- All `include/*/interfaces/*.h` files
+- All public API headers in each system
+
+---
+
+## 🎨 Phase 3: Adapter Optimization (Week 7-8)
+
+**Goal**: Reduce adapter overhead and prevent conversion issues
+
+**Priority**: 🟡 Moderate - Performance and maintainability improvement
+
+### Task 3.1: Remove Bidirectional Adapters
+
+**Problem**: Each system has both X→Common and Common→X adapters, creating:
+- Circular conversion risk (A→B→A)
+- Maintenance burden (2× adapter code)
+- Runtime overhead (double wrapping)
+
+**Strategy**: Keep only one direction
+
+**Decision**: Keep **System → Common** adapters only
+- Each system implements common interfaces directly where possible
+- Adapters only wrap legacy implementations
+- No Common → System adapters (forces common interface adoption)
+
+**Actions**:
+- [ ] Remove `executor_from_common_adapter` (thread_system)
+- [ ] Remove `logger_from_common_adapter` (thread_system, logger_system)
+- [ ] Remove `monitorable_from_common_adapter` (thread_system, monitoring_system)
+- [ ] Remove `database_from_common_adapter` (database_system)
+- [ ] Update documentation to reflect one-way adaptation
+
+**Files to Remove**:
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/adapters/common_system_executor_adapter.h:143-202` (executor_from_common_adapter)
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/adapters/common_system_logger_adapter.h:168-252` (logger_from_common_adapter)
+- `/Users/dongcheolshin/Sources/logger_system/include/kcenon/logger/adapters/common_system_adapter.h:213-298` (logger_from_common_adapter)
+- `/Users/dongcheolshin/Sources/database_system/database/adapters/common_system_adapter.h:215-350` (database_from_common_adapter)
+
+**Deprecation Notice**:
+```cpp
+// Add to headers before removal
+#ifdef ALLOW_REVERSE_ADAPTERS
+    #warning "Reverse adapters (Common→System) are deprecated and will be removed in v2.0"
+    // ... adapter code ...
+#else
+    #error "Reverse adapters removed. Use native common interfaces instead."
+#endif
+```
+
+---
+
+### Task 3.2: Add Type-Safe Unwrapping
+
+**Problem**: No protection against infinite wrapper chains
+
+**Solution**: Add type checking and direct unwrapping
+
+**Actions**:
+- [ ] Add RTTI or type_id to all adapters
+- [ ] Implement unwrap() method to get underlying object
+- [ ] Add wrapper depth tracking
+- [ ] Throw exception if depth > 2
+
+**Implementation**:
+```cpp
+namespace common::adapters {
+
+// Base adapter with type safety
+template<typename Interface, typename Implementation>
+class typed_adapter : public Interface {
+public:
+    explicit typed_adapter(std::shared_ptr<Implementation> impl)
+        : impl_(impl), wrapper_depth_(calculate_depth(impl)) {
+        if (wrapper_depth_ > 2) {
+            throw std::runtime_error("Adapter chain too deep (>2 levels)");
+        }
+    }
+
+    // Get underlying implementation
+    std::shared_ptr<Implementation> unwrap() const { return impl_; }
+
+    // Check if wrapping another adapter
+    bool is_wrapped_adapter() const { return wrapper_depth_ > 0; }
+
+    // Type identification
+    static constexpr const char* adapter_type_name() {
+        return typeid(typed_adapter).name();
+    }
+
+private:
+    std::shared_ptr<Implementation> impl_;
+    size_t wrapper_depth_;
+
+    static size_t calculate_depth(std::shared_ptr<Implementation> impl) {
+        // Check if impl is itself an adapter
+        if (auto* adapter = dynamic_cast<typed_adapter*>(impl.get())) {
+            return 1 + adapter->wrapper_depth_;
+        }
+        return 0;
+    }
+};
+
+} // namespace common::adapters
+```
+
+**Files to Create**:
+- `/Users/dongcheolshin/Sources/common_system/include/kcenon/common/adapters/typed_adapter.h`
+
+**Files to Modify**:
+- All adapter implementations to inherit from `typed_adapter`
+
+---
+
+### Task 3.3: Zero-Cost Adapter Optimization
+
+**Goal**: Eliminate adapter overhead for common cases
+
+**Strategy**: Direct cast when possible, only wrap when necessary
+
+**Actions**:
+- [ ] Add concept checks for interface compatibility
+- [ ] Implement smart adapter factory that avoids wrapping
+- [ ] Use compile-time checks to select direct cast vs adapter
+
+**Smart Adapter Factory**:
+```cpp
+namespace common::adapters {
+
+// Concept: Check if type already implements interface
+template<typename T, typename Interface>
+concept implements_interface = std::is_base_of_v<Interface, T>;
+
+// Factory function
+template<typename Interface, typename Impl>
+std::shared_ptr<Interface> make_adapter(std::shared_ptr<Impl> impl) {
+    // If already implements interface, just cast
+    if constexpr (implements_interface<Impl, Interface>) {
+        return std::static_pointer_cast<Interface>(impl);
+    }
+    // Otherwise, create adapter
+    else {
+        return std::make_shared<typed_adapter<Interface, Impl>>(impl);
+    }
+}
+
+} // namespace common::adapters
+```
+
+**Example Usage**:
+```cpp
+// Before: Always wraps
+auto executor = std::make_shared<common_system_executor_adapter>(thread_pool);
+
+// After: Zero-cost if thread_pool already implements IExecutor
+auto executor = common::adapters::make_adapter<IExecutor>(thread_pool);
+```
+
+**Files to Create**:
+- `/Users/dongcheolshin/Sources/common_system/include/kcenon/common/adapters/smart_adapter.h`
+
+---
+
+## 🧹 Phase 4: Code Cleanup and Documentation (Week 9-10)
+
+**Goal**: Remove technical debt and improve maintainability
+
+**Priority**: 🟢 Low - Quality of life improvements
+
+### Task 4.1: Namespace Standardization
+
+**Problem**: Inconsistent namespace usage
+
+**Actions**:
+- [ ] Rename `monitoring_interface` namespace to `kcenon::thread::detail::monitoring`
+- [ ] Move all thread_system internals to `kcenon::thread::detail`
+- [ ] Ensure all public APIs are in `kcenon::<system>` namespace
+- [ ] Add namespace aliases for backward compatibility
+
+**Standard Namespace Structure**:
+```cpp
+namespace kcenon {
+    namespace <system> {           // Public API
+        namespace interfaces { }   // Abstract interfaces
+        namespace adapters { }     // Adaptation layer
+        namespace detail { }       // Internal implementation
+    }
+}
+```
+
+**Files to Modify**:
+- `/Users/dongcheolshin/Sources/thread_system/include/kcenon/thread/interfaces/monitoring_interface.h:42` (rename namespace)
+- All internal implementation files (move to detail namespace)
+
+---
+
+### Task 4.2: Remove Deprecated Code
+
+**Actions**:
+- [ ] Remove `DATABASE_USE_COMMON_SYSTEM` flag and all references
+- [ ] Remove `USE_COMMON_SYSTEM` flag (network_system)
+- [ ] Remove C++17 fallback code from logger_system
+- [ ] Remove all deprecated adapters marked in Phase 3.1
+- [ ] Update CHANGELOG with breaking changes
+
+**Files to Remove/Modify**:
+- `/Users/dongcheolshin/Sources/database_system/CMakeLists.txt` (remove deprecated flag)
+- `/Users/dongcheolshin/Sources/network_system/include/network_system/integration/common_system_adapter.h:8,20` (change flag)
+- `/Users/dongcheolshin/Sources/logger_system/CMakeLists.txt:19-27` (remove fallback)
+
+---
+
+### Task 4.3: Documentation Update
+
+**Actions**:
+- [ ] Create integration guide (INTEGRATION.md)
+- [ ] Document Result<T> patterns (ERROR_HANDLING.md)
+- [ ] Update README in each system
+- [ ] Create architecture diagrams
+- [ ] Add migration guide for breaking changes
+- [ ] Document recommended project structure
+
+**Files to Create**:
+- `/Users/dongcheolshin/Sources/INTEGRATION.md` - How to integrate systems
+- `/Users/dongcheolshin/Sources/ERROR_HANDLING.md` - Result<T> best practices
+- `/Users/dongcheolshin/Sources/ARCHITECTURE.md` - System architecture overview
+- `/Users/dongcheolshin/Sources/MIGRATION_v2.md` - Breaking changes guide
+
+---
+
+### Task 4.4: Testing Infrastructure
+
+**Actions**:
+- [ ] Create integration test suite
+- [ ] Add cross-system test cases
+- [ ] Implement adapter performance benchmarks
+- [ ] Set up CI/CD pipeline for all systems
+- [ ] Add test coverage reporting
+
+**Test Structure**:
+```
+tests/
+├── integration/
+│   ├── thread_logger_integration_test.cpp
+│   ├── logger_monitoring_integration_test.cpp
+│   ├── database_network_integration_test.cpp
+│   └── full_stack_integration_test.cpp
+├── adapters/
+│   ├── executor_adapter_test.cpp
+│   ├── logger_adapter_test.cpp
+│   └── monitor_adapter_test.cpp
+└── benchmarks/
+    ├── adapter_overhead_bench.cpp
+    ├── conversion_performance_bench.cpp
+    └── integration_latency_bench.cpp
+```
+
+**Files to Create**:
+- `/Users/dongcheolshin/Sources/tests/integration/` directory structure
+- `/Users/dongcheolshin/Sources/tests/CMakeLists.txt`
+- `/Users/dongcheolshin/Sources/.github/workflows/ci.yml` (if using GitHub)
+
+---
+
+## 📊 Success Metrics
+
+### Phase 1 Success Criteria
+- ✅ All systems build with C++20 standard
+- ✅ `BUILD_WITH_COMMON_SYSTEM=ON` works for all systems
+- ✅ No CMake configuration warnings
+- ✅ FindCommonSystem.cmake locates library in all test scenarios
+
+### Phase 2 Success Criteria
+- ✅ All adapters removed or unified under common interfaces
+- ✅ Zero interface duplication
+- ✅ All public APIs use Result<T> pattern
+- ✅ Backward compatibility maintained with deprecation warnings
+
+### Phase 3 Success Criteria
+- ✅ No bidirectional adapters remain
+- ✅ Adapter overhead < 5% (measured via benchmarks)
+- ✅ Zero adapter-related runtime crashes in test suite
+- ✅ Type-safe unwrapping functional
+
+### Phase 4 Success Criteria
+- ✅ All deprecated code removed
+- ✅ Documentation coverage > 90%
+- ✅ Integration test coverage > 80%
+- ✅ CI/CD pipeline green for all systems
+
+---
+
+## 🔄 Rollback Plan
+
+Each phase should be implemented on a separate branch with ability to rollback:
+
+```bash
+# Create feature branches
+git checkout -b feature/phase1-build-config
+git checkout -b feature/phase2-interface-unification
+git checkout -b feature/phase3-adapter-optimization
+git checkout -b feature/phase4-cleanup
+
+# Rollback procedure
+git checkout main
+git branch -D feature/phaseN-xxx
+git clean -fd
+```
+
+**Rollback Triggers**:
+- Build failures that cannot be resolved within 2 days
+- Performance regression > 10%
+- Breaking changes affecting > 5 dependent projects
+- Critical bugs discovered in production
+
+---
+
+## 📞 Escalation Path
+
+| Issue Severity | Response Time | Escalation |
+|---------------|---------------|------------|
+| Build broken | Immediate | Stop phase, rollback |
+| Interface regression | 24 hours | Team review required |
+| Performance degradation | 48 hours | Architecture review |
+| Documentation gaps | 1 week | Continue phase, fix in parallel |
+
+---
+
+## 🎯 Definition of Done
+
+**Phase is complete when**:
+1. All tasks checked off
+2. Success criteria met
+3. Code review approved
+4. Tests passing (unit + integration)
+5. Documentation updated
+6. Changelog entries added
+7. No regressions in dependent systems
+
+---
+
+## 📅 Timeline Summary
+
+| Phase | Duration | Dependencies | Start Date | Completion Target |
+|-------|----------|--------------|------------|-------------------|
+| Phase 1 | 2 weeks | None | Week 1 | Week 2 |
+| Phase 2 | 4 weeks | Phase 1 complete | Week 3 | Week 6 |
+| Phase 3 | 2 weeks | Phase 2 complete | Week 7 | Week 8 |
+| Phase 4 | 2 weeks | Phase 3 complete | Week 9 | Week 10 |
+
+**Total Duration**: 10 weeks (2.5 months)
+
+---
+
+## 📝 Notes
+
+- **Breaking Changes**: Phase 2 will introduce breaking changes. Ensure all dependent projects are notified.
+- **Performance Testing**: Benchmark before and after Phase 3 to quantify improvements.
+- **Gradual Migration**: Use feature flags to allow gradual migration for existing code.
+- **Version Bump**: After Phase 2 completion, bump major version to 2.0.0.
+
+---
+
+*Last Updated: 2025-10-02*
+*Document Owner: System Integration Team*
+*Review Cycle: Weekly during active phases*

--- a/include/kcenon/logger/adapters/common_system_adapter.h
+++ b/include/kcenon/logger/adapters/common_system_adapter.h
@@ -206,11 +206,19 @@ private:
 
 /**
  * @brief Adapter to use common::interfaces::ILogger in kcenon::logger
+ * @deprecated This reverse adapter will be removed in Phase 3
  *
+ * Phase 2 Note: Bidirectional adapters create circular conversion risk.
  * This adapter allows a common_system logger to be used as
  * a kcenon::logger writer.
+ *
+ * MIGRATION: Use common::interfaces::ILogger directly instead of wrapping it.
+ * Reverse adapters (Common→System) are being phased out in favor of
+ * native common interface adoption.
+ *
+ * Will be removed in Phase 3 (Adapter Optimization)
  */
-class logger_from_common_adapter : public logger_interface {
+class [[deprecated("Will be removed in Phase 3. Use common::interfaces::ILogger directly")]] logger_from_common_adapter : public logger_interface {
 public:
     /**
      * @brief Construct adapter with common logger


### PR DESCRIPTION
## Summary

Phase 2 Interface Unification - Logger Adapter Deprecation

This PR deprecates the reverse adapter in logger_system to prevent circular conversion risks.

## Changes

### Task 2.1: Logger Adapter Deprecation
- Deprecated `logger_from_common_adapter` (reverse adapter)
- Added Phase 3 removal notice
- Documented circular conversion risks of bidirectional adapters
- Retained `common_system_logger_adapter` (forward adapter)

## Rationale

Bidirectional adapters create several issues:
- **Circular conversion risk**: A→B→A conversions
- **Maintenance burden**: 2× adapter code to maintain
- **Runtime overhead**: Double wrapping penalties

**Solution**: Keep only forward adapters (System → Common)

## Migration

```cpp
// Old: Wrapping common logger in logger_system interface
auto logger = std::make_shared<logger_from_common_adapter>(common_logger);

// New: Use common::interfaces::ILogger directly
common::interfaces::ILogger* logger = common_logger.get();
```

## Impact

- **Breaking Changes**: None (deprecation warning only)
- **Phase 3 Action**: Complete removal of reverse adapters
- **Forward Adapter**: `common_system_logger_adapter` remains fully supported

## Related PRs

- common_system: https://github.com/kcenon/common_system/pull/12
- thread_system: https://github.com/kcenon/thread_system/pull/27