### PR TITLE
feat(core): apply updated common_system with C++20 Concepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Part of a modular C++ ecosystem with clean interface boundaries:
 ### Dependencies
 
 **Required**:
-- **[common_system](https://github.com/kcenon/common_system)**: Core interfaces (ILogger, IMonitor, Result<T>)
+- **[common_system](https://github.com/kcenon/common_system)**: Core interfaces (ILogger, IMonitor, Result<T>) with C++20 Concepts support
 
 **Optional**:
 - **[thread_system](https://github.com/kcenon/thread_system)**: Enhanced threading primitives (optional since v3.1.0)

--- a/README_KO.md
+++ b/README_KO.md
@@ -200,7 +200,7 @@ target_link_libraries(your_app PRIVATE LoggerSystem::logger)
 ### 의존성
 
 **필수**:
-- **[common_system](https://github.com/kcenon/common_system)**: 핵심 인터페이스 (ILogger, IMonitor, Result<T>)
+- **[common_system](https://github.com/kcenon/common_system)**: 핵심 인터페이스 (ILogger, IMonitor, Result<T>) 및 C++20 Concepts 지원
 
 **선택사항**:
 - **[thread_system](https://github.com/kcenon/thread_system)**: 향상된 Threading primitive (v3.1.0부터 선택사항)

--- a/include/kcenon/logger/core/error_codes.h
+++ b/include/kcenon/logger/core/error_codes.h
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 #include <utility>
 #include <optional>
+#include <concepts>
 
 #if __has_include(<kcenon/common/patterns/result.h>)
 #include <kcenon/common/patterns/result.h>
@@ -460,13 +461,12 @@ inline std::string logger_error_to_string(logger_error_code code) {
 template<typename T>
 class result {
 public:
-    // Move constructor (works for all types)
-    result(T value)
+    // Move constructor (only enabled for move-constructible types)
+    result(T&& value) requires std::move_constructible<T>
         : value_(common::ok<T>(std::move(value))) {}
 
-    // Copy constructor (only enabled for copyable types)
-    template<typename U = T>
-    result(const T& value, typename std::enable_if<std::is_copy_constructible<U>::value, int>::type = 0)
+    // Copy constructor (only enabled for copyable types that are not rvalue references)
+    result(const T& value) requires std::copy_constructible<T>
         : value_(common::ok<T>(value)) {}
 
     result(logger_error_code code, const std::string& msg = "")


### PR DESCRIPTION
## Summary

- Update common_system dependency to latest version (commit 2ad407a) which includes C++20 Concepts support (PR common_system#194)
- Replace `std::enable_if` SFINAE patterns with C++20 concepts in `result<T>` class constructor constraints
- Update documentation to reflect C++20 Concepts support

## Changes

### Code Changes
- **include/kcenon/logger/core/error_codes.h**:
  - Added `<concepts>` header include
  - Replaced SFINAE pattern with `requires std::move_constructible<T>` for move constructor
  - Replaced SFINAE pattern with `requires std::copy_constructible<T>` for copy constructor

### Documentation Updates
- **README.md**: Updated common_system dependency description to mention C++20 Concepts support
- **README_KO.md**: Same update in Korean

## Benefits

- **Clearer error messages**: Template errors displayed as concept violations instead of SFINAE failures
- **Self-documenting code**: Explicit type requirements without boilerplate
- **Code simplification**: ~30% reduction in constraint code
- **Better IDE support**: Improved auto-completion and type hints

## Test plan

- [x] All logger_system unit tests pass
- [x] Build succeeds on local environment (macOS with Apple Clang)
- [x] CI/CD tests on Linux (GCC, Clang), Windows (MSVC)

## Related Issues

Closes #234

## Compiler Requirements

This change requires C++20 compiler support:
- GCC 10+
- Clang 10+
- MSVC 2019 16.3+

All CI/CD workflows already use compilers that meet these requirements.