### PR TITLE
feat(ci): add benchmark result tracking with github-action-benchmark

### DIFF
--- a/.github/workflows/README_WORKFLOW_IMPROVEMENTS.md
+++ b/.github/workflows/README_WORKFLOW_IMPROVEMENTS.md
@@ -160,8 +160,17 @@ vcpkg build failed. Falling back to system libraries...
 - [x] Add Windows MSYS2 workflow improvements (completed)
 - [x] Upgrade to upload-artifact@v4 (completed)
 - [ ] Consider matrix builds for multiple configurations
-- [ ] Add benchmark result tracking
+- [x] Add benchmark result tracking (completed - using github-action-benchmark)
 - [x] Implement coverage reporting (see coverage.yml)
+
+### Benchmark Result Tracking
+
+Added historical benchmark tracking using `benchmark-action/github-action-benchmark@v1`:
+- Stores benchmark data in `gh-pages` branch under `dev/bench/`
+- Provides interactive performance trend charts
+- Alerts on 10% performance regression
+- Auto-comments on PRs when performance degrades
+- View trends at: `https://<owner>.github.io/<repo>/dev/bench/`
 
 ## Troubleshooting
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -234,6 +234,34 @@ with open('build/benchmark_results_${{ matrix.os }}.json', 'w') as out:
 
         echo "✅ Baseline saved: benchmarks/baselines/baseline_${{ matrix.os }}_$(date +%Y%m%d).json" >> $GITHUB_STEP_SUMMARY
 
+    # Historical benchmark tracking with github-action-benchmark
+    - name: Store benchmark results for tracking
+      if: matrix.os == 'ubuntu-22.04'
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        name: Logger System Performance
+        tool: 'googlecpp'
+        output-file-path: build/benchmark_results_${{ matrix.os }}.json
+        # Store data in gh-pages branch
+        gh-pages-branch: gh-pages
+        benchmark-data-dir-path: dev/bench
+        # Commit benchmark data only on main branch push
+        auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        # Alert on performance regression (10% threshold)
+        alert-threshold: '110%'
+        # Comment on PR with comparison
+        comment-on-alert: true
+        fail-on-alert: false
+        # GitHub token for pushing and commenting
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Add performance tracking link to summary
+      if: matrix.os == 'ubuntu-22.04' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: |
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "## 📈 Performance Tracking" >> $GITHUB_STEP_SUMMARY
+        echo "View historical performance trends: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/dev/bench/" >> $GITHUB_STEP_SUMMARY
+
   report:
     name: Generate Benchmark Report
     needs: benchmark


### PR DESCRIPTION
## Summary

- Add historical benchmark tracking using `benchmark-action/github-action-benchmark`
- Store benchmark data in gh-pages branch under `dev/bench/`
- Provide interactive performance trend charts over time
- Alert on 10% performance regression threshold
- Auto-comment on PRs when performance degrades

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Run benchmarks manually using workflow_dispatch
- [ ] Confirm benchmark data is stored in gh-pages branch
- [ ] Check performance dashboard at `https://kcenon.github.io/logger_system/dev/bench/`