### PR TITLE
Modernize headers and improve namespace usage

### DIFF
--- a/include/kcenon/logger/compatibility.h
+++ b/include/kcenon/logger/compatibility.h
@@ -1,5 +1,12 @@
-#ifndef KCENON_LOGGER_COMPATIBILITY_H
-#define KCENON_LOGGER_COMPATIBILITY_H
+/**
+ * @file compatibility.h
+ * @brief Compatibility layer for legacy namespace aliases
+ *
+ * Provides namespace aliases to maintain backward compatibility
+ * with code using the old logger_system namespace.
+ */
+
+#pragma once
 
 // Forward declare legacy namespace so that aliasing works without including
 // heavier logger headers.
@@ -12,5 +19,3 @@ namespace logger = ::logger_system;
 
 // Additional legacy aliases kept for downstream projects.
 namespace logger_module = ::logger_system;
-
-#endif // KCENON_LOGGER_COMPATIBILITY_H

--- a/include/kcenon/logger/core/error_codes.h
+++ b/include/kcenon/logger/core/error_codes.h
@@ -67,9 +67,8 @@ using ::common::is_ok;
 using ::common::is_error;
 using ::common::get_value;
 using ::common::get_error;
-namespace error_codes {
-using namespace ::common::error_codes;
-} // namespace error_codes
+// Import common system error codes as namespace alias (not 'using namespace')
+namespace error_codes = ::common::error_codes;
 } // namespace common
 } // namespace kcenon
 #endif // KCENON_COMMON_RESULT_SHIM_DEFINED


### PR DESCRIPTION
## Summary
- Replace `using namespace` with namespace aliases to avoid namespace pollution
- Modernize header guards to `#pragma once`
- Add comprehensive file documentation

## Changes
- **error_codes.h**: Replace `using namespace ::common::error_codes` with namespace alias
- **compatibility.h**: Add file documentation and modernize to `#pragma once`

## Benefits
- Better namespace hygiene (prevents symbol conflicts)
- Cleaner code following modern C++ best practices
- Improved maintainability with clear documentation

## Testing
- All builds pass with no compilation errors
- No functional changes, purely style improvements