### PR TITLE
ci: enable test execution in sanitizer workflow

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -62,7 +62,7 @@ jobs:
           -DCMAKE_C_FLAGS="${SANITIZER_FLAGS}" \
           -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=${{ matrix.sanitizer }}" \
           -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=${{ matrix.sanitizer }}" \
-          -DLOGGER_BUILD_TESTS=OFF \
+          -DLOGGER_BUILD_TESTS=ON \
           -DLOGGER_BUILD_SAMPLES=OFF
 
     - name: Build with ${{ matrix.sanitizer }} sanitizer
@@ -70,15 +70,14 @@ jobs:
         cd logger_system
         cmake --build build -j
 
-    # TODO: Re-enable tests when test compilation issues are resolved
-    # - name: Run tests with ${{ matrix.sanitizer }} sanitizer
-    #   run: |
-    #     cd logger_system/build
-    #     ctest --output-on-failure --verbose
-    #   env:
-    #     TSAN_OPTIONS: "halt_on_error=0 second_deadlock_stack=1"
-    #     ASAN_OPTIONS: "halt_on_error=0 detect_leaks=1"
-    #     UBSAN_OPTIONS: "halt_on_error=0 print_stacktrace=1"
+    - name: Run tests with ${{ matrix.sanitizer }} sanitizer
+      run: |
+        cd logger_system/build
+        ctest --output-on-failure --verbose
+      env:
+        TSAN_OPTIONS: "halt_on_error=0 second_deadlock_stack=1"
+        ASAN_OPTIONS: "halt_on_error=0 detect_leaks=1"
+        UBSAN_OPTIONS: "halt_on_error=0 print_stacktrace=1"
 
     - name: Upload sanitizer logs
       if: failure()


### PR DESCRIPTION
Enable running tests in the sanitizer workflow to catch issues during CI.