### PR TITLE
Move include outside namespace in thread_system_backend.h

### DIFF
--- a/include/kcenon/logger/backends/thread_system_backend.h
+++ b/include/kcenon/logger/backends/thread_system_backend.h
@@ -10,6 +10,11 @@ All rights reserved.
 #include "integration_backend.h"
 #include <kcenon/logger/core/thread_integration_detector.h>
 
+// Conditional includes based on integration settings
+#ifdef USE_THREAD_SYSTEM_INTEGRATION
+#include <kcenon/thread/interfaces/logger_interface.h>
+#endif
+
 /**
  * @file thread_system_backend.h
  * @brief Thread system integration backend implementation
@@ -27,8 +32,6 @@ All rights reserved.
 namespace kcenon::logger::backends {
 
 #ifdef USE_THREAD_SYSTEM_INTEGRATION
-
-#include <kcenon/thread/interfaces/logger_interface.h>
 
 /**
  * @class thread_system_backend


### PR DESCRIPTION
## Summary

Fixes incorrect include placement where `logger_interface.h` was included inside a namespace declaration, violating C++ conventions and risking symbol resolution issues.

## Problem

**Incorrect Include Location:**
```cpp
namespace kcenon::logger::backends {

#ifdef USE_THREAD_SYSTEM_INTEGRATION

#include <kcenon/thread/interfaces/logger_interface.h>  // INSIDE namespace!
```

**Issues:**
- Violates C++ convention that all `#include` directives should be at file top (outside namespaces)
- Included file may contain its own namespace declarations, causing confusion
- Can lead to unexpected symbol resolution and name lookup problems
- Makes code harder to understand and maintain

## Solution

**Moved Include to File Top:**
```cpp
#include "integration_backend.h"
#include <kcenon/logger/core/thread_integration_detector.h>

// Conditional includes based on integration settings
#ifdef USE_THREAD_SYSTEM_INTEGRATION
#include <kcenon/thread/interfaces/logger_interface.h>
#endif

/**
 * File documentation...
 */

namespace kcenon::logger::backends {
```

## Changes

**File: `include/kcenon/logger/backends/thread_system_backend.h`**

1. Moved `#include <kcenon/thread/interfaces/logger_interface.h>` from line 31 to lines 14-16
2. Kept include inside `#ifdef USE_THREAD_SYSTEM_INTEGRATION` guard (still conditionally compiled)
3. Added clarifying comment: `// Conditional includes based on integration settings`
4. Maintained all existing functionality and behavior

## Impact

**No Functional Changes:**
- Same conditional compilation behavior
- Same symbols included/excluded based on `USE_THREAD_SYSTEM_INTEGRATION`
- No changes to class implementation or API

**Improved Code Quality:**
- Follows standard C++ include placement conventions
- Prevents potential namespace pollution issues
- Enhances code readability and maintainability
- Aligns with coding standards across other system headers

## Testing

- [ ] Verify compilation with `USE_THREAD_SYSTEM_INTEGRATION=ON`
- [ ] Verify compilation with `USE_THREAD_SYSTEM_INTEGRATION=OFF`
- [ ] Confirm thread_system_backend tests pass
- [ ] Check integration with thread_system

## Related Changes

- common_system PR #54: Namespace alias for backward compatibility
- monitoring_system PR #61: Fix invalid header includes
- Identified during cross-system integration review as part of include hygiene audit

## Migration Notes

No migration needed - this is a pure refactor with no API or behavioral changes.