### PR TITLE
refactor(api): mark native log_level API as deprecated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -49,6 +49,44 @@ common::VoidResult res = make_logger_void_result(code, "message");
 
 ## [Unreleased]
 
+### Native log_level API Deprecation (Issue #320)
+
+#### Deprecated
+- **Native `logger_system::log_level` enum** - Use `common::interfaces::log_level` instead
+  - Marked with `[[deprecated]]` attribute for compiler warnings
+  - Will be removed in v3.0.0
+
+- **Native log_level methods in `logger` class**
+  - `log(log_level, const std::string&)` - Use ILogger interface methods instead
+  - `log(log_level, msg, file, line, func)` - Use `log(level, msg, source_location)` instead
+  - `log(log_level, msg, log_context)` - Use `log(level, msg, source_location)` instead
+  - `is_enabled(log_level)` - Use `is_enabled(common::interfaces::log_level)` instead
+  - `set_min_level(log_level)` - Use `set_level(common::interfaces::log_level)` instead
+  - `get_min_level()` - Use `get_level()` instead
+
+- **Utility functions in `logger_types.h`**
+  - `log_level_to_string()` - Use `common::interfaces::log_level_to_string()` instead
+  - `string_to_log_level()` - Use `common::interfaces::string_to_log_level()` instead
+
+- **Conversion functions in `level_converter.h`**
+  - `to_logger_system_level()` - Use `common::interfaces::log_level` directly
+  - `to_common_level()` - Use `common::interfaces::log_level` directly
+
+#### Migration
+```cpp
+// Before (deprecated):
+logger->log(log_level::info, "Message");
+logger->set_min_level(log_level::debug);
+
+// After (recommended):
+logger->log(common::interfaces::log_level::info, "Message");
+logger->set_level(common::interfaces::log_level::debug);
+```
+
+See [Migration Guide](guides/MIGRATION_GUIDE.md#deprecated-native-log_level-api-planned-for-removal-in-v300) for details.
+
+---
+
 ### Real-time Log Analysis Integration (Issue #281)
 
 #### Added

--- a/docs/guides/MIGRATION_GUIDE.md
+++ b/docs/guides/MIGRATION_GUIDE.md
@@ -451,6 +451,52 @@ logger->debug("Message", {{"value", value}});
 | N/A | `with_performance_tuning(level)` | New configuration strategy |
 | N/A | `with_monitoring(monitor)` | New monitoring integration |
 
+### Deprecated Native log_level API (Planned for Removal in v3.0.0)
+
+The following native `logger_system::log_level` APIs are deprecated in favor of `common::interfaces::log_level`:
+
+| Deprecated API | Recommended Alternative | Status |
+|----------------|------------------------|--------|
+| `logger_system::log_level` enum | `common::interfaces::log_level` | Deprecated, will be removed in v3.0.0 |
+| `log(log_level, const std::string&)` | `log(common::interfaces::log_level, const std::string&)` | Deprecated |
+| `log(log_level, msg, file, line, func)` | `log(common::interfaces::log_level, std::string_view, source_location)` | Deprecated |
+| `log(log_level, msg, log_context)` | `log(common::interfaces::log_level, std::string_view, source_location)` | Deprecated |
+| `is_enabled(log_level)` | `is_enabled(common::interfaces::log_level)` | Deprecated |
+| `set_min_level(log_level)` | `set_level(common::interfaces::log_level)` | Deprecated |
+| `get_min_level()` | `get_level()` | Deprecated |
+| `log_level_to_string()` | `common::interfaces::log_level_to_string()` | Deprecated |
+| `string_to_log_level()` | `common::interfaces::string_to_log_level()` | Deprecated |
+| `to_logger_system_level()` | Use `common::interfaces::log_level` directly | Deprecated |
+| `to_common_level()` | Use `common::interfaces::log_level` directly | Deprecated |
+
+**Migration Example:**
+
+```cpp
+// OLD (deprecated)
+#include <kcenon/logger/interfaces/logger_types.h>
+using namespace kcenon::logger;
+
+logger->log(log_level::info, "Message");
+logger->set_min_level(log_level::debug);
+if (logger->is_enabled(log_level::trace)) { ... }
+
+// NEW (recommended)
+#include <kcenon/common/interfaces/logger_interface.h>
+using namespace kcenon::logger;
+
+logger->log(common::interfaces::log_level::info, "Message");
+logger->set_level(common::interfaces::log_level::debug);
+if (logger->is_enabled(common::interfaces::log_level::trace)) { ... }
+
+// Or with using directive for brevity
+using common::interfaces::log_level;
+logger->log(log_level::info, "Message");
+```
+
+**Timeline:**
+- **Current**: APIs marked with `[[deprecated]]` attribute - compiler warnings will be generated
+- **v3.0.0**: Deprecated APIs will be removed
+
 ### Core Logger API
 
 | v1.x Method | v2.x Equivalent | v3.0 Equivalent |

--- a/include/kcenon/logger/core/level_converter.h
+++ b/include/kcenon/logger/core/level_converter.h
@@ -35,8 +35,11 @@ namespace kcenon::logger {
  * @note Both enumerations use identical numeric values, so this is essentially
  * a type-safe cast with no runtime overhead.
  *
+ * @deprecated Use common::interfaces::log_level directly instead of converting.
+ *             Will be removed in v3.0.0.
  * @since 2.0.0
  */
+[[deprecated("Use common::interfaces::log_level directly instead of converting. Will be removed in v3.0.0.")]]
 [[nodiscard]] constexpr logger_system::log_level
 to_logger_system_level(common::interfaces::log_level level) noexcept {
     switch (level) {
@@ -70,8 +73,11 @@ to_logger_system_level(common::interfaces::log_level level) noexcept {
  * @note logger_system::log_level has aliases (warn=warning=3, fatal=critical=5),
  * so we use the underlying integer value for conversion to avoid duplicate case errors.
  *
+ * @deprecated Use common::interfaces::log_level directly instead of converting.
+ *             Will be removed in v3.0.0.
  * @since 2.0.0
  */
+[[deprecated("Use common::interfaces::log_level directly instead of converting. Will be removed in v3.0.0.")]]
 [[nodiscard]] constexpr common::interfaces::log_level
 to_common_level(logger_system::log_level level) noexcept {
     // Use underlying integer to avoid duplicate case value errors

--- a/include/kcenon/logger/core/logger.h
+++ b/include/kcenon/logger/core/logger.h
@@ -325,8 +325,11 @@ public:
      *
      * @note Messages below the minimum log level are discarded for performance.
      *
+     * @deprecated Use log(common::interfaces::log_level, const std::string&) instead.
+     *             Will be removed in v3.0.0.
      * @since 1.0.0
      */
+    [[deprecated("Use log(common::interfaces::log_level, const std::string&) instead. Will be removed in v3.0.0.")]]
     void log(log_level level, const std::string& message);
 
     /**
@@ -341,8 +344,11 @@ public:
      * This overload is useful for tracking the exact origin of log messages.
      * Internally converts to common::interfaces::log_level.
      *
+     * @deprecated Use log(common::interfaces::log_level, std::string_view, const source_location&) instead.
+     *             Will be removed in v3.0.0.
      * @since 1.0.0
      */
+    [[deprecated("Use log(common::interfaces::log_level, std::string_view, const source_location&) instead. Will be removed in v3.0.0.")]]
     void log(log_level level,
              const std::string& message,
              const std::string& file,
@@ -355,8 +361,11 @@ public:
      * @param message The message to log
      * @param context Source location context
      *
+     * @deprecated Use log(common::interfaces::log_level, std::string_view, const source_location&) instead.
+     *             Will be removed in v3.0.0.
      * @since 1.0.0
      */
+    [[deprecated("Use log(common::interfaces::log_level, std::string_view, const source_location&) instead. Will be removed in v3.0.0.")]]
     void log(log_level level,
              const std::string& message,
              const core::log_context& context);
@@ -369,8 +378,11 @@ public:
      * @details Use this method to avoid expensive message construction
      * for log levels that won't be output.
      *
+     * @deprecated Use is_enabled(common::interfaces::log_level) instead.
+     *             Will be removed in v3.0.0.
      * @since 1.0.0
      */
+    [[deprecated("Use is_enabled(common::interfaces::log_level) instead. Will be removed in v3.0.0.")]]
     bool is_enabled(log_level level) const;
     
     // Additional logger-specific methods
@@ -419,22 +431,26 @@ public:
      * @details Sets the threshold for message logging. Messages with a level
      * below this threshold are discarded for performance optimization.
      *
-     * @deprecated Use set_level(common::interfaces::log_level) instead
+     * @deprecated Use set_level(common::interfaces::log_level) instead.
+     *             Will be removed in v3.0.0.
      * @note This is a thread-safe operation that takes effect immediately.
      *
      * @since 1.0.0
      */
+    [[deprecated("Use set_level(common::interfaces::log_level) instead. Will be removed in v3.0.0.")]]
     void set_min_level(log_level level);
 
     /**
      * @brief Get the minimum log level (legacy API)
      * @return Current minimum log level using logger_system::log_level
      *
-     * @deprecated Use get_level() which returns common::interfaces::log_level instead
+     * @deprecated Use get_level() which returns common::interfaces::log_level instead.
+     *             Will be removed in v3.0.0.
      * @details Returns the current threshold level for message logging.
      *
      * @since 1.0.0
      */
+    [[deprecated("Use get_level() which returns common::interfaces::log_level instead. Will be removed in v3.0.0.")]]
     log_level get_min_level() const;
     
     /**

--- a/include/kcenon/logger/interfaces/logger_types.h
+++ b/include/kcenon/logger/interfaces/logger_types.h
@@ -33,7 +33,7 @@ namespace logger_system {
  *             This enum is maintained for backward compatibility only.
  *             Will be removed in v3.0.0.
  */
-enum class log_level {
+enum class [[deprecated("Use common::interfaces::log_level instead. Will be removed in v3.0.0.")]] log_level {
     trace = 0,
     debug = 1,
     info = 2,
@@ -92,7 +92,9 @@ enum class logger_error_code {
 
 /**
  * @brief Convert log level to string
+ * @deprecated Use common::interfaces::log_level_to_string instead. Will be removed in v3.0.0.
  */
+[[deprecated("Use common::interfaces::log_level_to_string instead. Will be removed in v3.0.0.")]]
 inline const char* log_level_to_string(log_level level) {
     switch (level) {
         case log_level::trace: return "TRACE";
@@ -108,7 +110,9 @@ inline const char* log_level_to_string(log_level level) {
 
 /**
  * @brief Convert string to log level
+ * @deprecated Use common::interfaces::string_to_log_level instead. Will be removed in v3.0.0.
  */
+[[deprecated("Use common::interfaces::string_to_log_level instead. Will be removed in v3.0.0.")]]
 inline log_level string_to_log_level(const std::string& str) {
     if (str == "TRACE" || str == "trace") return log_level::trace;
     if (str == "DEBUG" || str == "debug") return log_level::debug;


### PR DESCRIPTION
Closes #320

## Summary
- Mark native `logger_system::log_level` enum with `[[deprecated]]` attribute
- Mark native log_level methods in logger class as deprecated
- Mark utility functions `log_level_to_string()` and `string_to_log_level()` as deprecated
- Mark level converter functions as deprecated
- Update MIGRATION_GUIDE.md with detailed migration instructions
- Update CHANGELOG.md with deprecation notice

## Deprecated APIs

| API | Replacement |
|-----|-------------|
| `logger_system::log_level` | `common::interfaces::log_level` |
| `log(log_level, msg)` | `log(common::interfaces::log_level, msg)` |
| `is_enabled(log_level)` | `is_enabled(common::interfaces::log_level)` |
| `set_min_level(log_level)` | `set_level(common::interfaces::log_level)` |
| `get_min_level()` | `get_level()` |
| `to_logger_system_level()` | Use `common::interfaces::log_level` directly |
| `to_common_level()` | Use `common::interfaces::log_level` directly |

## Test Plan
- [x] Build succeeds (with expected deprecation warnings)
- [x] All tests pass (except pre-existing encryption test failures)
- [x] Documentation updated