### PR TITLE
refactor: Replace fmt::format with std::format in common_logger_adapter

### DIFF
--- a/include/kcenon/logger/adapters/common_logger_adapter.h
+++ b/include/kcenon/logger/adapters/common_logger_adapter.h
@@ -11,7 +11,7 @@ All rights reserved.
 #include <string>
 #include <chrono>
 #include <functional>
-#include <fmt/format.h>
+#include <format>
 
 // common_system integration
 #include <kcenon/common/interfaces/logger_interface.h>
@@ -115,7 +115,7 @@ public:
         // Create formatted message with location info
         // Logger operations are noexcept - format may throw but we catch at API boundary
         try {
-            std::string formatted = fmt::format("[{}:{}:{}] {}",
+            std::string formatted = std::format("[{}:{}:{}] {}",
                 file, line, function, message);
             logger_->log(from_common_level(level), formatted);
         } catch (const std::exception& e) {
@@ -139,7 +139,7 @@ public:
         try {
             std::string message = entry.message;
             if (!entry.file.empty()) {
-                message = fmt::format("[{}:{}:{}] {}",
+                message = std::format("[{}:{}:{}] {}",
                     entry.file, entry.line, entry.function, entry.message);
             }
 


### PR DESCRIPTION
## Summary
- Remove direct dependency on fmt library from common_logger_adapter.h
- Use C++20 std::format instead of fmt::format
- Part of the fmt to std::format migration effort (TICKET-002)

## Changes
- Replace `#include <fmt/format.h>` with `#include <format>`
- Replace `fmt::format()` calls with `std::format()`

## Test plan
- [x] LoggerSystem library builds successfully
- [x] integrated_thread_system builds and runs with updated logger_system