### PR TITLE
fix: disable integration tests in standalone mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DLOGGER_STANDALONE_MODE=ON \
           -DUSE_THREAD_SYSTEM=OFF \
+          -DLOGGER_BUILD_INTEGRATION_TESTS=OFF \
           -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
           -DCMAKE_C_COMPILER=${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }} \
           -DCMAKE_CXX_COMPILER=${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}
@@ -192,6 +193,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE `
           -DLOGGER_STANDALONE_MODE=ON `
           -DUSE_THREAD_SYSTEM=OFF `
+          -DLOGGER_BUILD_INTEGRATION_TESTS=OFF `
           -DCMAKE_TOOLCHAIN_FILE="$env:GITHUB_WORKSPACE\vcpkg\scripts\buildsystems\vcpkg.cmake" `
           -DCMAKE_CXX_FLAGS="/std:c++20 /permissive- /Zc:__cplusplus /EHsc" `
           -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY"
@@ -237,6 +239,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE `
           -DLOGGER_STANDALONE_MODE=ON `
           -DUSE_THREAD_SYSTEM=OFF `
+          -DLOGGER_BUILD_INTEGRATION_TESTS=OFF `
           -DCMAKE_CXX_FLAGS="/std:c++20 /permissive- /Zc:__cplusplus /EHsc" `
           -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY" `
           -DNO_VCPKG=ON


### PR DESCRIPTION
Fixes integration test execution failures in standalone mode builds.

## Problem
When building logger_system with `LOGGER_STANDALONE_MODE=ON`, integration tests are not built but CTest attempts to execute them, resulting in 'Unable to find executable' errors.

## Solution
Add `-DLOGGER_BUILD_INTEGRATION_TESTS=OFF` to CI workflow when `LOGGER_STANDALONE_MODE=ON` is set. This prevents CTest from registering integration test targets that don't exist.

## Changes
- Updated `.github/workflows/ci.yml`:
  - Added `-DLOGGER_BUILD_INTEGRATION_TESTS=OFF` to Unix build configuration  
  - Added `-DLOGGER_BUILD_INTEGRATION_TESTS=OFF` to Windows build configuration
  - Both applied only when `LOGGER_STANDALONE_MODE=ON`

## Testing
- CI builds now complete successfully on all platforms (Ubuntu, macOS, Windows)
- CTest no longer attempts to run non-existent integration test executables