### PR TITLE
fix(monitoring): resolve monitoring_interface type conflict

### DIFF
--- a/include/kcenon/logger/core/monitoring/monitoring_factory.h
+++ b/include/kcenon/logger/core/monitoring/monitoring_factory.h
@@ -13,8 +13,7 @@
 
 namespace kcenon::logger::monitoring {
 
-// Forward compatibility aliases
-using monitoring_interface = common::interfaces::IMonitor;
+// Forward compatibility aliases (monitoring_interface removed due to conflict with transition header)
 using monitoring_metrics = common::interfaces::metrics_snapshot;
 
 /**


### PR DESCRIPTION
## Summary

Remove conflicting `monitoring_interface` type alias from `monitoring_factory.h` to resolve build errors when integrating with network_system.

## Problem

The `monitoring_interface` alias in `monitoring_factory.h:17` conflicted with the class definition in `monitoring_interface_transition.h:114`, causing compilation errors:

```
error: typedef redefinition with different types
  ('common::interfaces::IMonitor' vs 'kcenon::logger::monitoring::monitoring_interface')
```

## Solution

Removed the redundant `using monitoring_interface = common::interfaces::IMonitor;` alias since:
1. The transition header already defines `monitoring_interface` class
2. `monitoring_factory.h` uses `common::interfaces::IMonitor` directly
3. The alias serves no purpose and creates ambiguity

## Testing

- Built logger_system successfully
- Built network_system with logger_system integration
- No functional changes, only removes conflicting type alias

## Part of Phase 3

This fix is part of Phase 3: Documentation and Consistency Improvements, specifically Task 3.1 (Standardize common_system Integration).