### PR TITLE
build(standalone): allow common_system in standalone mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,10 @@ option(LOGGER_STANDALONE "Build in standalone mode without thread_system" OFF)
 option(NO_VCPKG "Skip vcpkg and use system libraries only" OFF)
 option(BUILD_WITH_COMMON_SYSTEM "Build with common_system integration (optional)" ON)
 
-# LOGGER_STANDALONE_MODE takes precedence - force disable common_system and thread_system
+# LOGGER_STANDALONE_MODE takes precedence - force disable thread_system only
+# common_system is still allowed for Result type compatibility
 if(LOGGER_STANDALONE_MODE)
-    message(STATUS "LOGGER_STANDALONE_MODE is ON - forcing BUILD_WITH_COMMON_SYSTEM=OFF and USE_THREAD_SYSTEM=OFF")
-    set(BUILD_WITH_COMMON_SYSTEM OFF CACHE BOOL "Disabled by LOGGER_STANDALONE_MODE" FORCE)
+    message(STATUS "LOGGER_STANDALONE_MODE is ON - forcing USE_THREAD_SYSTEM=OFF (common_system still allowed)")
     set(USE_THREAD_SYSTEM OFF CACHE BOOL "Disabled by LOGGER_STANDALONE_MODE" FORCE)
 endif()
 


### PR DESCRIPTION
## Summary
- Refine LOGGER_STANDALONE_MODE behavior to permit common_system usage while still disabling thread_system
- Enable Result type compatibility even in standalone builds, improving integration flexibility
- Only thread_system dependency is now forced off in standalone mode, while common_system can be optionally used for type consistency

## Changes
- Modified CMakeLists.txt to allow BUILD_WITH_COMMON_SYSTEM in LOGGER_STANDALONE_MODE
- Updated status message to clarify that only thread_system is disabled
- Removed forced disabling of common_system in standalone mode

## Test plan
- [ ] Verify that standalone builds work without thread_system
- [ ] Confirm that common_system can be optionally used in standalone mode
- [ ] Test Result type compatibility in standalone builds
- [ ] Ensure existing functionality remains intact