### PR TITLE
Upgrade C++ standard from C++17 to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 project(
     LoggerSystem
     VERSION 1.0.0
-    DESCRIPTION "High-performance C++17 logging system with asynchronous batching"
+    DESCRIPTION "High-performance C++20 logging system with asynchronous batching"
     HOMEPAGE_URL "https://github.com/kcenon/logger_system"
     LANGUAGES CXX
 )
@@ -15,16 +15,16 @@ project(
 # C++ standard requirements
 ##################################################
 
-# C++17 is REQUIRED (no fallback to earlier standards)
-set(CMAKE_CXX_STANDARD 17)
+# C++20 is REQUIRED (no fallback to earlier standards)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Verify that C++17 is actually being used
-if(CMAKE_CXX_STANDARD LESS 17)
-    message(FATAL_ERROR "Logger System requires C++17 or later. Current standard: C++${CMAKE_CXX_STANDARD}")
+# Verify that C++20 is actually being used
+if(CMAKE_CXX_STANDARD LESS 20)
+    message(FATAL_ERROR "Logger System requires C++20 or later. Current standard: C++${CMAKE_CXX_STANDARD}")
 endif()
 
-message(STATUS "Logger System: Using C++17 mode with optional C++20 feature detection")
+message(STATUS "Logger System: Using C++20 standard")
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # Generate compile_commands.json for tooling
 


### PR DESCRIPTION
## Summary

- Upgrade CMAKE_CXX_STANDARD from 17 to 20
- Update project description to reflect C++20 standard
- Update version check and status messages accordingly

## Motivation

This change aligns `logger_system` with other `unified_system` projects that already use C++20, enabling:
- Consistent build configurations across all subsystems
- Access to C++20 features (concepts, ranges, coroutines, std::format, etc.)
- Simplified dependency management

## Changes

| File | Change |
|------|--------|
| `CMakeLists.txt` | C++17 → C++20 |

## Test Plan

- [x] Build with GCC 10+
- [x] Build with Clang 12+
- [x] Build with MSVC 2019+
- [x] Run all unit tests
- [x] Run all integration tests

## Related

Resolves: TICKET-002