### PR TITLE
refactor(tests): migrate integration tests to ILogger interface log_level

### DIFF
--- a/tests/integration_test.cpp
+++ b/tests/integration_test.cpp
@@ -10,6 +10,7 @@ All rights reserved.
 #include <kcenon/logger/writers/console_writer.h>
 #include <kcenon/logger/writers/file_writer.h>
 #include <kcenon/logger/writers/rotating_file_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 #include <thread>
 #include <chrono>
@@ -18,6 +19,7 @@ All rights reserved.
 
 using namespace kcenon::logger;
 using namespace std::chrono_literals;
+namespace ci = kcenon::common::interfaces;
 
 class IntegrationTest : public ::testing::Test {
 protected:
@@ -64,11 +66,14 @@ TEST_F(IntegrationTest, MultiWriterLogging) {
     // Log messages at various levels
     for (int i = 0; i < 50; ++i) {
         if (i % 10 == 0) {
-            test_logger->log(log_level::error, "Error message " + std::to_string(i));
+            std::string msg = "Error message " + std::to_string(i);
+            test_logger->log(ci::log_level::error, std::string_view(msg));
         } else if (i % 5 == 0) {
-            test_logger->log(log_level::warning, "Warning message " + std::to_string(i));
+            std::string msg = "Warning message " + std::to_string(i);
+            test_logger->log(ci::log_level::warning, std::string_view(msg));
         } else {
-            test_logger->log(log_level::info, "Info message " + std::to_string(i));
+            std::string msg = "Info message " + std::to_string(i);
+            test_logger->log(ci::log_level::info, std::string_view(msg));
         }
     }
 
@@ -98,7 +103,8 @@ TEST_F(IntegrationTest, MetricsCollection) {
 
     const int message_count = 100;
     for (int i = 0; i < message_count; ++i) {
-        test_logger->log(log_level::info, "Test message " + std::to_string(i));
+        std::string msg = "Test message " + std::to_string(i);
+        test_logger->log(ci::log_level::info, std::string_view(msg));
     }
 
     test_logger->flush();
@@ -125,9 +131,9 @@ TEST_F(IntegrationTest, FileRotation) {
 
     // Write enough messages to trigger rotation
     for (int i = 0; i < 100; ++i) {
-        test_logger->log(log_level::info,
-            "Long message to trigger file rotation - message number " + std::to_string(i) +
-            " with additional padding to increase file size quickly");
+        std::string msg = "Long message to trigger file rotation - message number " + std::to_string(i) +
+            " with additional padding to increase file size quickly";
+        test_logger->log(ci::log_level::info, std::string_view(msg));
     }
 
     test_logger->flush();
@@ -165,7 +171,7 @@ TEST_F(IntegrationTest, ConcurrentLogging) {
             for (int i = 0; i < messages_per_thread; ++i) {
                 std::string msg = "Thread " + std::to_string(t) +
                                  " message " + std::to_string(i);
-                test_logger->log(log_level::info, msg);
+                test_logger->log(ci::log_level::info, std::string_view(msg));
             }
         });
     }
@@ -211,7 +217,8 @@ TEST_F(IntegrationTest, StartStopLifecycle) {
     for (int cycle = 0; cycle < 5; ++cycle) {
         test_logger->start();
 
-        test_logger->log(log_level::info, "Cycle " + std::to_string(cycle) + " message");
+        std::string msg = "Cycle " + std::to_string(cycle) + " message";
+        test_logger->log(ci::log_level::info, std::string_view(msg));
 
         test_logger->flush();
         test_logger->stop();

--- a/tests/routing_integration_test.cpp
+++ b/tests/routing_integration_test.cpp
@@ -10,6 +10,7 @@ All rights reserved.
 #include <kcenon/logger/core/logger_builder.h>
 #include <kcenon/logger/writers/file_writer.h>
 #include <kcenon/logger/filters/log_filter.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 #include <filesystem>
 #include <fstream>
@@ -19,6 +20,7 @@ All rights reserved.
 
 using namespace kcenon::logger;
 using namespace std::chrono_literals;
+namespace ci = kcenon::common::interfaces;
 
 class RoutingIntegrationTest : public ::testing::Test {
 protected:
@@ -77,7 +79,7 @@ TEST_F(RoutingIntegrationTest, ExclusiveRoutingByLevel) {
     // Use with_route() with exact_level_filter for precise level matching
     routing::route_config error_route;
     error_route.writer_names = {"errors"};
-    error_route.filter = std::make_unique<filters::exact_level_filter>(log_level::error);
+    error_route.filter = std::make_unique<filters::exact_level_filter>(static_cast<logger_system::log_level>(ci::log_level::error));
     error_route.stop_propagation = false;
 
     auto result = logger_builder()
@@ -92,9 +94,9 @@ TEST_F(RoutingIntegrationTest, ExclusiveRoutingByLevel) {
     auto& test_logger = result.value();
 
     // Log messages at different levels
-    test_logger->log(log_level::info, "Info message");
-    test_logger->log(log_level::error, "Error message");
-    test_logger->log(log_level::warning, "Warning message");
+    test_logger->log(ci::log_level::info, std::string_view("Info message"));
+    test_logger->log(ci::log_level::error, std::string_view("Error message"));
+    test_logger->log(ci::log_level::warning, std::string_view("Warning message"));
 
     test_logger->flush();
 
@@ -112,7 +114,7 @@ TEST_F(RoutingIntegrationTest, NonExclusiveRouting) {
         .with_async(false)
         .add_writer("all", std::make_unique<file_writer>("test_all.log"))
         .add_writer("errors", std::make_unique<file_writer>("test_errors.log"))
-        .route_level(log_level::error, {"errors"})
+        .route_level(static_cast<logger_system::log_level>(ci::log_level::error), {"errors"})
         .with_exclusive_routing(false)  // Non-exclusive (default)
         .build();
 
@@ -120,8 +122,8 @@ TEST_F(RoutingIntegrationTest, NonExclusiveRouting) {
     auto& test_logger = result.value();
 
     // Log messages
-    test_logger->log(log_level::info, "Info message");
-    test_logger->log(log_level::error, "Error message");
+    test_logger->log(ci::log_level::info, std::string_view("Info message"));
+    test_logger->log(ci::log_level::error, std::string_view("Error message"));
 
     test_logger->flush();
 
@@ -144,9 +146,9 @@ TEST_F(RoutingIntegrationTest, PatternBasedRouting) {
     auto& test_logger = result.value();
 
     // Log messages
-    test_logger->log(log_level::info, "Normal operation");
-    test_logger->log(log_level::info, "Security check passed");
-    test_logger->log(log_level::warning, "Authentication failed for user");
+    test_logger->log(ci::log_level::info, std::string_view("Normal operation"));
+    test_logger->log(ci::log_level::info, std::string_view("Security check passed"));
+    test_logger->log(ci::log_level::warning, std::string_view("Authentication failed for user"));
 
     test_logger->flush();
 
@@ -160,7 +162,7 @@ TEST_F(RoutingIntegrationTest, PatternBasedRouting) {
 TEST_F(RoutingIntegrationTest, DirectRouterConfiguration) {
     auto result = logger_builder()
         .with_async(false)
-        .with_min_level(log_level::debug)  // Enable debug level
+        .with_min_level(static_cast<logger_system::log_level>(ci::log_level::debug))  // Enable debug level
         .add_writer("all", std::make_unique<file_writer>("test_all.log"))
         .add_writer("debug", std::make_unique<file_writer>("test_debug.log"))
         .build();
@@ -175,13 +177,13 @@ TEST_F(RoutingIntegrationTest, DirectRouterConfiguration) {
     // Use exact_level_filter for precise level matching
     routing::route_config config;
     config.writer_names = {"debug"};
-    config.filter = std::make_unique<filters::exact_level_filter>(log_level::debug);
+    config.filter = std::make_unique<filters::exact_level_filter>(static_cast<logger_system::log_level>(ci::log_level::debug));
     config.stop_propagation = false;
     router.add_route(std::move(config));
 
     // Log messages
-    test_logger->log(log_level::debug, "Debug message");
-    test_logger->log(log_level::info, "Info message");
+    test_logger->log(ci::log_level::debug, std::string_view("Debug message"));
+    test_logger->log(ci::log_level::info, std::string_view("Info message"));
 
     test_logger->flush();
 
@@ -195,17 +197,17 @@ TEST_F(RoutingIntegrationTest, MultipleRoutes) {
     // Create routes with exact level filters
     routing::route_config error_route;
     error_route.writer_names = {"errors"};
-    error_route.filter = std::make_unique<filters::exact_level_filter>(log_level::error);
+    error_route.filter = std::make_unique<filters::exact_level_filter>(static_cast<logger_system::log_level>(ci::log_level::error));
     error_route.stop_propagation = false;
 
     routing::route_config debug_route;
     debug_route.writer_names = {"debug"};
-    debug_route.filter = std::make_unique<filters::exact_level_filter>(log_level::debug);
+    debug_route.filter = std::make_unique<filters::exact_level_filter>(static_cast<logger_system::log_level>(ci::log_level::debug));
     debug_route.stop_propagation = false;
 
     auto result = logger_builder()
         .with_async(false)
-        .with_min_level(log_level::debug)  // Enable debug level
+        .with_min_level(static_cast<logger_system::log_level>(ci::log_level::debug))  // Enable debug level
         .add_writer("all", std::make_unique<file_writer>("test_all.log"))
         .add_writer("errors", std::make_unique<file_writer>("test_errors.log"))
         .add_writer("debug", std::make_unique<file_writer>("test_debug.log"))
@@ -218,9 +220,9 @@ TEST_F(RoutingIntegrationTest, MultipleRoutes) {
     auto& test_logger = result.value();
 
     // Log messages at different levels
-    test_logger->log(log_level::debug, "Debug message");
-    test_logger->log(log_level::info, "Info message");  // No route, dropped in exclusive mode
-    test_logger->log(log_level::error, "Error message");
+    test_logger->log(ci::log_level::debug, std::string_view("Debug message"));
+    test_logger->log(ci::log_level::info, std::string_view("Info message"));  // No route, dropped in exclusive mode
+    test_logger->log(ci::log_level::error, std::string_view("Error message"));
 
     test_logger->flush();
 


### PR DESCRIPTION
Closes #331

## Summary
- Migrate integration test files to use `common::interfaces::log_level` instead of deprecated `logger_system::log_level`
- Part 3 of the #328 deprecation removal work
- Uses `std::string_view` overload to disambiguate between canonical and deprecated `log()` methods

## Changes
- Add `#include <kcenon/common/interfaces/logger_interface.h>` to test files
- Add namespace alias: `namespace ci = kcenon::common::interfaces`
- Replace `log_level::` with `ci::log_level::`
- Use `std::string_view(msg)` for log calls to invoke canonical API
- Use `static_cast<logger_system::log_level>(ci::log_level::...)` for filter APIs still using deprecated type

## Files Modified
- `tests/integration_test.cpp`
- `tests/routing_integration_test.cpp`
- `tests/thread_safety_tests.cpp`

## Test Plan
- [x] Build passes without errors
- [x] `basic_integration_test` passes
- [x] `logger_routing_integration_test` passes
- [x] `logger_thread_safety_test` passes