### PR TITLE
fix(examples): update ILogger adapter to use source_location interface

### DIFF
--- a/examples/di_pattern_example.cpp
+++ b/examples/di_pattern_example.cpp
@@ -94,15 +94,13 @@ public:
     }
 
     kcenon::common::VoidResult log(ci::log_level level,
-                           const std::string& message,
-                           const std::string& file,
-                           int line,
-                           const std::string& function) override {
+                           std::string_view message,
+                           const ci::source_location& loc) override {
         if (!logger_) {
             return make_adapter_error("Logger not initialized");
         }
         std::ostringstream oss;
-        oss << "[" << file << ':' << line << ':' << function << "] " << message;
+        oss << "[" << loc.file_name() << ':' << loc.line() << ':' << loc.function_name() << "] " << message;
         logger_->log(to_logger_level(level), oss.str());
         return kcenon::common::ok();
     }


### PR DESCRIPTION
## Summary

- Updates `logger_interface_adapter` in `di_pattern_example.cpp` to use the new `source_location` interface
- The `ILogger` interface in common_system changed from using separate `file`, `line`, `function` parameters to using `source_location`

## Changes

- Updated `log()` method signature from `(level, message, file, line, function)` to `(level, message, source_location)`
- Updated method implementation to use `loc.file_name()`, `loc.line()`, `loc.function_name()`

## Test plan

- [x] Build succeeds on macOS
- [x] All 11 tests pass