### PR TITLE
refactor(tests): migrate unit tests to ILogger interface log_level

### DIFF
--- a/tests/structured_logging_test.cpp
+++ b/tests/structured_logging_test.cpp
@@ -26,6 +26,7 @@ All rights reserved.
 using namespace kcenon::logger;
 using namespace kcenon::common;
 using namespace std::chrono_literals;
+namespace ci = kcenon::common::interfaces;
 
 namespace {
 
@@ -296,7 +297,7 @@ TEST_F(StructuredLoggingTest, JsonFormatterWithCategory) {
 // Test 8: Structured logging with all level methods (deprecated convenience methods)
 TEST_F(StructuredLoggingTest, AllStructuredLevelMethods) {
     auto test_logger = std::make_shared<logger>(false);
-    test_logger->set_min_level(log_level::trace);
+    test_logger->set_level(ci::log_level::trace);
     test_logger->start();
 
     auto writer = std::make_unique<capture_writer>();
@@ -331,7 +332,7 @@ TEST_F(StructuredLoggingTest, AllStructuredLevelMethods) {
 // Test 8b: Structured logging with generic log_structured method (canonical API)
 TEST_F(StructuredLoggingTest, GenericLogStructuredMethod) {
     auto test_logger = std::make_shared<logger>(false);
-    test_logger->set_min_level(log_level::trace);
+    test_logger->set_level(ci::log_level::trace);
     test_logger->start();
 
     auto writer = std::make_unique<capture_writer>();

--- a/tests/unit/config_test/config_test.cpp
+++ b/tests/unit/config_test/config_test.cpp
@@ -10,8 +10,11 @@ All rights reserved.
 #include <logger/config/logger_builder.h>
 #include <logger/writers/console_writer.h>
 #include <logger/filters/log_filter.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 using namespace logger_module;
+namespace ci = kcenon::common::interfaces;
+using log_level = ci::log_level;
 
 class ConfigTest : public ::testing::Test {
 protected:
@@ -35,7 +38,7 @@ TEST_F(ConfigTest, DefaultConfigValidation) {
     // Check default values
     EXPECT_TRUE(config.async);
     EXPECT_EQ(config.buffer_size, 8192);
-    EXPECT_EQ(config.min_level, thread_module::log_level::info);
+    EXPECT_EQ(config.min_level, log_level::info);
     EXPECT_EQ(config.batch_size, 100);
     EXPECT_EQ(config.flush_interval.count(), 1000);
     EXPECT_FALSE(config.use_lock_free);
@@ -214,7 +217,7 @@ TEST_F(ConfigTest, PredefinedConfigurations) {
     auto debug_config = logger_config::debug_config();
     EXPECT_TRUE(debug_config.validate());
     EXPECT_FALSE(debug_config.async);
-    EXPECT_EQ(debug_config.min_level, thread_module::log_level::trace);
+    EXPECT_EQ(debug_config.min_level, log_level::trace);
     
     // Production config
     auto prod_config = logger_config::production();
@@ -230,7 +233,7 @@ TEST_F(ConfigTest, LoggerBuilderBasic) {
     // Configure builder
     builder.with_async(true)
            .with_buffer_size(4096)
-           .with_min_level(thread_module::log_level::debug)
+           .with_min_level(log_level::debug)
            .with_metrics(true);
     
     // Validate configuration
@@ -260,7 +263,7 @@ TEST_F(ConfigTest, LoggerBuilderWithFilters) {
     logger_builder builder;
     
     // Add level filter
-    builder.add_filter(std::make_unique<level_filter>(thread_module::log_level::warning));
+    builder.add_filter(std::make_unique<level_filter>(log_level::warning));
     
     // Build logger
     auto result = builder.build();
@@ -310,7 +313,7 @@ TEST_F(ConfigTest, LoggerBuilderInvalidConfig) {
 TEST_F(ConfigTest, LoggerBuilderFluentInterface) {
     auto result = logger_builder()
         .use_template("production")
-        .with_min_level(thread_module::log_level::info)
+        .with_min_level(log_level::info)
         .with_buffer_size(16384)
         .with_metrics(true)
         .with_crash_handler(true)

--- a/tests/unit/config_test/strategy_test.cpp
+++ b/tests/unit/config_test/strategy_test.cpp
@@ -15,10 +15,13 @@ All rights reserved.
 #include <kcenon/logger/factories/writer_factory.h>
 #include <kcenon/logger/factories/formatter_factory.h>
 #include <kcenon/logger/factories/filter_factory.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <chrono>
 #include <cstdlib>
 
 using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
+using log_level = ci::log_level;
 
 class ConfigStrategyTest : public ::testing::Test {
 protected:
@@ -133,7 +136,7 @@ TEST_F(ConfigStrategyTest, DeploymentStrategy_Development) {
 
     // Verify development settings
     EXPECT_FALSE(config.async);
-    EXPECT_EQ(config.min_level, logger_system::log_level::trace);
+    EXPECT_EQ(config.min_level, log_level::trace);
     EXPECT_TRUE(config.enable_color_output);
     EXPECT_TRUE(config.enable_source_location);
     EXPECT_EQ(config.batch_size, 1);
@@ -149,7 +152,7 @@ TEST_F(ConfigStrategyTest, DeploymentStrategy_Staging) {
 
     // Verify staging settings
     EXPECT_TRUE(config.async);
-    EXPECT_EQ(config.min_level, logger_system::log_level::info);
+    EXPECT_EQ(config.min_level, log_level::info);
     EXPECT_TRUE(config.enable_structured_logging);
     EXPECT_TRUE(config.enable_batch_writing);
 }
@@ -164,7 +167,7 @@ TEST_F(ConfigStrategyTest, DeploymentStrategy_Production) {
 
     // Verify production settings
     EXPECT_TRUE(config.async);
-    EXPECT_EQ(config.min_level, logger_system::log_level::warn);
+    EXPECT_EQ(config.min_level, log_level::warn);
     EXPECT_TRUE(config.enable_crash_handler);
     EXPECT_FALSE(config.enable_color_output);
     EXPECT_TRUE(config.enable_structured_logging);
@@ -181,7 +184,7 @@ TEST_F(ConfigStrategyTest, DeploymentStrategy_Testing) {
 
     // Verify testing settings
     EXPECT_FALSE(config.async);
-    EXPECT_EQ(config.min_level, logger_system::log_level::trace);
+    EXPECT_EQ(config.min_level, log_level::trace);
     EXPECT_FALSE(config.enable_crash_handler);
     EXPECT_TRUE(config.enable_source_location);
 }
@@ -200,7 +203,7 @@ TEST_F(ConfigStrategyTest, EnvironmentStrategy_LogLevel) {
     logger_config config;
     strategy.apply(config);
 
-    EXPECT_EQ(config.min_level, logger_system::log_level::error);
+    EXPECT_EQ(config.min_level, log_level::error);
 }
 
 TEST_F(ConfigStrategyTest, EnvironmentStrategy_MultipleVars) {
@@ -216,7 +219,7 @@ TEST_F(ConfigStrategyTest, EnvironmentStrategy_MultipleVars) {
     logger_config config;
     strategy.apply(config);
 
-    EXPECT_EQ(config.min_level, logger_system::log_level::debug);
+    EXPECT_EQ(config.min_level, log_level::debug);
     EXPECT_FALSE(config.async);
     EXPECT_EQ(config.buffer_size, 16384);
     EXPECT_TRUE(config.enable_color_output);
@@ -362,7 +365,7 @@ TEST_F(ConfigStrategyTest, FormatterFactory_Presets) {
 //============================================================================
 
 TEST_F(ConfigStrategyTest, FilterFactory_CreateLevel) {
-    auto filter = filter_factory::create_level(logger_system::log_level::warn);
+    auto filter = filter_factory::create_level(log_level::warn);
     ASSERT_NE(filter, nullptr);
     EXPECT_EQ(filter->get_name(), "level_filter");
 }
@@ -375,7 +378,7 @@ TEST_F(ConfigStrategyTest, FilterFactory_CreateRegex) {
 
 TEST_F(ConfigStrategyTest, FilterFactory_Builder) {
     auto filter = filter_factory::create_builder()
-        .with_min_level(logger_system::log_level::info)
+        .with_min_level(log_level::info)
         .exclude_pattern("password|secret")
         .build();
 

--- a/tests/unit/di_test/di_container_test.cpp
+++ b/tests/unit/di_test/di_container_test.cpp
@@ -12,6 +12,7 @@ All rights reserved.
 
 #include <gtest/gtest.h>
 #include <kcenon/logger/writers/base_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include "../../../src/impl/di/lightweight_di_container.h"
 #include <memory>
 #include <thread>
@@ -19,23 +20,26 @@ All rights reserved.
 #include <chrono>
 
 using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
+using log_level = ci::log_level;
 
 // Mock writer for testing
 class mock_writer : public base_writer {
 private:
     std::string name_;
     static int instance_count_;
-    
+
 public:
     explicit mock_writer(const std::string& name = "mock")
         : name_(name) {
         ++instance_count_;
     }
-    
+
     ~mock_writer() override {
         --instance_count_;
     }
-    
+
+    // Note: base_writer::write uses logger_system::log_level for backward compatibility
     common::VoidResult write(logger_system::log_level level,
                       const std::string& message,
                       const std::string& file,
@@ -48,19 +52,19 @@ public:
     common::VoidResult flush() override {
         return common::ok();
     }
-    
+
     bool is_healthy() const override {
         return true;
     }
-    
+
     std::string get_name() const override {
         return name_;
     }
-    
+
     static int get_instance_count() {
         return instance_count_;
     }
-    
+
     static void reset_instance_count() {
         instance_count_ = 0;
     }

--- a/tests/unit/health_test/health_check_test.cpp
+++ b/tests/unit/health_test/health_check_test.cpp
@@ -9,18 +9,22 @@ All rights reserved.
 #include "../../sources/logger/health/health_check_system.h"
 #include "../../sources/logger/writers/base_writer.h"
 #include "../../sources/logger/core/log_collector.h"
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <thread>
 #include <chrono>
 
 using namespace logger_module;
 using namespace std::chrono_literals;
+namespace ci = kcenon::common::interfaces;
+using log_level = ci::log_level;
 
 // Mock writer for testing
 class mock_writer : public base_writer {
 public:
     mock_writer() : fail_writes_(false), write_count_(0) {}
-    
-    common::VoidResult write(thread_module::log_level /* level */,
+
+    // Note: base_writer::write uses logger_system::log_level for backward compatibility
+    common::VoidResult write(logger_system::log_level /* level */,
                      const std::string& /* message */,
                      const std::string& /* file */,
                      int /* line */,
@@ -36,19 +40,19 @@ public:
     common::VoidResult flush() override {
         return common::ok();
     }
-    
+
     std::string get_name() const override {
         return "mock_writer";
     }
-    
+
     void set_fail_writes(bool fail) {
         fail_writes_ = fail;
     }
-    
+
     int get_write_count() const {
         return write_count_;
     }
-    
+
 private:
     bool fail_writes_;
     int write_count_;

--- a/tests/unit/ilogger_interface_test.cpp
+++ b/tests/unit/ilogger_interface_test.cpp
@@ -207,26 +207,26 @@ TEST_F(ILoggerInterfaceTest, FlushReturnsVoidResult) {
  * @brief Test level conversion between logger_system and common types
  */
 TEST_F(ILoggerInterfaceTest, LevelConversionConsistency) {
-    // Test using native log_level
-    logger_->set_min_level(log_level::warning);
+    // Test using ILogger interface set_level/get_level
+    logger_->set_level(ci::log_level::warning);
     EXPECT_EQ(logger_->get_level(), ci::log_level::warning);
 
     // Test using common log_level
     logger_->set_level(ci::log_level::debug);
-    EXPECT_EQ(logger_->get_min_level(), log_level::debug);
+    EXPECT_EQ(logger_->get_level(), ci::log_level::debug);
 }
 
 /**
- * @brief Test backward compatibility with logger_system::log_level
+ * @brief Test logging with common::interfaces::log_level
  */
-TEST_F(ILoggerInterfaceTest, BackwardCompatibilityWithNativeLogLevel) {
-    // These should still work with logger_system::log_level
-    logger_->log(log_level::info, "Native log level message");
+TEST_F(ILoggerInterfaceTest, LoggingWithCommonLogLevel) {
+    // Test logging with common::interfaces::log_level
+    logger_->log(ci::log_level::info, std::string("Common log level message"));
     // Using simple message (source_location auto-captured internally)
-    logger_->log(log_level::warning, "Native warning message");
+    logger_->log(ci::log_level::warning, std::string("Common warning message"));
 
-    EXPECT_TRUE(logger_->is_enabled(log_level::info));
-    EXPECT_TRUE(logger_->is_enabled(log_level::error));
+    EXPECT_TRUE(logger_->is_enabled(ci::log_level::info));
+    EXPECT_TRUE(logger_->is_enabled(ci::log_level::error));
 }
 
 /**

--- a/tests/unit/mocks/mock_writer.hpp
+++ b/tests/unit/mocks/mock_writer.hpp
@@ -13,6 +13,7 @@
 #include "../../sources/logger/writers/base_writer.h"
 #include "../../sources/logger/interfaces/log_entry.h"
 #include "../../sources/logger/error_codes.h"
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <atomic>
 #include <vector>
 #include <mutex>
@@ -22,6 +23,8 @@
 namespace logger_system::testing {
 
 using namespace logger_module;
+namespace ci = kcenon::common::interfaces;
+using log_level_type = ci::log_level;
 
 /**
  * @brief Mock writer for unit testing
@@ -32,14 +35,14 @@ using namespace logger_module;
 class mock_writer : public base_writer {
 public:
     struct write_record {
-        thread_module::log_level level;
+        log_level_type level;
         std::string message;
         std::optional<source_location> location;
         std::chrono::system_clock::time_point log_timestamp;
         std::chrono::steady_clock::time_point write_timestamp;
-        
+
         write_record(log_entry&& entry, std::chrono::steady_clock::time_point write_ts)
-            : level(entry.level)
+            : level(static_cast<log_level_type>(static_cast<int>(entry.level)))
             , message(entry.message.to_string())
             , location(std::move(entry.location))
             , log_timestamp(entry.timestamp)
@@ -61,7 +64,8 @@ public:
     ~mock_writer() override = default;
 
     // base_writer interface implementation
-    common::VoidResult write(thread_module::log_level level,
+    // Note: base_writer::write uses logger_system::log_level for backward compatibility
+    common::VoidResult write(logger_system::log_level level,
                       const std::string& message,
                       const std::string& file,
                       int line,

--- a/tests/unit/stress_test/stress_test.cpp
+++ b/tests/unit/stress_test/stress_test.cpp
@@ -24,12 +24,14 @@
 #include "../../sources/logger/writers/console_writer.h"
 #include "../../sources/logger/writers/file_writer.h"
 #include "../mocks/mock_writer.hpp"
+#include <kcenon/common/interfaces/logger_interface.h>
 
 using namespace logger_system;
 using namespace logger_system::testing;
 using namespace logger_module;
 using namespace std::chrono_literals;
-using log_level = thread_module::log_level;
+namespace ci = kcenon::common::interfaces;
+using log_level = ci::log_level;
 
 class stress_test : public ::testing::Test {
 protected:

--- a/tests/unit/writers_test/writers_test.cpp
+++ b/tests/unit/writers_test/writers_test.cpp
@@ -33,11 +33,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 #include <logger/writers/console_writer.h>
 #include <logger/writers/base_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <memory>
 #include <chrono>
 #include <thread>
 
 using namespace logger_module;
+namespace ci = kcenon::common::interfaces;
+using log_level = ci::log_level;
 
 class ConsoleWriterTest : public ::testing::Test {
 protected:
@@ -65,7 +68,7 @@ TEST_F(ConsoleWriterTest, ConstructorTest) {
 // Test basic write functionality
 TEST_F(ConsoleWriterTest, BasicWrite) {
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::info,
+        log_level::info,
         "Test message",
         "",
         0,
@@ -79,7 +82,7 @@ TEST_F(ConsoleWriterTest, BasicWrite) {
 // Test write with source location
 TEST_F(ConsoleWriterTest, WriteWithSourceLocation) {
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::error,
+        log_level::error,
         "Error message with location",
         __FILE__,
         __LINE__,
@@ -92,12 +95,12 @@ TEST_F(ConsoleWriterTest, WriteWithSourceLocation) {
 
 // Test all log levels
 TEST_F(ConsoleWriterTest, AllLogLevels) {
-    EXPECT_NO_THROW(writer_->write(thread_module::log_level::trace, "Trace", "", 0, "", timestamp_));
-    EXPECT_NO_THROW(writer_->write(thread_module::log_level::debug, "Debug", "", 0, "", timestamp_));
-    EXPECT_NO_THROW(writer_->write(thread_module::log_level::info, "Info", "", 0, "", timestamp_));
-    EXPECT_NO_THROW(writer_->write(thread_module::log_level::warning, "Warning", "", 0, "", timestamp_));
-    EXPECT_NO_THROW(writer_->write(thread_module::log_level::error, "Error", "", 0, "", timestamp_));
-    EXPECT_NO_THROW(writer_->write(thread_module::log_level::critical, "Critical", "", 0, "", timestamp_));
+    EXPECT_NO_THROW(writer_->write(log_level::trace, "Trace", "", 0, "", timestamp_));
+    EXPECT_NO_THROW(writer_->write(log_level::debug, "Debug", "", 0, "", timestamp_));
+    EXPECT_NO_THROW(writer_->write(log_level::info, "Info", "", 0, "", timestamp_));
+    EXPECT_NO_THROW(writer_->write(log_level::warning, "Warning", "", 0, "", timestamp_));
+    EXPECT_NO_THROW(writer_->write(log_level::error, "Error", "", 0, "", timestamp_));
+    EXPECT_NO_THROW(writer_->write(log_level::critical, "Critical", "", 0, "", timestamp_));
     
     writer_->flush();
 }
@@ -109,7 +112,7 @@ TEST_F(ConsoleWriterTest, ColorFunctionality) {
     EXPECT_TRUE(writer_->use_color());
     
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::error,
+        log_level::error,
         "Colored error message",
         "",
         0,
@@ -122,7 +125,7 @@ TEST_F(ConsoleWriterTest, ColorFunctionality) {
     EXPECT_FALSE(writer_->use_color());
     
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::warning,
+        log_level::warning,
         "Non-colored warning message",
         "",
         0,
@@ -138,7 +141,7 @@ TEST_F(ConsoleWriterTest, StderrUsage) {
     auto stderr_writer = std::make_unique<console_writer>(true);
     
     EXPECT_NO_THROW(stderr_writer->write(
-        thread_module::log_level::critical,
+        log_level::critical,
         "Critical message to stderr",
         "",
         0,
@@ -153,7 +156,7 @@ TEST_F(ConsoleWriterTest, StderrUsage) {
 TEST_F(ConsoleWriterTest, SpecialMessages) {
     // Empty message
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::info,
+        log_level::info,
         "",
         "",
         0,
@@ -164,7 +167,7 @@ TEST_F(ConsoleWriterTest, SpecialMessages) {
     // Very long message
     std::string long_message(1000, 'X');
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::info,
+        log_level::info,
         long_message,
         "",
         0,
@@ -174,7 +177,7 @@ TEST_F(ConsoleWriterTest, SpecialMessages) {
     
     // Message with special characters
     EXPECT_NO_THROW(writer_->write(
-        thread_module::log_level::info,
+        log_level::info,
         "Message with special chars: \\n\\t\\r\\0",
         "",
         0,
@@ -195,7 +198,7 @@ TEST_F(ConsoleWriterTest, MultithreadedAccess) {
         threads.emplace_back([this, t]() {
             for (int i = 0; i < messages_per_thread; ++i) {
                 writer_->write(
-                    thread_module::log_level::info,
+                    log_level::info,
                     "Thread " + std::to_string(t) + " Message " + std::to_string(i),
                     "",
                     0,
@@ -218,7 +221,7 @@ TEST_F(ConsoleWriterTest, FlushFunctionality) {
     // Write several messages
     for (int i = 0; i < 5; ++i) {
         writer_->write(
-            thread_module::log_level::info,
+            log_level::info,
             "Message " + std::to_string(i),
             "",
             0,
@@ -238,14 +241,15 @@ TEST_F(ConsoleWriterTest, FlushFunctionality) {
 // Mock writer for testing base_writer functionality
 class MockWriter : public base_writer {
 public:
-    common::VoidResult write(thread_module::log_level level,
+    // Note: base_writer::write uses logger_system::log_level for backward compatibility
+    common::VoidResult write(logger_system::log_level level,
               const std::string& message,
               const std::string& file,
               int line,
               const std::string& function,
               const std::chrono::system_clock::time_point& timestamp) override {
         last_formatted_ = format_log_entry(level, message, file, line, function, timestamp);
-        last_level_ = level;
+        last_level_ = static_cast<log_level>(static_cast<int>(level));
         write_count_++;
         return common::ok();
     }
@@ -254,13 +258,13 @@ public:
         flush_count_++;
         return common::ok();
     }
-    
+
     std::string get_name() const override {
         return "mock";
     }
-    
+
     std::string last_formatted_;
-    thread_module::log_level last_level_ = thread_module::log_level::trace;
+    log_level last_level_ = log_level::trace;
     int write_count_ = 0;
     int flush_count_ = 0;
 };
@@ -279,7 +283,7 @@ protected:
 // Test base writer formatting
 TEST_F(BaseWriterTest, MessageFormatting) {
     mock_writer_->write(
-        thread_module::log_level::warning,
+        log_level::warning,
         "Test warning message",
         "/path/to/test.cpp",
         42,
@@ -288,7 +292,7 @@ TEST_F(BaseWriterTest, MessageFormatting) {
     );
     
     EXPECT_EQ(mock_writer_->write_count_, 1);
-    EXPECT_EQ(mock_writer_->last_level_, thread_module::log_level::warning);
+    EXPECT_EQ(mock_writer_->last_level_, log_level::warning);
     EXPECT_FALSE(mock_writer_->last_formatted_.empty());
     EXPECT_NE(mock_writer_->last_formatted_.find("WARNING"), std::string::npos);
     EXPECT_NE(mock_writer_->last_formatted_.find("Test warning message"), std::string::npos);


### PR DESCRIPTION
## Summary
- Migrate unit test files to use `common::interfaces::log_level` instead of deprecated `thread_module::log_level` and `logger_system::log_level`
- Update `set_min_level`/`get_min_level` calls to `set_level`/`get_level`
- Maintain backward compatibility with `base_writer::write` interface

## Changes Made
- **tests/unit/logger_test/logger_test.cpp**: Migrate log_level usage and setter/getter methods
- **tests/unit/ilogger_interface_test.cpp**: Update to use common interfaces
- **tests/min_level_filter_test.cpp**: Migrate memory_writer and test assertions
- **tests/structured_logging_test.cpp**: Update set_level calls
- **tests/unit/writers_test/writers_test.cpp**: Migrate MockWriter class
- **tests/unit/collectors_test/log_collector_test.cpp**: Migrate MockCollectorWriter class
- **tests/unit/config_test/config_test.cpp**: Update log_level references
- **tests/unit/config_test/strategy_test.cpp**: Update log_level references
- **tests/unit/flow_test/overflow_policy_test.cpp**: Migrate log_entry struct
- **tests/unit/health_test/health_check_test.cpp**: Migrate mock_writer class
- **tests/unit/di_test/di_container_test.cpp**: Migrate mock_writer class
- **tests/unit/stress_test/stress_test.cpp**: Update namespace alias
- **tests/unit/mocks/mock_writer.hpp**: Migrate write_record and write method

## Test Plan
- [x] Build passes with `cmake --build build/ --config Release`
- [x] `logger_min_level_threshold_test` passes
- [x] `logger_ilogger_interface_test` passes
- [x] `logger_structured_logging_test` passes
- [x] All logger-related unit tests pass

Part of #328
Closes #330