### PR TITLE
refactor(examples): migrate examples to ILogger interface

### DIFF
--- a/examples/basic_usage.cpp
+++ b/examples/basic_usage.cpp
@@ -32,8 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <kcenon/logger/core/logger.h>
 #include <kcenon/logger/writers/console_writer.h>
-using log_level_type = logger_system::log_level;
-namespace log_levels = logger_system;
+#include <kcenon/common/interfaces/logger_interface.h>
+namespace ci = kcenon::common::interfaces;
+using log_level_type = ci::log_level;
 #include <thread>
 #include <vector>
 #include <iostream>
@@ -55,15 +56,15 @@ void basic_logging_example() {
     logger_instance->start();
     
     // Log messages at different levels
-    logger_instance->log(log_level_type::trace, "This is a trace message");
-    logger_instance->log(log_level_type::debug, "Debug information here");
-    logger_instance->log(log_level_type::info, "Application started successfully");
-    logger_instance->log(log_level_type::warning, "This is a warning");
-    logger_instance->log(log_level_type::error, "An error occurred!");
-    logger_instance->log(log_level_type::critical, "Critical system failure!");
+    logger_instance->log(log_level_type::trace, std::string("This is a trace message"));
+    logger_instance->log(log_level_type::debug, std::string("Debug information here"));
+    logger_instance->log(log_level_type::info, std::string("Application started successfully"));
+    logger_instance->log(log_level_type::warning, std::string("This is a warning"));
+    logger_instance->log(log_level_type::error, std::string("An error occurred!"));
+    logger_instance->log(log_level_type::critical, std::string("Critical system failure!"));
 
     // Log with simple message (source_location auto-captured internally)
-    logger_instance->log(log_level_type::info, "Message with auto-captured location");
+    logger_instance->log(log_level_type::info, std::string("Message with auto-captured location"));
     
     // Stop and flush
     logger_instance->stop();
@@ -106,16 +107,16 @@ void log_level_filtering_example() {
     logger_instance->start();
     
     // Set minimum level to INFO
-    logger_instance->set_min_level(log_level_type::info);
+    logger_instance->set_level(log_level_type::info);
     std::cout << "Minimum level set to INFO\n" << std::endl;
 
     // These won't be logged
-    logger_instance->log(log_level_type::trace, "This trace won't show");
-    logger_instance->log(log_level_type::debug, "This debug won't show");
+    logger_instance->log(log_level_type::trace, std::string("This trace won't show"));
+    logger_instance->log(log_level_type::debug, std::string("This debug won't show"));
 
     // These will be logged
-    logger_instance->log(log_level_type::info, "This info will show");
-    logger_instance->log(log_level_type::warning, "This warning will show");
+    logger_instance->log(log_level_type::info, std::string("This info will show"));
+    logger_instance->log(log_level_type::warning, std::string("This warning will show"));
     
     logger_instance->stop();
 }

--- a/examples/crash_protection/main.cpp
+++ b/examples/crash_protection/main.cpp
@@ -50,9 +50,11 @@
 #include "logger/logger.h"
 #include "logger/writers/console_writer.h"
 #include "logger/writers/file_writer.h"
+#include <kcenon/common/interfaces/logger_interface.h>
 
 using namespace kcenon::logger;
 namespace logger_module = kcenon::logger;
+namespace ci = kcenon::common::interfaces;
 
 // Global state for demonstration
 std::atomic<bool> logging_active{true};
@@ -90,7 +92,7 @@ void normal_logging_task(int task_id, std::shared_ptr<logger> logger_instance) {
         std::string message = "Task " + std::to_string(task_id) + 
                              " - Log entry " + std::to_string(i);
         
-        logger_instance->log(log_level::info, message);
+        logger_instance->log(ci::log_level::info, message);
         logs_written.fetch_add(1);
         
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -107,11 +109,11 @@ void heavy_logging_task(int task_id, std::shared_ptr<logger> logger_instance) {
                                    " - Large log entry " + std::to_string(i) + 
                                    " with lots of data: " + std::string(100, 'X');
         
-        logger_instance->log(log_level::debug, large_message);
+        logger_instance->log(ci::log_level::debug, large_message);
         logs_written.fetch_add(1);
         
         if (i % 5 == 0) {
-            logger_instance->log(log_level::warning, 
+            logger_instance->log(ci::log_level::warning,
                 "Checkpoint " + std::to_string(i) + " for task " + std::to_string(task_id));
         }
         
@@ -132,7 +134,7 @@ void potentially_crashing_logging_task(int task_id, std::shared_ptr<logger> logg
         std::string message = "Risky Task " + std::to_string(task_id) + 
                              " - Entry " + std::to_string(i);
         
-        logger_instance->log(log_level::info, message);
+        logger_instance->log(ci::log_level::info, message);
         logs_written.fetch_add(1);
         
         // Random chance of causing issues
@@ -216,7 +218,7 @@ int main() {
     auto main_logger = std::make_shared<logger>(true); // async mode
     main_logger->add_writer(std::make_unique<console_writer>());
     main_logger->add_writer(std::make_unique<file_writer>("./logs/application.log"));
-    main_logger->set_min_level(log_level::debug);
+    main_logger->set_level(ci::log_level::debug);
     main_logger->start();
     
     // Register logger for crash protection
@@ -230,9 +232,9 @@ int main() {
         // Step 3: Test normal logging operations
         std::cout << "\n--- Step 3: Normal Logging Operations ---" << std::endl;
         
-        main_logger->log(log_level::info, "Logger crash protection demo started");
-        main_logger->log(log_level::debug, "Debug information available");
-        main_logger->log(log_level::warning, "This is a warning message");
+        main_logger->log(ci::log_level::info, std::string("Logger crash protection demo started"));
+        main_logger->log(ci::log_level::debug, std::string("Debug information available"));
+        main_logger->log(ci::log_level::warning, std::string("This is a warning message"));
         
         // Step 4: Multi-threaded logging stress test
         std::cout << "\n--- Step 4: Multi-threaded Logging Stress Test ---" << std::endl;
@@ -319,7 +321,7 @@ int main() {
         
         // Generate burst of logs to test overflow handling
         for (int i = 0; i < 1000; ++i) {
-            main_logger->log(log_level::debug, "Burst log " + std::to_string(i));
+            main_logger->log(ci::log_level::debug, "Burst log " + std::to_string(i));
         }
         
         // Force flush to test emergency procedures
@@ -355,7 +357,7 @@ int main() {
     // Step 11: Graceful shutdown
     std::cout << "\n--- Step 11: Graceful Shutdown ---" << std::endl;
     
-    main_logger->log(log_level::info, "Shutting down logger crash protection demo");
+    main_logger->log(ci::log_level::info, std::string("Shutting down logger crash protection demo"));
     main_logger->stop();
     
     std::cout << "\n=== Demo Completed Successfully ===" << std::endl;

--- a/examples/critical_logging_example.cpp
+++ b/examples/critical_logging_example.cpp
@@ -43,11 +43,13 @@
 #include <kcenon/logger/writers/rotating_file_writer.h>
 #include <kcenon/logger/writers/critical_writer.h>
 #include <kcenon/logger/writers/async_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <iostream>
 #include <thread>
 #include <chrono>
 
 using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
 using namespace std::chrono_literals;
 
 /**
@@ -76,11 +78,11 @@ void example_basic_critical_writer() {
     log.add_writer(std::move(critical));
 
     // Normal logs (buffered)
-    log.log(log_level::info, "Application started");
-    log.log(log_level::debug, "Debug information");
+    log.log(ci::log_level::info, std::string("Application started"));
+    log.log(ci::log_level::debug, std::string("Debug information"));
 
     // Critical log (immediately flushed to disk)
-    log.log(log_level::critical, "Critical error occurred - guaranteed on disk");
+    log.log(ci::log_level::critical, std::string("Critical error occurred - guaranteed on disk"));
 
     // Even if the program crashes here, the critical log above is safe
     std::cout << "Critical log written and flushed immediately\n";
@@ -114,8 +116,8 @@ void example_write_ahead_logging() {
 
     log.add_writer(std::move(critical));
 
-    log.log(log_level::info, "Normal log");
-    log.log(log_level::critical, "Critical log - written to WAL first");
+    log.log(ci::log_level::info, std::string("Normal log"));
+    log.log(ci::log_level::critical, std::string("Critical log - written to WAL first"));
 
     std::cout << "Check logs/.critical.wal for write-ahead log entries\n";
 }
@@ -146,11 +148,11 @@ void example_hybrid_writer() {
 
     // These go through async queue (fast)
     for (int i = 0; i < 100; ++i) {
-        log.log(log_level::info, "High-frequency log " + std::to_string(i));
+        log.log(ci::log_level::info, "High-frequency log " + std::to_string(i));
     }
 
     // This bypasses the queue and flushes immediately (safe)
-    log.log(log_level::critical, "Critical error - no loss guaranteed");
+    log.log(ci::log_level::critical, std::string("Critical error - no loss guaranteed"));
 
     std::cout << "Hybrid writer provides both performance and safety\n";
 }
@@ -178,8 +180,8 @@ void example_signal_handler() {
     auto& stats = critical->get_stats();
     log.add_writer(std::move(critical));
 
-    log.log(log_level::info, "Before critical log");
-    log.log(log_level::critical, "Critical log before potential crash");
+    log.log(ci::log_level::info, std::string("Before critical log"));
+    log.log(ci::log_level::critical, std::string("Critical log before potential crash"));
 
     std::cout << "Try sending SIGTERM (Ctrl+C) to this process\n";
     std::cout << "The signal handler will ensure logs are flushed\n";
@@ -236,10 +238,10 @@ void example_production_setup() {
     log->start();
 
     // Production logging examples
-    log->log(log_level::info, "Service started");
-    log->log(log_level::warning, "Cache miss rate high");
-    log->log(log_level::error, "Database connection timeout");
-    log->log(log_level::critical, "Out of memory - terminating");
+    log->log(ci::log_level::info, std::string("Service started"));
+    log->log(ci::log_level::warning, std::string("Cache miss rate high"));
+    log->log(ci::log_level::error, std::string("Database connection timeout"));
+    log->log(ci::log_level::critical, std::string("Out of memory - terminating"));
 
     log->flush();
     log->stop();
@@ -278,12 +280,12 @@ void example_error_handling() {
     log.add_writer(std::move(critical));
 
     // Generate logs
-    log.log(log_level::info, "Info message");
-    log.log(log_level::warning, "Warning message");
-    log.log(log_level::error, "Error message");
-    log.log(log_level::critical, "Critical message 1");
-    log.log(log_level::critical, "Critical message 2");
-    log.log(log_level::critical, "Fatal message");
+    log.log(ci::log_level::info, std::string("Info message"));
+    log.log(ci::log_level::warning, std::string("Warning message"));
+    log.log(ci::log_level::error, std::string("Error message"));
+    log.log(ci::log_level::critical, std::string("Critical message 1"));
+    log.log(ci::log_level::critical, std::string("Critical message 2"));
+    log.log(ci::log_level::critical, std::string("Fatal message"));
 
     // Check statistics
     std::cout << "\nConfiguration:\n";

--- a/examples/custom_writer_example.cpp
+++ b/examples/custom_writer_example.cpp
@@ -48,11 +48,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/logger/writers/console_writer.h>
 #include <kcenon/logger/formatters/json_formatter.h>
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <iostream>
 #include <vector>
 #include <map>
 
 using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
 
 /**
  * @class memory_writer
@@ -273,9 +275,9 @@ int main() {
         auto logger = std::move(result.value());
 
         // Log some messages
-        logger->log(logger_system::log_level::info, "First message");
-        logger->log(logger_system::log_level::warning, "Second message");
-        logger->log(logger_system::log_level::error, "Third message");
+        logger->log(ci::log_level::info, std::string("First message"));
+        logger->log(ci::log_level::warning, std::string("Second message"));
+        logger->log(ci::log_level::error, std::string("Third message"));
 
         std::cout << "Logged 3 messages to memory writer" << std::endl;
     }
@@ -301,11 +303,11 @@ int main() {
         auto logger = std::move(result.value());
 
         // Log messages at different levels
-        logger->log(logger_system::log_level::debug, "Debug message 1");
-        logger->log(logger_system::log_level::debug, "Debug message 2");
-        logger->log(logger_system::log_level::info, "Info message");
-        logger->log(logger_system::log_level::warning, "Warning message");
-        logger->log(logger_system::log_level::error, "Error message");
+        logger->log(ci::log_level::debug, std::string("Debug message 1"));
+        logger->log(ci::log_level::debug, std::string("Debug message 2"));
+        logger->log(ci::log_level::info, std::string("Info message"));
+        logger->log(ci::log_level::warning, std::string("Warning message"));
+        logger->log(ci::log_level::error, std::string("Error message"));
 
         // Print statistics
         counted_ptr->print_stats();

--- a/examples/metrics_demo.cpp
+++ b/examples/metrics_demo.cpp
@@ -8,12 +8,14 @@ All rights reserved.
 #include <kcenon/logger/core/logger.h>
 #include <kcenon/logger/writers/console_writer.h>
 #include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <thread>
 #include <iostream>
 #include <random>
 
 using namespace kcenon::logger;
 namespace logger_module = kcenon::logger;
+namespace ci = kcenon::common::interfaces;
 
 void generate_logs(logger* log, int thread_id, int count) {
     std::random_device rd;
@@ -55,9 +57,9 @@ void test_structured_logging() {
     base_logger->start();
 
     // Test basic logging at different levels
-    base_logger->log(kcenon::logger::log_level::info, "User logged in - user_id: 12345, ip: 192.168.1.100");
-    base_logger->log(kcenon::logger::log_level::error, "Database connection failed - host: db.example.com, port: 5432");
-    base_logger->log(kcenon::logger::log_level::debug, "Retry attempt 3 of 5");
+    base_logger->log(ci::log_level::info, std::string("User logged in - user_id: 12345, ip: 192.168.1.100"));
+    base_logger->log(ci::log_level::error, std::string("Database connection failed - host: db.example.com, port: 5432"));
+    base_logger->log(ci::log_level::debug, std::string("Retry attempt 3 of 5"));
 
     base_logger->stop();
 }

--- a/examples/monitoring_integration_example.cpp
+++ b/examples/monitoring_integration_example.cpp
@@ -245,7 +245,7 @@ void example_1_basic_integration() {
 
     // Perform logging operations
     for (int i = 0; i < 5; ++i) {
-        logger_instance->log(log_level::info,
+        logger_instance->log(ci::log_level::info,
             "Log message " + std::to_string(i + 1));
     }
 
@@ -296,9 +296,9 @@ void example_2_multiple_loggers() {
     std::cout << "[Note: logger IMonitorable integration pending Phase 2.2]" << std::endl;
 
     // Both loggers use the same monitor
-    logger1->log(log_level::info, "Message from logger 1");
-    logger2->log(log_level::warning, "Message from logger 2");
-    logger1->log(log_level::error, "Error from logger 1");
+    logger1->log(ci::log_level::info, std::string("Message from logger 1"));
+    logger2->log(ci::log_level::warning, std::string("Message from logger 2"));
+    logger1->log(ci::log_level::error, std::string("Error from logger 1"));
 
     std::cout << "\nMonitor tracks " << monitor->get_component_count()
               << " components" << std::endl;
@@ -334,8 +334,8 @@ void example_3_imonitorable_interface() {
                   << monitorable->get_component_name() << std::endl;
 
         // Perform operations
-        logger_instance->log(log_level::info, "Test message 1");
-        logger_instance->log(log_level::info, "Test message 2");
+        logger_instance->log(ci::log_level::info, std::string("Test message 1"));
+        logger_instance->log(ci::log_level::info, std::string("Test message 2"));
 
         // Get monitoring data directly from logger
         auto data = monitorable->get_monitoring_data();
@@ -378,7 +378,7 @@ void example_4_monitoring_system_simulation() {
 
     // Simulate application activity
     for (int i = 0; i < 10; ++i) {
-        logger_instance->log(log_level::info,
+        logger_instance->log(ci::log_level::info,
             "Application event " + std::to_string(i + 1));
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }

--- a/examples/security_demo.cpp
+++ b/examples/security_demo.cpp
@@ -37,6 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // #include <kcenon/logger/routing/log_router.h>  // TODO: Not implemented yet
 #include <kcenon/logger/writers/console_writer.h>
 #include <kcenon/logger/writers/file_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 #include <iostream>
 #include <thread>
@@ -45,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace kcenon::logger;
 namespace logger_module = kcenon::logger;
+namespace ci = kcenon::common::interfaces;
 using namespace std::chrono_literals;
 
 // Custom security filter that blocks sensitive logs
@@ -108,20 +110,20 @@ void demonstrate_security_logging() {
     std::cout << "\nLogging security events (sensitive data will be sanitized):" << std::endl;
     
     // This will be blocked by the security filter
-    logger->log(logger_system::log_level::warning,
-                "User login attempt with password=admin123");
-    
+    logger->log(ci::log_level::warning,
+                std::string("User login attempt with password=admin123"));
+
     // These will be logged but sanitized
-    logger->log(logger_system::log_level::warning,
+    logger->log(ci::log_level::warning,
                 sanitizer->sanitize("Suspicious activity from IP 192.168.1.100"));
-    
-    logger->log(logger_system::log_level::warning,
+
+    logger->log(ci::log_level::warning,
                 sanitizer->sanitize("Failed login for email user@example.com"));
-    
-    logger->log(logger_system::log_level::error,
+
+    logger->log(ci::log_level::error,
                 sanitizer->sanitize("Data breach detected: SSN 123-45-6789 exposed"));
-    
-    logger->log(logger_system::log_level::critical,
+
+    logger->log(ci::log_level::critical,
                 sanitizer->sanitize("API key compromised: key=EXAMPLE_KEY_12345"));
 }
 
@@ -133,11 +135,11 @@ void demonstrate_encryption() {
     // Add encrypted file writer
     logger->add_writer(std::make_unique<file_writer>("security_encrypted.log"));
     
-    logger->log(logger_system::log_level::info,
-                "This message will be written to an encrypted log file");
-    
-    logger->log(logger_system::log_level::warning,
-                "Sensitive operations are logged securely");
+    logger->log(ci::log_level::info,
+                std::string("This message will be written to an encrypted log file"));
+
+    logger->log(ci::log_level::warning,
+                std::string("Sensitive operations are logged securely"));
     
     std::cout << "Messages written to encrypted log file: security_encrypted.log" << std::endl;
 }
@@ -156,11 +158,11 @@ void demonstrate_audit_trail() {
     // Note: Router configuration would be done here if needed
     
     // Simulate various events
-    logger->log(logger_system::log_level::info, "Normal operation");
-    logger->log(logger_system::log_level::warning, "High CPU usage");
-    logger->log(logger_system::log_level::critical, "Security breach detected");
-    logger->log(logger_system::log_level::critical, "Unauthorized access attempt");
-    logger->log(logger_system::log_level::error, "Database connection failed");
+    logger->log(ci::log_level::info, std::string("Normal operation"));
+    logger->log(ci::log_level::warning, std::string("High CPU usage"));
+    logger->log(ci::log_level::critical, std::string("Security breach detected"));
+    logger->log(ci::log_level::critical, std::string("Unauthorized access attempt"));
+    logger->log(ci::log_level::error, std::string("Database connection failed"));
     
     std::cout << "Audit events written to: audit_trail.log" << std::endl;
 }
@@ -259,8 +261,8 @@ void demonstrate_security_metrics() {
             std::cout << "\nMessage rate: " << message_rate << " msgs/sec" << std::endl;
         
             if (message_rate > 1000.0) {
-                logger->log(logger_system::log_level::critical,
-                           "High message rate detected!");
+                logger->log(ci::log_level::critical,
+                           std::string("High message rate detected!"));
             }
         }
     } else {
@@ -275,7 +277,7 @@ int main() {
         
         // Create and configure logger
         auto logger = std::make_shared<logger_module::logger>();
-        logger->set_min_level(logger_system::log_level::debug);
+        logger->set_level(ci::log_level::debug);
         logger->start();
         
         // Add console output for demo


### PR DESCRIPTION
Closes #329

## Summary
- Migrate 8 example files to use `common::interfaces::log_level` instead of the deprecated `logger_system::log_level`
- Replace `set_min_level()` with `set_level()` API
- Simplify `di_pattern_example.cpp` adapter to use ILogger methods directly instead of conversion functions

## Changed Files
| File | Changes |
|------|---------|
| `basic_usage.cpp` | Use `ci::log_level`, `set_level()` |
| `crash_protection/main.cpp` | Use `ci::log_level` for all log calls |
| `critical_logging_example.cpp` | Use `ci::log_level` for log() calls |
| `custom_writer_example.cpp` | Use `ci::log_level` for log() calls |
| `di_pattern_example.cpp` | Remove conversion functions, use ILogger directly |
| `metrics_demo.cpp` | Use `ci::log_level` for log() calls |
| `monitoring_integration_example.cpp` | Use `ci::log_level` for log() calls |
| `security_demo.cpp` | Use `ci::log_level`, `set_level()` |

## Notes
- Some examples still use `logger_system::log_level` for internal APIs (`with_min_level`, `log_entry`, `filters`) which will be addressed in subsequent issues (#330-#333)
- Build passes with deprecation warnings (expected during migration)
- Test suite passes (failures are pre-existing and unrelated to these changes)

## Test Plan
- [x] Build verification passes
- [x] ctest runs without new failures

Part of #328