### PR TITLE
refactor(logger): add kcenon::logger::log_level alias for common::interfaces::log_level

### DIFF
--- a/examples/structured_logging_example.cpp
+++ b/examples/structured_logging_example.cpp
@@ -55,7 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <chrono>
 
 using namespace kcenon::logger;
-using log_level = logger_system::log_level;
 
 /**
  * @brief Demonstrates basic structured logging with key-value fields

--- a/include/kcenon/logger/core/logger.h
+++ b/include/kcenon/logger/core/logger.h
@@ -107,8 +107,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace kcenon::logger {
 
-// Type aliases - always use logger_system types
-using log_level = logger_system::log_level;
+// Type aliases - use common::interfaces types for standardization
+using log_level = common::interfaces::log_level;
 using health_status = logger_system::health_status;
 using overflow_policy = logger_system::overflow_policy;
 
@@ -687,6 +687,9 @@ public:
      * @since 3.1.0
      */
     [[nodiscard]] structured_log_builder log_structured(log_level level);
+
+    /// Overload accepting logger_system::log_level for backward compatibility
+    [[nodiscard]] structured_log_builder log_structured(logger_system::log_level level);
 
     // =========================================================================
     // Context fields management

--- a/include/kcenon/logger/core/logger_builder.h
+++ b/include/kcenon/logger/core/logger_builder.h
@@ -220,7 +220,13 @@ public:
         config_.min_level = level;
         return *this;
     }
-    
+
+    /// Overload accepting common::interfaces::log_level for compatibility with kcenon::logger::log_level
+    logger_builder& with_min_level(kcenon::common::interfaces::log_level level) {
+        config_.min_level = static_cast<logger_system::log_level>(static_cast<int>(level));
+        return *this;
+    }
+
     /**
      * @brief Set batch size for processing
      * @param size Batch size

--- a/include/kcenon/logger/core/structured_log_builder.h
+++ b/include/kcenon/logger/core/structured_log_builder.h
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <kcenon/logger/interfaces/log_entry.h>
 #include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 #include <string>
 #include <functional>
@@ -88,14 +89,26 @@ public:
 
     /**
      * @brief Constructor
-     * @param level Log level for the entry
+     * @param level Log level for the entry (using common::interfaces::log_level)
      * @param callback Callback to invoke when emit() is called
      * @param context_fields Context fields to include automatically
      */
+    structured_log_builder(common::interfaces::log_level level,
+                           emit_callback callback,
+                           const log_fields* context_fields = nullptr)
+        : level_(static_cast<logger_system::log_level>(static_cast<int>(level))),
+          callback_(std::move(callback)) {
+        if (context_fields && !context_fields->empty()) {
+            fields_ = *context_fields;
+        }
+    }
+
+    /// Constructor accepting logger_system::log_level for backward compatibility
     structured_log_builder(logger_system::log_level level,
                            emit_callback callback,
                            const log_fields* context_fields = nullptr)
-        : level_(level), callback_(std::move(callback)) {
+        : level_(level),
+          callback_(std::move(callback)) {
         if (context_fields && !context_fields->empty()) {
             fields_ = *context_fields;
         }

--- a/include/kcenon/logger/filters/log_filter.h
+++ b/include/kcenon/logger/filters/log_filter.h
@@ -36,6 +36,7 @@
 
 #include <kcenon/logger/interfaces/log_filter_interface.h>
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <algorithm>
 #include <regex>
 #include <functional>
@@ -53,6 +54,10 @@ private:
 
 public:
     explicit level_filter(logger_system::log_level min_level) : min_level_(min_level) {}
+
+    /// Constructor accepting common::interfaces::log_level for compatibility with kcenon::logger::log_level
+    explicit level_filter(kcenon::common::interfaces::log_level min_level)
+        : min_level_(static_cast<logger_system::log_level>(static_cast<int>(min_level))) {}
 
     bool should_log(const log_entry& entry) const override {
         return static_cast<int>(entry.level) >= static_cast<int>(min_level_);
@@ -74,6 +79,10 @@ private:
 
 public:
     explicit exact_level_filter(logger_system::log_level level) : level_(level) {}
+
+    /// Constructor accepting common::interfaces::log_level for compatibility with kcenon::logger::log_level
+    explicit exact_level_filter(kcenon::common::interfaces::log_level level)
+        : level_(static_cast<logger_system::log_level>(static_cast<int>(level))) {}
 
     bool should_log(const log_entry& entry) const override {
         return entry.level == level_;

--- a/include/kcenon/logger/interfaces/log_entry.h
+++ b/include/kcenon/logger/interfaces/log_entry.h
@@ -267,7 +267,45 @@ struct log_entry {
               std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
         : level(lvl), message(msg), timestamp(ts),
           location(source_location{file, line, function}) {}
-    
+
+    /**
+     * @brief Constructor accepting common::interfaces::log_level
+     * @param lvl Log severity level (common::interfaces::log_level)
+     * @param msg Log message
+     * @param ts Timestamp (default: current time)
+     *
+     * @details Enables seamless use with kcenon::logger::log_level alias.
+     * Internally converts to logger_system::log_level for storage.
+     *
+     * @since 3.0.0
+     */
+    log_entry(kcenon::common::interfaces::log_level lvl,
+              const std::string& msg,
+              std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
+        : level(static_cast<logger_system::log_level>(static_cast<int>(lvl))),
+          message(msg), timestamp(ts) {}
+
+    /**
+     * @brief Constructor with source location accepting common::interfaces::log_level
+     * @param lvl Log severity level (common::interfaces::log_level)
+     * @param msg Log message
+     * @param file Source file path
+     * @param line Line number in source file
+     * @param function Function name
+     * @param ts Timestamp (default: current time)
+     *
+     * @since 3.0.0
+     */
+    log_entry(kcenon::common::interfaces::log_level lvl,
+              const std::string& msg,
+              const std::string& file,
+              int line,
+              const std::string& function,
+              std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
+        : level(static_cast<logger_system::log_level>(static_cast<int>(lvl))),
+          message(msg), timestamp(ts),
+          location(source_location{file, line, function}) {}
+
     /**
      * @brief Move constructor
      * @details Enables efficient transfer of log entries without copying

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -713,10 +713,13 @@ structured_log_builder logger::log_structured(log_level level) {
         }
     }
 
+    // Convert common::interfaces::log_level to logger_system::log_level for internal use
+    auto native_level = static_cast<logger_system::log_level>(static_cast<int>(level));
+
     return structured_log_builder(
         level,
-        [this, level](log_entry&& entry) {
-            if (!pimpl_ || !meets_threshold(level, pimpl_->min_level_.load())) {
+        [this, native_level](log_entry&& entry) {
+            if (!pimpl_ || !meets_threshold(native_level, pimpl_->min_level_.load())) {
                 return;
             }
 
@@ -751,6 +754,12 @@ structured_log_builder logger::log_structured(log_level level) {
         },
         ctx_ptr
     );
+}
+
+// Overload accepting logger_system::log_level for backward compatibility
+structured_log_builder logger::log_structured(logger_system::log_level level) {
+    // Convert to common::interfaces::log_level and delegate
+    return log_structured(static_cast<log_level>(static_cast<int>(level)));
 }
 
 // =========================================================================

--- a/tests/structured_logging_test.cpp
+++ b/tests/structured_logging_test.cpp
@@ -27,6 +27,8 @@ using namespace kcenon::logger;
 using namespace kcenon::common;
 using namespace std::chrono_literals;
 namespace ci = kcenon::common::interfaces;
+// Use logger_system::log_level for comparisons with captured entries (which store logger_system::log_level)
+namespace ls = logger_system;
 
 namespace {
 
@@ -89,7 +91,7 @@ TEST_F(StructuredLoggingTest, BasicStructuredLogBuilder) {
     log_entry* captured_entry = nullptr;
 
     structured_log_builder builder(
-        log_level::info,
+        ls::log_level::info,
         [&callback_invoked, &captured_entry](log_entry&& entry) {
             callback_invoked = true;
             // Store a copy of entry data for validation
@@ -110,7 +112,7 @@ TEST_F(StructuredLoggingTest, StructuredLogBuilderFieldTypes) {
     log_fields captured_fields;
 
     structured_log_builder builder(
-        log_level::info,
+        ls::log_level::info,
         [&captured_fields](log_entry&& entry) {
             if (entry.fields) {
                 captured_fields = *entry.fields;
@@ -159,7 +161,7 @@ TEST_F(StructuredLoggingTest, ContextFieldsIncluded) {
     log_fields captured_fields;
 
     structured_log_builder builder(
-        log_level::info,
+        ls::log_level::info,
         [&captured_fields](log_entry&& entry) {
             if (entry.fields) {
                 captured_fields = *entry.fields;
@@ -187,8 +189,8 @@ TEST_F(StructuredLoggingTest, LoggerStructuredMethods) {
     auto* writer_ptr = writer.get();
     test_logger->add_writer("capture", std::move(writer));
 
-    // Test log_structured with log_level::info (canonical API)
-    test_logger->log_structured(log_level::info)
+    // Test log_structured with ls::log_level::info (canonical API)
+    test_logger->log_structured(ls::log_level::info)
         .message("User logged in")
         .field("user_id", 12345)
         .emit();
@@ -197,7 +199,7 @@ TEST_F(StructuredLoggingTest, LoggerStructuredMethods) {
 
     auto entries = writer_ptr->get_entries();
     ASSERT_GE(entries.size(), 1);
-    EXPECT_EQ(entries[0].level, log_level::info);
+    EXPECT_EQ(entries[0].level, ls::log_level::info);
     EXPECT_EQ(entries[0].message, "User logged in");
 
     test_logger->stop();
@@ -261,7 +263,7 @@ TEST_F(StructuredLoggingTest, LoggerContextManagement) {
 TEST_F(StructuredLoggingTest, JsonFormatterStructuredFields) {
     json_formatter formatter;
 
-    log_entry entry(log_level::info, "Test message");
+    log_entry entry(ls::log_level::info, "Test message");
     entry.fields = log_fields{
         {"user_id", static_cast<int64_t>(12345)},
         {"action", std::string("login")},
@@ -283,7 +285,7 @@ TEST_F(StructuredLoggingTest, JsonFormatterStructuredFields) {
 TEST_F(StructuredLoggingTest, JsonFormatterWithCategory) {
     json_formatter formatter;
 
-    log_entry entry(log_level::info, "Database query");
+    log_entry entry(ls::log_level::info, "Database query");
     entry.category = small_string_128("database");
 
     std::string output = formatter.format(entry);
@@ -301,24 +303,24 @@ TEST_F(StructuredLoggingTest, AllStructuredLevelMethods) {
     auto* writer_ptr = writer.get();
     test_logger->add_writer("capture", std::move(writer));
 
-    test_logger->log_structured(log_level::trace).message("Trace").emit();
-    test_logger->log_structured(log_level::debug).message("Debug").emit();
-    test_logger->log_structured(log_level::info).message("Info").emit();
-    test_logger->log_structured(log_level::warn).message("Warn").emit();
-    test_logger->log_structured(log_level::error).message("Error").emit();
-    test_logger->log_structured(log_level::fatal).message("Fatal").emit();
+    test_logger->log_structured(ls::log_level::trace).message("Trace").emit();
+    test_logger->log_structured(ls::log_level::debug).message("Debug").emit();
+    test_logger->log_structured(ls::log_level::info).message("Info").emit();
+    test_logger->log_structured(ls::log_level::warn).message("Warn").emit();
+    test_logger->log_structured(ls::log_level::error).message("Error").emit();
+    test_logger->log_structured(ls::log_level::fatal).message("Fatal").emit();
 
     test_logger->flush();
 
     auto entries = writer_ptr->get_entries();
     ASSERT_EQ(entries.size(), 6);
 
-    EXPECT_EQ(entries[0].level, log_level::trace);
-    EXPECT_EQ(entries[1].level, log_level::debug);
-    EXPECT_EQ(entries[2].level, log_level::info);
-    EXPECT_EQ(entries[3].level, log_level::warn);
-    EXPECT_EQ(entries[4].level, log_level::error);
-    EXPECT_EQ(entries[5].level, log_level::fatal);
+    EXPECT_EQ(entries[0].level, ls::log_level::trace);
+    EXPECT_EQ(entries[1].level, ls::log_level::debug);
+    EXPECT_EQ(entries[2].level, ls::log_level::info);
+    EXPECT_EQ(entries[3].level, ls::log_level::warn);
+    EXPECT_EQ(entries[4].level, ls::log_level::error);
+    EXPECT_EQ(entries[5].level, ls::log_level::fatal);
 
     test_logger->stop();
 }
@@ -334,24 +336,24 @@ TEST_F(StructuredLoggingTest, GenericLogStructuredMethod) {
     test_logger->add_writer("capture", std::move(writer));
 
     // Use the canonical log_structured(level) API
-    test_logger->log_structured(log_level::trace).message("Trace").emit();
-    test_logger->log_structured(log_level::debug).message("Debug").emit();
-    test_logger->log_structured(log_level::info).message("Info").emit();
-    test_logger->log_structured(log_level::warn).message("Warn").emit();
-    test_logger->log_structured(log_level::error).message("Error").emit();
-    test_logger->log_structured(log_level::fatal).message("Fatal").emit();
+    test_logger->log_structured(ls::log_level::trace).message("Trace").emit();
+    test_logger->log_structured(ls::log_level::debug).message("Debug").emit();
+    test_logger->log_structured(ls::log_level::info).message("Info").emit();
+    test_logger->log_structured(ls::log_level::warn).message("Warn").emit();
+    test_logger->log_structured(ls::log_level::error).message("Error").emit();
+    test_logger->log_structured(ls::log_level::fatal).message("Fatal").emit();
 
     test_logger->flush();
 
     auto entries = writer_ptr->get_entries();
     ASSERT_EQ(entries.size(), 6);
 
-    EXPECT_EQ(entries[0].level, log_level::trace);
-    EXPECT_EQ(entries[1].level, log_level::debug);
-    EXPECT_EQ(entries[2].level, log_level::info);
-    EXPECT_EQ(entries[3].level, log_level::warn);
-    EXPECT_EQ(entries[4].level, log_level::error);
-    EXPECT_EQ(entries[5].level, log_level::fatal);
+    EXPECT_EQ(entries[0].level, ls::log_level::trace);
+    EXPECT_EQ(entries[1].level, ls::log_level::debug);
+    EXPECT_EQ(entries[2].level, ls::log_level::info);
+    EXPECT_EQ(entries[3].level, ls::log_level::warn);
+    EXPECT_EQ(entries[4].level, ls::log_level::error);
+    EXPECT_EQ(entries[5].level, ls::log_level::fatal);
 
     test_logger->stop();
 }
@@ -366,7 +368,7 @@ TEST_F(StructuredLoggingTest, GenericLogStructuredWithFields) {
     test_logger->add_writer("capture", std::move(writer));
 
     // Use the canonical log_structured(level) API with fields
-    test_logger->log_structured(log_level::info)
+    test_logger->log_structured(ls::log_level::info)
         .message("User action completed")
         .field("user_id", 12345)
         .field("action", "purchase")
@@ -378,7 +380,7 @@ TEST_F(StructuredLoggingTest, GenericLogStructuredWithFields) {
 
     auto entries = writer_ptr->get_entries();
     ASSERT_EQ(entries.size(), 1);
-    EXPECT_EQ(entries[0].level, log_level::info);
+    EXPECT_EQ(entries[0].level, ls::log_level::info);
     EXPECT_EQ(entries[0].message, "User action completed");
 
     test_logger->stop();
@@ -386,7 +388,7 @@ TEST_F(StructuredLoggingTest, GenericLogStructuredWithFields) {
 
 // Test 9: log_entry with fields
 TEST_F(StructuredLoggingTest, LogEntryWithFields) {
-    log_entry entry(log_level::info, "Test");
+    log_entry entry(ls::log_level::info, "Test");
 
     EXPECT_FALSE(entry.fields.has_value());
 
@@ -701,7 +703,7 @@ TEST_F(StructuredLoggingTest, ThreadIsolation) {
 TEST_F(StructuredLoggingTest, LogfmtFormatterBasic) {
     logfmt_formatter formatter;
 
-    log_entry entry(log_level::info, "Server started");
+    log_entry entry(ls::log_level::info, "Server started");
 
     std::string output = formatter.format(entry);
 
@@ -715,7 +717,7 @@ TEST_F(StructuredLoggingTest, LogfmtFormatterBasic) {
 TEST_F(StructuredLoggingTest, LogfmtFormatterWithFields) {
     logfmt_formatter formatter;
 
-    log_entry entry(log_level::error, "Connection failed");
+    log_entry entry(ls::log_level::error, "Connection failed");
     entry.fields = log_fields{
         {"host", std::string("localhost")},
         {"port", static_cast<int64_t>(5432)},
@@ -735,7 +737,7 @@ TEST_F(StructuredLoggingTest, LogfmtFormatterWithFields) {
 TEST_F(StructuredLoggingTest, LogfmtFormatterEscaping) {
     logfmt_formatter formatter;
 
-    log_entry entry(log_level::info, "Message with spaces and \"quotes\"");
+    log_entry entry(ls::log_level::info, "Message with spaces and \"quotes\"");
 
     std::string output = formatter.format(entry);
 
@@ -747,7 +749,7 @@ TEST_F(StructuredLoggingTest, LogfmtFormatterEscaping) {
 TEST_F(StructuredLoggingTest, TemplateFormatterBasic) {
     template_formatter formatter("[{level}] {message}");
 
-    log_entry entry(log_level::info, "Test message");
+    log_entry entry(ls::log_level::info, "Test message");
 
     std::string output = formatter.format(entry);
 
@@ -759,7 +761,7 @@ TEST_F(StructuredLoggingTest, TemplateFormatterBasic) {
 TEST_F(StructuredLoggingTest, TemplateFormatterWithTimestamp) {
     template_formatter formatter("{timestamp} [{level}] {message}");
 
-    log_entry entry(log_level::debug, "Debug info");
+    log_entry entry(ls::log_level::debug, "Debug info");
 
     std::string output = formatter.format(entry);
 
@@ -773,7 +775,7 @@ TEST_F(StructuredLoggingTest, TemplateFormatterWithTimestamp) {
 TEST_F(StructuredLoggingTest, TemplateFormatterWithLocation) {
     template_formatter formatter("{message} ({filename}:{line})");
 
-    log_entry entry(log_level::error, "Error occurred",
+    log_entry entry(ls::log_level::error, "Error occurred",
                     "/path/to/file.cpp", 42, "test_function");
 
     std::string output = formatter.format(entry);
@@ -787,7 +789,7 @@ TEST_F(StructuredLoggingTest, TemplateFormatterWithLocation) {
 TEST_F(StructuredLoggingTest, TemplateFormatterWithFields) {
     template_formatter formatter("{message} user_id={user_id}");
 
-    log_entry entry(log_level::info, "User action");
+    log_entry entry(ls::log_level::info, "User action");
     entry.fields = log_fields{
         {"user_id", static_cast<int64_t>(12345)}
     };
@@ -802,7 +804,7 @@ TEST_F(StructuredLoggingTest, TemplateFormatterWithFields) {
 TEST_F(StructuredLoggingTest, TemplateFormatterLowercaseLevel) {
     template_formatter formatter("{level_lower}: {message}");
 
-    log_entry entry(log_level::warn, "Warning message");
+    log_entry entry(ls::log_level::warn, "Warning message");
 
     std::string output = formatter.format(entry);
 
@@ -813,7 +815,7 @@ TEST_F(StructuredLoggingTest, TemplateFormatterLowercaseLevel) {
 TEST_F(StructuredLoggingTest, TemplateFormatterFieldWidth) {
     template_formatter formatter("[{level:10}] {message}");
 
-    log_entry entry(log_level::info, "Test");
+    log_entry entry(ls::log_level::info, "Test");
 
     std::string output = formatter.format(entry);
 
@@ -825,7 +827,7 @@ TEST_F(StructuredLoggingTest, TemplateFormatterFieldWidth) {
 TEST_F(StructuredLoggingTest, TemplateFormatterSetTemplate) {
     template_formatter formatter("[{level}] {message}");
 
-    log_entry entry(log_level::info, "Test");
+    log_entry entry(ls::log_level::info, "Test");
 
     std::string output1 = formatter.format(entry);
     EXPECT_NE(output1.find("[INFO]"), std::string::npos);


### PR DESCRIPTION
## Summary
- Change `kcenon::logger::log_level` from `logger_system::log_level` alias to `common::interfaces::log_level` alias
- Add backward compatibility constructors/overloads to support both log_level types during migration
- Enable gradual migration from deprecated `logger_system::log_level`

## Changes Made
| File | Change |
|------|--------|
| `logger.h` | Change `using log_level = common::interfaces::log_level` |
| `log_entry.h` | Add constructors accepting `common::interfaces::log_level` |
| `structured_log_builder.h` | Support both log_level types in constructor |
| `log_filter.h` | Add `common::interfaces::log_level` constructors for filters |
| `logger_builder.h` | Add `with_min_level` overload for new type |
| `logger.cpp` | Add `log_structured` overload for backward compatibility |
| Examples/Tests | Update to use correct log_level types |

## Test Plan
- [x] All existing tests pass (except pre-existing encrypted_writer_test failures)
- [x] Build succeeds with no new errors
- [x] Deprecation warnings appear for `logger_system::log_level` usage

Closes #340