### PR TITLE
refactor(core): migrate core components to common::interfaces::log_level

### DIFF
--- a/include/kcenon/logger/analysis/log_analyzer.h
+++ b/include/kcenon/logger/analysis/log_analyzer.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -43,11 +43,14 @@
 
 namespace kcenon::logger::analysis {
 
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
 /**
  * @brief Log entry for analysis
  */
 struct analyzed_log_entry {
-    logger_system::log_level level;
+    log_level level;
     std::string message;
     std::chrono::system_clock::time_point timestamp;
     std::string source_file;
@@ -60,7 +63,7 @@ struct analyzed_log_entry {
  */
 struct analysis_stats {
     size_t total_entries = 0;
-    std::unordered_map<logger_system::log_level, size_t> level_counts;
+    std::unordered_map<log_level, size_t> level_counts;
     std::chrono::system_clock::time_point earliest_timestamp;
     std::chrono::system_clock::time_point latest_timestamp;
     std::vector<std::string> most_frequent_messages;
@@ -116,7 +119,7 @@ public:
     /**
      * @brief Filter entries by log level
      */
-    std::vector<analyzed_log_entry> filter_by_level(logger_system::log_level level) const {
+    std::vector<analyzed_log_entry> filter_by_level(log_level level) const {
         std::vector<analyzed_log_entry> filtered;
         for (const auto& entry : entries_) {
             if (entry.level == level) {
@@ -168,8 +171,8 @@ public:
         for (const auto& entry : entries_) {
             if (entry.timestamp >= start_time) {
                 total_in_window++;
-                if (entry.level == logger_system::log_level::error ||
-                    entry.level == logger_system::log_level::fatal) {
+                if (entry.level == log_level::error ||
+                    entry.level == log_level::fatal) {
                     errors_in_window++;
                 }
             }
@@ -228,15 +231,15 @@ private:
         }
     }
 
-    std::string level_to_string(logger_system::log_level level) const {
+    std::string level_to_string(log_level level) const {
         switch (level) {
-            case logger_system::log_level::trace: return "TRACE";
-            case logger_system::log_level::debug: return "DEBUG";
-            case logger_system::log_level::info: return "INFO";
-            case logger_system::log_level::warn: return "WARN";
-            case logger_system::log_level::error: return "ERROR";
-            case logger_system::log_level::fatal: return "FATAL";
-            case logger_system::log_level::off: return "OFF";
+            case log_level::trace: return "TRACE";
+            case log_level::debug: return "DEBUG";
+            case log_level::info: return "INFO";
+            case log_level::warn: return "WARN";
+            case log_level::error: return "ERROR";
+            case log_level::fatal: return "FATAL";
+            case log_level::off: return "OFF";
             default: return "UNKNOWN";
         }
     }

--- a/include/kcenon/logger/analysis/realtime_log_analyzer.h
+++ b/include/kcenon/logger/analysis/realtime_log_analyzer.h
@@ -66,7 +66,7 @@
 
 #pragma once
 
-#include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <kcenon/logger/analysis/log_analyzer.h>
 
 #include <atomic>
@@ -83,6 +83,9 @@
 #include <vector>
 
 namespace kcenon::logger::analysis {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @brief Represents an anomaly event detected during real-time analysis
@@ -130,10 +133,10 @@ struct realtime_analysis_config {
  */
 struct pattern_alert {
     std::string pattern;                                     ///< Regex pattern to match
-    logger_system::log_level min_level;                      ///< Minimum log level to trigger
+    log_level min_level;                                     ///< Minimum log level to trigger
     std::regex compiled_pattern;                             ///< Pre-compiled regex for efficiency
 
-    pattern_alert(const std::string& p, logger_system::log_level level)
+    pattern_alert(const std::string& p, log_level level)
         : pattern(p), min_level(level), compiled_pattern(p, std::regex::optimize) {}
 };
 
@@ -204,8 +207,8 @@ public:
         add_to_window(entry, now);
 
         // Check for error spike
-        if (entry.level == logger_system::log_level::error ||
-            entry.level == logger_system::log_level::fatal) {
+        if (entry.level == log_level::error ||
+            entry.level == log_level::fatal) {
             check_error_spike(entry, now);
         }
 
@@ -219,8 +222,8 @@ public:
 
         // Track new error types
         if (config_.track_new_errors &&
-            (entry.level == logger_system::log_level::error ||
-             entry.level == logger_system::log_level::fatal)) {
+            (entry.level == log_level::error ||
+             entry.level == log_level::fatal)) {
             check_new_error_type(entry, now);
         }
     }
@@ -238,7 +241,7 @@ public:
      * @param pattern Regex pattern to match against log messages
      * @param min_level Minimum log level for this pattern to trigger
      */
-    void add_pattern_alert(const std::string& pattern, logger_system::log_level min_level) {
+    void add_pattern_alert(const std::string& pattern, log_level min_level) {
         std::unique_lock lock(patterns_mutex_);
         patterns_.emplace_back(pattern, min_level);
     }
@@ -394,8 +397,8 @@ private:
         log_window_.push_back({now, entry});
 
         // Add to error window if error/fatal
-        if (entry.level == logger_system::log_level::error ||
-            entry.level == logger_system::log_level::fatal) {
+        if (entry.level == log_level::error ||
+            entry.level == log_level::fatal) {
             error_window_.push_back({now, entry});
         }
 
@@ -406,8 +409,8 @@ private:
 
         // Update statistics
         total_analyzed_.fetch_add(1, std::memory_order_relaxed);
-        if (entry.level == logger_system::log_level::error ||
-            entry.level == logger_system::log_level::fatal) {
+        if (entry.level == log_level::error ||
+            entry.level == log_level::fatal) {
             total_errors_.fetch_add(1, std::memory_order_relaxed);
         }
     }

--- a/include/kcenon/logger/core/filtered_logger.h
+++ b/include/kcenon/logger/core/filtered_logger.h
@@ -7,16 +7,20 @@
 
 #include <kcenon/logger/core/log_context.h>
 #include <kcenon/logger/core/logger.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 namespace kcenon::logger::core {
 
-template<logger_system::log_level MinLevel = logger_system::log_level::info>
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
+template<log_level MinLevel = log_level::info>
 class filtered_logger {
 public:
     explicit filtered_logger(std::shared_ptr<kcenon::logger::logger> impl)
         : logger_(std::move(impl)) {}
 
-    void log(logger_system::log_level level,
+    void log(log_level level,
              const std::string& message,
              const log_context& context) const {
         if (!logger_) {
@@ -31,7 +35,7 @@ public:
                      std::string(context.function));
     }
 
-    template<logger_system::log_level Level>
+    template<log_level Level>
     void log(const std::string& message, const log_context& context) const {
         if constexpr (static_cast<int>(Level) >= static_cast<int>(MinLevel)) {
             if (logger_) {

--- a/include/kcenon/logger/core/log_collector.h
+++ b/include/kcenon/logger/core/log_collector.h
@@ -43,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kcenon/common/interfaces/logger_interface.h>
-#include <kcenon/logger/interfaces/logger_types.h>
 
 #include <atomic>
 #include <chrono>
@@ -85,7 +84,7 @@ public:
      * @param function Function name
      * @param timestamp Log timestamp
      */
-    bool enqueue(logger_system::log_level level,
+    bool enqueue(common::interfaces::log_level level,
                  const std::string& message,
                  const std::string& file,
                  int line,

--- a/include/kcenon/logger/core/logger_config.h
+++ b/include/kcenon/logger/core/logger_config.h
@@ -15,9 +15,11 @@ All rights reserved.
 
 // Use common_system's standard interface
 #include <kcenon/common/interfaces/logger_interface.h>
-#include <kcenon/logger/interfaces/logger_types.h>
 
 namespace kcenon::logger {
+
+// Type alias for log_level using common::interfaces::log_level as the canonical type
+using log_level = common::interfaces::log_level;
 
 /**
  * @struct logger_config
@@ -30,7 +32,7 @@ struct logger_config {
     // Basic settings
     bool async = true;
     std::size_t buffer_size = 8192;
-    logger_system::log_level min_level = logger_system::log_level::info;
+    log_level min_level = log_level::info;
     
     // Performance settings
     std::size_t batch_size = 100;
@@ -241,7 +243,7 @@ struct logger_config {
     static logger_config debug_config() {
         logger_config config;
         config.async = false;  // Synchronous for immediate output
-        config.min_level = logger_system::log_level::trace;
+        config.min_level = log_level::trace;
         config.enable_metrics = true;
         config.enable_crash_handler = true;
         config.enable_color_output = true;
@@ -258,7 +260,7 @@ struct logger_config {
         logger_config config;
         config.async = true;
         config.buffer_size = 16384;
-        config.min_level = logger_system::log_level::warn;
+        config.min_level = log_level::warning;
         config.enable_metrics = true;
         config.enable_crash_handler = true;
         config.enable_color_output = false;

--- a/include/kcenon/logger/core/logger_config_builder.h
+++ b/include/kcenon/logger/core/logger_config_builder.h
@@ -117,7 +117,7 @@ public:
      * @param level Minimum log level to output
      * @return Reference to builder for chaining
      */
-    logger_config_builder& set_min_level(logger_system::log_level level) {
+    logger_config_builder& set_min_level(log_level level) {
         config_.min_level = level;
         return *this;
     }

--- a/include/kcenon/logger/core/strategies/deployment_strategy.h
+++ b/include/kcenon/logger/core/strategies/deployment_strategy.h
@@ -84,7 +84,7 @@ private:
 
     static void apply_development(logger_config& config) {
         config.async = false;
-        config.min_level = logger_system::log_level::trace;
+        config.min_level = log_level::trace;
         config.enable_metrics = true;
         config.enable_crash_handler = true;
         config.enable_color_output = true;
@@ -96,7 +96,7 @@ private:
 
     static void apply_staging(logger_config& config) {
         config.async = true;
-        config.min_level = logger_system::log_level::info;
+        config.min_level = log_level::info;
         config.enable_metrics = true;
         config.enable_crash_handler = true;
         config.enable_color_output = false;
@@ -111,7 +111,7 @@ private:
 
     static void apply_production(logger_config& config) {
         config.async = true;
-        config.min_level = logger_system::log_level::warn;
+        config.min_level = log_level::warn;
         config.enable_metrics = true;
         config.enable_crash_handler = true;
         config.enable_color_output = false;
@@ -129,7 +129,7 @@ private:
 
     static void apply_testing(logger_config& config) {
         config.async = false;
-        config.min_level = logger_system::log_level::trace;
+        config.min_level = log_level::trace;
         config.enable_metrics = false;
         config.enable_crash_handler = false;
         config.enable_color_output = false;

--- a/include/kcenon/logger/core/strategies/environment_strategy.h
+++ b/include/kcenon/logger/core/strategies/environment_strategy.h
@@ -125,18 +125,18 @@ public:
     }
 
 private:
-    static logger_system::log_level parse_log_level(const char* str) {
-        std::string level(str);
-        std::transform(level.begin(), level.end(), level.begin(), ::tolower);
+    static log_level parse_log_level(const char* str) {
+        std::string level_str(str);
+        std::transform(level_str.begin(), level_str.end(), level_str.begin(), ::tolower);
 
-        if (level == "trace") return logger_system::log_level::trace;
-        if (level == "debug") return logger_system::log_level::debug;
-        if (level == "info") return logger_system::log_level::info;
-        if (level == "warn" || level == "warning") return logger_system::log_level::warn;
-        if (level == "error") return logger_system::log_level::error;
-        if (level == "fatal" || level == "critical") return logger_system::log_level::fatal;
+        if (level_str == "trace") return log_level::trace;
+        if (level_str == "debug") return log_level::debug;
+        if (level_str == "info") return log_level::info;
+        if (level_str == "warn" || level_str == "warning") return log_level::warning;
+        if (level_str == "error") return log_level::error;
+        if (level_str == "fatal" || level_str == "critical") return log_level::critical;
 
-        return logger_system::log_level::info;  // Default
+        return log_level::info;  // Default
     }
 
     static bool parse_bool(const char* str) {

--- a/include/kcenon/logger/core/structured_log_builder.h
+++ b/include/kcenon/logger/core/structured_log_builder.h
@@ -53,13 +53,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kcenon/logger/interfaces/log_entry.h>
-#include <kcenon/logger/interfaces/logger_types.h>
 #include <kcenon/common/interfaces/logger_interface.h>
 
 #include <string>
 #include <functional>
 
 namespace kcenon::logger {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 // Forward declaration
 class logger;
@@ -89,22 +91,11 @@ public:
 
     /**
      * @brief Constructor
-     * @param level Log level for the entry (using common::interfaces::log_level)
+     * @param level Log level for the entry
      * @param callback Callback to invoke when emit() is called
      * @param context_fields Context fields to include automatically
      */
-    structured_log_builder(common::interfaces::log_level level,
-                           emit_callback callback,
-                           const log_fields* context_fields = nullptr)
-        : level_(static_cast<logger_system::log_level>(static_cast<int>(level))),
-          callback_(std::move(callback)) {
-        if (context_fields && !context_fields->empty()) {
-            fields_ = *context_fields;
-        }
-    }
-
-    /// Constructor accepting logger_system::log_level for backward compatibility
-    structured_log_builder(logger_system::log_level level,
+    structured_log_builder(log_level level,
                            emit_callback callback,
                            const log_fields* context_fields = nullptr)
         : level_(level),
@@ -253,7 +244,7 @@ public:
     structured_log_builder& operator=(structured_log_builder&&) noexcept = default;
 
 private:
-    logger_system::log_level level_;
+    log_level level_;
     emit_callback callback_;
     std::string message_;
     std::string category_;

--- a/include/kcenon/logger/filters/log_filter.h
+++ b/include/kcenon/logger/filters/log_filter.h
@@ -43,6 +43,9 @@
 
 namespace kcenon::logger::filters {
 
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
 /**
  * @brief Level-based log filter (minimum level threshold)
  *
@@ -50,14 +53,10 @@ namespace kcenon::logger::filters {
  */
 class level_filter : public log_filter_interface {
 private:
-    logger_system::log_level min_level_;
+    log_level min_level_;
 
 public:
-    explicit level_filter(logger_system::log_level min_level) : min_level_(min_level) {}
-
-    /// Constructor accepting common::interfaces::log_level for compatibility with kcenon::logger::log_level
-    explicit level_filter(kcenon::common::interfaces::log_level min_level)
-        : min_level_(static_cast<logger_system::log_level>(static_cast<int>(min_level))) {}
+    explicit level_filter(log_level min_level) : min_level_(min_level) {}
 
     bool should_log(const log_entry& entry) const override {
         return static_cast<int>(entry.level) >= static_cast<int>(min_level_);
@@ -75,14 +74,10 @@ public:
  */
 class exact_level_filter : public log_filter_interface {
 private:
-    logger_system::log_level level_;
+    log_level level_;
 
 public:
-    explicit exact_level_filter(logger_system::log_level level) : level_(level) {}
-
-    /// Constructor accepting common::interfaces::log_level for compatibility with kcenon::logger::log_level
-    explicit exact_level_filter(kcenon::common::interfaces::log_level level)
-        : level_(static_cast<logger_system::log_level>(static_cast<int>(level))) {}
+    explicit exact_level_filter(log_level level) : level_(level) {}
 
     bool should_log(const log_entry& entry) const override {
         return entry.level == level_;

--- a/include/kcenon/logger/formatters/base_formatter.h
+++ b/include/kcenon/logger/formatters/base_formatter.h
@@ -9,11 +9,15 @@ All rights reserved.
 
 #include "../interfaces/log_formatter_interface.h"
 #include "../interfaces/log_entry.h"
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <sstream>
 #include <iomanip>
 #include <thread>
 
 namespace kcenon::logger {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @class base_formatter
@@ -38,14 +42,14 @@ protected:
      * @param level Log level
      * @return String representation
      */
-    std::string level_to_string(logger_system::log_level level) const {
+    std::string level_to_string(log_level level) const {
         switch (level) {
-            case logger_system::log_level::fatal:  return "FATAL";
-            case logger_system::log_level::error:  return "ERROR";
-            case logger_system::log_level::warn:   return "WARNING";
-            case logger_system::log_level::info:   return "INFO";
-            case logger_system::log_level::debug:  return "DEBUG";
-            case logger_system::log_level::trace:  return "TRACE";
+            case log_level::critical:  return "CRITICAL";
+            case log_level::error:  return "ERROR";
+            case log_level::warning:   return "WARNING";
+            case log_level::info:   return "INFO";
+            case log_level::debug:  return "DEBUG";
+            case log_level::trace:  return "TRACE";
             default: return "UNKNOWN";
         }
     }

--- a/include/kcenon/logger/formatters/logfmt_formatter.h
+++ b/include/kcenon/logger/formatters/logfmt_formatter.h
@@ -71,6 +71,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace kcenon::logger {
 
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
 /**
  * @class logfmt_formatter
  * @brief Formatter that outputs logfmt-structured log messages
@@ -221,15 +224,15 @@ private:
      * @param level Log level
      * @return Lowercase string representation
      */
-    static std::string level_to_lowercase(logger_system::log_level level) {
+    static std::string level_to_lowercase(log_level level) {
         switch (level) {
-            case logger_system::log_level::trace: return "trace";
-            case logger_system::log_level::debug: return "debug";
-            case logger_system::log_level::info: return "info";
-            case logger_system::log_level::warn: return "warn";
-            case logger_system::log_level::error: return "error";
-            case logger_system::log_level::fatal: return "fatal";
-            case logger_system::log_level::off: return "off";
+            case log_level::trace: return "trace";
+            case log_level::debug: return "debug";
+            case log_level::info: return "info";
+            case log_level::warning: return "warn";
+            case log_level::error: return "error";
+            case log_level::critical: return "critical";
+            case log_level::off: return "off";
             default: return "unknown";
         }
     }

--- a/include/kcenon/logger/interfaces/log_entry.h
+++ b/include/kcenon/logger/interfaces/log_entry.h
@@ -51,12 +51,14 @@ All rights reserved.
 
 // Use common_system's standard interface
 #include <kcenon/common/interfaces/logger_interface.h>
-#include <kcenon/logger/interfaces/logger_types.h>
 
 // OpenTelemetry context support
 #include <kcenon/logger/otlp/otel_context.h>
 
 namespace kcenon::logger {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @brief Value type for structured logging fields
@@ -155,12 +157,12 @@ struct source_location {
  */
 struct log_entry {
     // Required fields
-    
+
     /**
      * @brief Severity level of the log message
      * @details Determines the importance and routing of the message
      */
-    logger_system::log_level level;
+    log_level level;
     
     /**
      * @brief The actual log message
@@ -218,22 +220,22 @@ struct log_entry {
      * @param lvl Log severity level
      * @param msg Log message
      * @param ts Timestamp (default: current time)
-     * 
+     *
      * @details Creates a log entry with the minimum required information.
      * The timestamp defaults to the current system time if not specified.
-     * 
+     *
      * @example
      * @code
      * log_entry entry(log_level::info, "Server started on port 8080");
      * @endcode
-     * 
+     *
      * @since 1.0.0
      */
-    log_entry(logger_system::log_level lvl, 
+    log_entry(log_level lvl,
               const std::string& msg,
               std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
         : level(lvl), message(msg), timestamp(ts) {}
-    
+
     /**
      * @brief Constructor with source location information
      * @param lvl Log severity level
@@ -242,10 +244,10 @@ struct log_entry {
      * @param line Line number in source file
      * @param function Function name
      * @param ts Timestamp (default: current time)
-     * 
+     *
      * @details Creates a log entry with complete source location information.
      * This constructor is typically used with __FILE__, __LINE__, and __FUNCTION__ macros.
-     * 
+     *
      * @example
      * @code
      * log_entry entry(
@@ -256,54 +258,16 @@ struct log_entry {
      *     __FUNCTION__
      * );
      * @endcode
-     * 
+     *
      * @since 1.0.0
      */
-    log_entry(logger_system::log_level lvl,
+    log_entry(log_level lvl,
               const std::string& msg,
               const std::string& file,
               int line,
               const std::string& function,
               std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
         : level(lvl), message(msg), timestamp(ts),
-          location(source_location{file, line, function}) {}
-
-    /**
-     * @brief Constructor accepting common::interfaces::log_level
-     * @param lvl Log severity level (common::interfaces::log_level)
-     * @param msg Log message
-     * @param ts Timestamp (default: current time)
-     *
-     * @details Enables seamless use with kcenon::logger::log_level alias.
-     * Internally converts to logger_system::log_level for storage.
-     *
-     * @since 3.0.0
-     */
-    log_entry(kcenon::common::interfaces::log_level lvl,
-              const std::string& msg,
-              std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
-        : level(static_cast<logger_system::log_level>(static_cast<int>(lvl))),
-          message(msg), timestamp(ts) {}
-
-    /**
-     * @brief Constructor with source location accepting common::interfaces::log_level
-     * @param lvl Log severity level (common::interfaces::log_level)
-     * @param msg Log message
-     * @param file Source file path
-     * @param line Line number in source file
-     * @param function Function name
-     * @param ts Timestamp (default: current time)
-     *
-     * @since 3.0.0
-     */
-    log_entry(kcenon::common::interfaces::log_level lvl,
-              const std::string& msg,
-              const std::string& file,
-              int line,
-              const std::string& function,
-              std::chrono::system_clock::time_point ts = std::chrono::system_clock::now())
-        : level(static_cast<logger_system::log_level>(static_cast<int>(lvl))),
-          message(msg), timestamp(ts),
           location(source_location{file, line, function}) {}
 
     /**

--- a/include/kcenon/logger/routing/log_router.h
+++ b/include/kcenon/logger/routing/log_router.h
@@ -36,6 +36,7 @@
 
 #include <kcenon/logger/interfaces/log_filter_interface.h>
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -43,6 +44,9 @@
 #include <regex>
 
 namespace kcenon::logger::routing {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @brief Route configuration for log messages
@@ -124,7 +128,7 @@ private:
 public:
     explicit router_builder(log_router& router) : router_(router) {}
 
-    router_builder& when_level(logger_system::log_level level) {
+    router_builder& when_level(log_level level) {
         config_.filter = std::make_unique<class level_condition>(level);
         return *this;
     }
@@ -151,9 +155,9 @@ public:
 private:
     class level_condition : public log_filter_interface {
     private:
-        logger_system::log_level target_level_;
+        log_level target_level_;
     public:
-        explicit level_condition(logger_system::log_level level) : target_level_(level) {}
+        explicit level_condition(log_level level) : target_level_(level) {}
 
         bool should_log(const log_entry& entry) const override {
             return entry.level == target_level_;

--- a/include/kcenon/logger/sampling/log_sampler.h
+++ b/include/kcenon/logger/sampling/log_sampler.h
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "sampling_config.h"
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 #include <atomic>
 #include <chrono>
@@ -70,6 +71,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <optional>
 
 namespace kcenon::logger::sampling {
+
+// Type alias for log_level (may already be available from sampling_config.h, but explicit here for clarity)
+using log_level = common::interfaces::log_level;
 
 /**
  * @class log_sampler
@@ -146,7 +150,7 @@ public:
      * @param message Log message (used for hash-based sampling)
      * @return true if the entry should be logged
      */
-    [[nodiscard]] bool should_sample(logger_system::log_level level,
+    [[nodiscard]] bool should_sample(log_level level,
                                      const std::string& message);
 
     /**
@@ -156,7 +160,7 @@ public:
      * @param category Optional category for category-specific rates
      * @return true if the entry should be logged
      */
-    [[nodiscard]] bool should_sample(logger_system::log_level level,
+    [[nodiscard]] bool should_sample(log_level level,
                                      const std::string& message,
                                      const std::optional<std::string>& category);
 
@@ -213,7 +217,7 @@ private:
      * @param level Log level to check
      * @return true if the level should always be logged
      */
-    [[nodiscard]] bool should_bypass_level(logger_system::log_level level) const;
+    [[nodiscard]] bool should_bypass_level(log_level level) const;
 
     /**
      * @brief Check if any field should bypass sampling
@@ -354,10 +358,10 @@ public:
      */
     static std::unique_ptr<log_sampler> create_production(
         double base_rate = 0.1,
-        std::vector<logger_system::log_level> critical_levels = {
-            logger_system::log_level::warn,
-            logger_system::log_level::error,
-            logger_system::log_level::fatal
+        std::vector<log_level> critical_levels = {
+            log_level::warn,
+            log_level::error,
+            log_level::fatal
         });
 };
 

--- a/include/kcenon/logger/sampling/sampling_config.h
+++ b/include/kcenon/logger/sampling/sampling_config.h
@@ -56,9 +56,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstddef>
 #include <cstdint>
 
-#include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 namespace kcenon::logger::sampling {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @enum sampling_strategy
@@ -123,11 +126,11 @@ struct sampling_config {
     /**
      * @brief Log levels that are never sampled (always logged)
      * @details Critical levels should bypass sampling to ensure important
-     * messages are never dropped. Default includes error and fatal.
+     * messages are never dropped. Default includes error and critical.
      */
-    std::vector<logger_system::log_level> always_log_levels = {
-        logger_system::log_level::error,
-        logger_system::log_level::fatal
+    std::vector<log_level> always_log_levels = {
+        log_level::error,
+        log_level::critical
     };
 
     /**

--- a/include/kcenon/logger/utils/string_utils.h
+++ b/include/kcenon/logger/utils/string_utils.h
@@ -41,6 +41,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace kcenon::logger::utils {
 
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
 /**
  * @brief String utility functions for log formatting and conversion
  *
@@ -58,15 +61,15 @@ public:
      *
      * @note Thread-safe and stateless.
      */
-    static std::string level_to_string(logger_system::log_level level) {
+    static std::string level_to_string(log_level level) {
         switch (level) {
-            case logger_system::log_level::fatal:   return "CRITICAL";
-            case logger_system::log_level::error:   return "ERROR";
-            case logger_system::log_level::warn:    return "WARNING";
-            case logger_system::log_level::info:    return "INFO";
-            case logger_system::log_level::debug:   return "DEBUG";
-            case logger_system::log_level::trace:   return "TRACE";
-            case logger_system::log_level::off:     return "OFF";
+            case log_level::critical:  return "CRITICAL";
+            case log_level::error:     return "ERROR";
+            case log_level::warning:   return "WARNING";
+            case log_level::info:      return "INFO";
+            case log_level::debug:     return "DEBUG";
+            case log_level::trace:     return "TRACE";
+            case log_level::off:       return "OFF";
         }
         return "UNKNOWN";
     }
@@ -88,19 +91,19 @@ public:
      * @note Use with "\033[0m" to reset color after output.
      * @note Thread-safe and stateless.
      */
-    static std::string level_to_color(logger_system::log_level level, bool use_colors = true) {
+    static std::string level_to_color(log_level level, bool use_colors = true) {
         if (!use_colors) {
             return "";
         }
 
         switch (level) {
-            case logger_system::log_level::fatal:   return "\033[1;35m"; // Bright Magenta
-            case logger_system::log_level::error:   return "\033[1;31m"; // Bright Red
-            case logger_system::log_level::warn:    return "\033[1;33m"; // Bright Yellow
-            case logger_system::log_level::info:    return "\033[1;32m"; // Bright Green
-            case logger_system::log_level::debug:   return "\033[1;36m"; // Bright Cyan
-            case logger_system::log_level::trace:   return "\033[37m";   // White
-            case logger_system::log_level::off:     return "\033[90m";   // Dark Gray
+            case log_level::critical:  return "\033[1;35m"; // Bright Magenta
+            case log_level::error:     return "\033[1;31m"; // Bright Red
+            case log_level::warning:   return "\033[1;33m"; // Bright Yellow
+            case log_level::info:      return "\033[1;32m"; // Bright Green
+            case log_level::debug:     return "\033[1;36m"; // Bright Cyan
+            case log_level::trace:     return "\033[37m";   // White
+            case log_level::off:       return "\033[90m";   // Dark Gray
         }
         return "";
     }

--- a/src/core/log_collector.cpp
+++ b/src/core/log_collector.cpp
@@ -60,6 +60,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace kcenon::logger {
 
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
 /**
  * @brief Shared state for log processing - survives impl destruction
  *
@@ -261,13 +264,10 @@ private:
         int line = entry.location ? entry.location->line : 0;
         std::string function = entry.location ? entry.location->function.to_string() : "";
 
-        // Convert logger_system::log_level to common::interfaces::log_level
-        auto level = static_cast<common::interfaces::log_level>(static_cast<int>(entry.level));
-
         // Write to all writers without holding mutex
         for (auto& writer : writers_snapshot) {
             try {
-                writer->write(level, entry.message.to_string(), file,
+                writer->write(entry.level, entry.message.to_string(), file,
                              line, function, entry.timestamp);
             } catch (...) {
                 // Swallow exceptions to prevent thread termination
@@ -292,7 +292,7 @@ public:
         stop();
     }
 
-    bool enqueue(logger_system::log_level level,
+    bool enqueue(log_level level,
                  const std::string& message,
                  const std::string& file,
                  int line,
@@ -439,13 +439,10 @@ private:
         int line = entry.location ? entry.location->line : 0;
         std::string function = entry.location ? entry.location->function.to_string() : "";
 
-        // Convert logger_system::log_level to common::interfaces::log_level
-        auto level = static_cast<common::interfaces::log_level>(static_cast<int>(entry.level));
-
         // Write to all writers without holding mutex
         for (auto& writer : writers_snapshot) {
             try {
-                writer->write(level, entry.message.to_string(), file,
+                writer->write(entry.level, entry.message.to_string(), file,
                              line, function, entry.timestamp);
             } catch (...) {
                 // Swallow exceptions to prevent issues
@@ -467,7 +464,7 @@ log_collector::log_collector(std::size_t buffer_size, std::size_t batch_size)
 
 log_collector::~log_collector() = default;
 
-bool log_collector::enqueue(logger_system::log_level level,
+bool log_collector::enqueue(log_level level,
                            const std::string& message,
                            const std::string& file,
                            int line,

--- a/src/impl/async/batch_processor.h
+++ b/src/impl/async/batch_processor.h
@@ -18,8 +18,8 @@ All rights reserved.
 #include "lockfree_queue.h"
 #include <kcenon/logger/interfaces/log_entry.h>
 #include <kcenon/logger/writers/base_writer.h>
-#include <kcenon/logger/interfaces/logger_types.h>
 #include <kcenon/logger/core/error_codes.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <vector>
 #include <chrono>
 #include <atomic>

--- a/src/impl/filters/log_filter.h
+++ b/src/impl/filters/log_filter.h
@@ -7,16 +7,18 @@ Copyright (c) 2025, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-// Use logger_system's log_level (thread_system is now optional)
-#include <kcenon/logger/interfaces/logger_types.h>
 #include <kcenon/logger/interfaces/log_filter_interface.h>
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <string>
 #include <regex>
 #include <memory>
 #include <functional>
 
 namespace kcenon::logger {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @class log_filter
@@ -51,7 +53,7 @@ public:
      * @param function Function name
      * @return true if the log should be processed
      */
-    virtual bool should_log(logger_system::log_level level,
+    virtual bool should_log(log_level level,
                            const std::string& message,
                            const std::string& file,
                            int line,
@@ -72,10 +74,10 @@ public:
  */
 class level_filter : public log_filter {
 public:
-    explicit level_filter(logger_system::log_level min_level)
+    explicit level_filter(log_level min_level)
         : min_level_(min_level) {}
 
-    bool should_log(logger_system::log_level level,
+    bool should_log(log_level level,
                    const std::string& message,
                    const std::string& file,
                    int line,
@@ -87,7 +89,7 @@ public:
         return static_cast<int>(level) >= static_cast<int>(min_level_);
     }
 
-    void set_min_level(logger_system::log_level level) {
+    void set_min_level(log_level level) {
         min_level_ = level;
     }
 
@@ -96,7 +98,7 @@ public:
     }
 
 private:
-    logger_system::log_level min_level_;
+    log_level min_level_;
 };
 
 /**
@@ -108,7 +110,7 @@ public:
     explicit regex_filter(const std::string& pattern, bool include = true)
         : pattern_(pattern), include_(include) {}
 
-    bool should_log(logger_system::log_level level,
+    bool should_log(log_level level,
                    const std::string& message,
                    const std::string& file,
                    int line,
@@ -136,7 +138,7 @@ private:
  */
 class function_filter : public log_filter {
 public:
-    using filter_function = std::function<bool(logger_system::log_level,
+    using filter_function = std::function<bool(log_level,
                                                const std::string&,
                                                const std::string&,
                                                int,
@@ -145,7 +147,7 @@ public:
     explicit function_filter(filter_function func)
         : filter_func_(std::move(func)) {}
 
-    bool should_log(logger_system::log_level level,
+    bool should_log(log_level level,
                    const std::string& message,
                    const std::string& file,
                    int line,
@@ -179,7 +181,7 @@ public:
         filters_.push_back(std::move(filter));
     }
 
-    bool should_log(logger_system::log_level level,
+    bool should_log(log_level level,
                    const std::string& message,
                    const std::string& file,
                    int line,

--- a/src/impl/writers/critical_writer.cpp
+++ b/src/impl/writers/critical_writer.cpp
@@ -8,6 +8,7 @@ All rights reserved.
 #include <kcenon/logger/writers/critical_writer.h>
 #include <kcenon/logger/core/error_codes.h>
 #include <kcenon/logger/utils/error_handling_utils.h>
+#include <kcenon/logger/utils/string_utils.h>
 #include <iostream>
 #include <sstream>
 #include <iomanip>
@@ -229,13 +230,10 @@ void critical_writer::write_to_wal(
             timestamp.time_since_epoch()
         ).count() % 1000;
 
-        // Convert common::interfaces::log_level to logger_system::log_level for string conversion
-        auto legacy_level = static_cast<logger_system::log_level>(static_cast<int>(level));
-
         std::ostringstream oss;
         oss << "[" << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S")
             << "." << std::setfill('0') << std::setw(3) << ms << "] "
-            << "[" << logger_system::log_level_to_string(legacy_level) << "] "
+            << "[" << utils::string_utils::level_to_string(level) << "] "
             << "[" << file << ":" << line << ":" << function << "] "
             << message << "\n";
 

--- a/src/impl/writers/network_writer.cpp
+++ b/src/impl/writers/network_writer.cpp
@@ -17,6 +17,7 @@ All rights reserved.
 
 #include <kcenon/logger/writers/network_writer.h>
 #include <kcenon/logger/utils/error_handling_utils.h>
+#include <kcenon/logger/utils/string_utils.h>
 #include "../async/jthread_compat.h"
 
 #ifdef _WIN32
@@ -459,9 +460,8 @@ std::string network_writer::format_for_network(const buffered_log& log) {
     oss << "\"@timestamp\":\"";
     oss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%SZ") << "\",";
 
-    // Level - convert to logger_system::log_level for string conversion
-    auto legacy_level = static_cast<logger_system::log_level>(static_cast<int>(log.level));
-    oss << "\"level\":\"" << logger_system::log_level_to_string(legacy_level) << "\",";
+    // Level
+    oss << "\"level\":\"" << utils::string_utils::level_to_string(log.level) << "\",";
 
     // Message
     oss << "\"message\":\"" << escape_json(log.message) << "\"";

--- a/src/sampling/log_sampler.cpp
+++ b/src/sampling/log_sampler.cpp
@@ -154,12 +154,12 @@ bool log_sampler::should_sample(const log_entry& entry) {
     return sampled;
 }
 
-bool log_sampler::should_sample(logger_system::log_level level,
+bool log_sampler::should_sample(log_level level,
                                 const std::string& message) {
     return should_sample(level, message, std::nullopt);
 }
 
-bool log_sampler::should_sample(logger_system::log_level level,
+bool log_sampler::should_sample(log_level level,
                                 const std::string& message,
                                 const std::optional<std::string>& category) {
     // Increment total count
@@ -262,7 +262,7 @@ double log_sampler::get_effective_rate() const {
     return effective_rate_.load(std::memory_order_relaxed);
 }
 
-bool log_sampler::should_bypass_level(logger_system::log_level level) const {
+bool log_sampler::should_bypass_level(log_level level) const {
     std::shared_lock<std::shared_mutex> lock(config_mutex_);
     const auto& levels = config_.always_log_levels;
     return std::find(levels.begin(), levels.end(), level) != levels.end();
@@ -510,7 +510,7 @@ std::unique_ptr<log_sampler> sampler_factory::create_adaptive(
 
 std::unique_ptr<log_sampler> sampler_factory::create_production(
     double base_rate,
-    std::vector<logger_system::log_level> critical_levels) {
+    std::vector<log_level> critical_levels) {
     sampling_config config;
     config.enabled = true;
     config.rate = base_rate;

--- a/tests/log_sampling_test.cpp
+++ b/tests/log_sampling_test.cpp
@@ -148,11 +148,11 @@ TEST(SamplingConfigTest, AlwaysLogLevelsDefault) {
     EXPECT_EQ(config.always_log_levels.size(), 2U);
     EXPECT_NE(std::find(config.always_log_levels.begin(),
                         config.always_log_levels.end(),
-                        ls::log_level::error),
+                        kcenon::logger::log_level::error),
               config.always_log_levels.end());
     EXPECT_NE(std::find(config.always_log_levels.begin(),
                         config.always_log_levels.end(),
-                        ls::log_level::fatal),
+                        kcenon::logger::log_level::critical),
               config.always_log_levels.end());
 }
 
@@ -207,7 +207,7 @@ TEST(LogSamplerTest, DisabledSamplerPassesAll) {
     log_sampler sampler(sampling_config::disabled());
 
     for (int i = 0; i < 100; ++i) {
-        EXPECT_TRUE(sampler.should_sample(ls::log_level::info, "test message"));
+        EXPECT_TRUE(sampler.should_sample(kcenon::logger::log_level::info, "test message"));
     }
 
     auto stats = sampler.get_stats();
@@ -221,7 +221,7 @@ TEST(LogSamplerTest, FullRatePassesAll) {
     log_sampler sampler(config);
 
     for (int i = 0; i < 100; ++i) {
-        EXPECT_TRUE(sampler.should_sample(ls::log_level::info, "test message"));
+        EXPECT_TRUE(sampler.should_sample(kcenon::logger::log_level::info, "test message"));
     }
 
     auto stats = sampler.get_stats();
@@ -235,7 +235,7 @@ TEST(LogSamplerTest, ZeroRateDropsAll) {
     log_sampler sampler(config);
 
     for (int i = 0; i < 100; ++i) {
-        EXPECT_FALSE(sampler.should_sample(ls::log_level::info, "test message"));
+        EXPECT_FALSE(sampler.should_sample(kcenon::logger::log_level::info, "test message"));
     }
 
     auto stats = sampler.get_stats();
@@ -245,17 +245,17 @@ TEST(LogSamplerTest, ZeroRateDropsAll) {
 
 TEST(LogSamplerTest, AlwaysLogLevelBypassesSampling) {
     auto config = sampling_config::random_sampling(0.0);  // Drop all
-    config.always_log_levels = {ls::log_level::error, ls::log_level::fatal};
+    config.always_log_levels = {kcenon::logger::log_level::error, kcenon::logger::log_level::critical};
     log_sampler sampler(config);
 
     // Info should be dropped
-    EXPECT_FALSE(sampler.should_sample(ls::log_level::info, "info message"));
+    EXPECT_FALSE(sampler.should_sample(kcenon::logger::log_level::info, "info message"));
 
     // Error should bypass
-    EXPECT_TRUE(sampler.should_sample(ls::log_level::error, "error message"));
+    EXPECT_TRUE(sampler.should_sample(kcenon::logger::log_level::error, "error message"));
 
     // Fatal should bypass
-    EXPECT_TRUE(sampler.should_sample(ls::log_level::fatal, "fatal message"));
+    EXPECT_TRUE(sampler.should_sample(kcenon::logger::log_level::critical, "fatal message"));
 
     auto stats = sampler.get_stats();
     EXPECT_EQ(stats.bypassed_count, 2U);
@@ -275,7 +275,7 @@ TEST(LogSamplerTest, RandomSamplingApproximatesRate) {
     int sampled = 0;
 
     for (int i = 0; i < iterations; ++i) {
-        if (sampler.should_sample(ls::log_level::info, "test message " + std::to_string(i))) {
+        if (sampler.should_sample(kcenon::logger::log_level::info, "test message " + std::to_string(i))) {
             ++sampled;
         }
     }
@@ -295,7 +295,7 @@ TEST(LogSamplerTest, RandomSamplingLowRate) {
     int sampled = 0;
 
     for (int i = 0; i < iterations; ++i) {
-        if (sampler.should_sample(ls::log_level::info, "test message " + std::to_string(i))) {
+        if (sampler.should_sample(kcenon::logger::log_level::info, "test message " + std::to_string(i))) {
             ++sampled;
         }
     }
@@ -316,7 +316,7 @@ TEST(LogSamplerTest, RateLimitingBasic) {
 
     int sampled = 0;
     for (int i = 0; i < 200; ++i) {
-        if (sampler.should_sample(ls::log_level::info, "test message")) {
+        if (sampler.should_sample(kcenon::logger::log_level::info, "test message")) {
             ++sampled;
         }
     }
@@ -335,9 +335,9 @@ TEST(LogSamplerTest, HashBasedSamplingIsDeterministic) {
     log_sampler sampler(config);
 
     // Same message should always get same result
-    bool result1 = sampler.should_sample(ls::log_level::info, "specific message");
+    bool result1 = sampler.should_sample(kcenon::logger::log_level::info, "specific message");
     sampler.reset_stats();
-    bool result2 = sampler.should_sample(ls::log_level::info, "specific message");
+    bool result2 = sampler.should_sample(kcenon::logger::log_level::info, "specific message");
 
     EXPECT_EQ(result1, result2);
 }
@@ -354,7 +354,7 @@ TEST(LogSamplerTest, HashBasedSamplingDifferentMessages) {
     for (int i = 0; i < iterations; ++i) {
         std::string msg = "log_event_" + std::to_string(i) + "_action_" +
                           std::to_string(i * 7 % 100);
-        if (sampler.should_sample(ls::log_level::info, msg)) {
+        if (sampler.should_sample(kcenon::logger::log_level::info, msg)) {
             ++sampled;
         }
     }
@@ -383,7 +383,7 @@ TEST(LogSamplerTest, CategorySpecificRates) {
     // Test security category - should all pass
     int security_passed = 0;
     for (int i = 0; i < 100; ++i) {
-        if (sampler.should_sample(ls::log_level::info, "security event", std::string("security"))) {
+        if (sampler.should_sample(kcenon::logger::log_level::info, "security event", std::string("security"))) {
             ++security_passed;
         }
     }
@@ -394,7 +394,7 @@ TEST(LogSamplerTest, CategorySpecificRates) {
     // Test database category - should have low pass rate
     int database_passed = 0;
     for (int i = 0; i < 1000; ++i) {
-        if (sampler.should_sample(ls::log_level::info, "db query " + std::to_string(i), std::string("database"))) {
+        if (sampler.should_sample(kcenon::logger::log_level::info, "db query " + std::to_string(i), std::string("database"))) {
             ++database_passed;
         }
     }
@@ -410,7 +410,7 @@ TEST(LogSamplerTest, ConfigCanBeUpdated) {
     log_sampler sampler(sampling_config::disabled());
 
     // Initially passes all
-    EXPECT_TRUE(sampler.should_sample(ls::log_level::info, "test"));
+    EXPECT_TRUE(sampler.should_sample(kcenon::logger::log_level::info, "test"));
 
     // Update to drop all
     auto new_config = sampling_config::random_sampling(0.0);
@@ -418,7 +418,7 @@ TEST(LogSamplerTest, ConfigCanBeUpdated) {
     sampler.set_config(new_config);
 
     // Now should drop
-    EXPECT_FALSE(sampler.should_sample(ls::log_level::info, "test"));
+    EXPECT_FALSE(sampler.should_sample(kcenon::logger::log_level::info, "test"));
 }
 
 TEST(LogSamplerTest, EnableDisableToggle) {
@@ -428,17 +428,17 @@ TEST(LogSamplerTest, EnableDisableToggle) {
 
     // Enabled by default via config
     EXPECT_TRUE(sampler.is_enabled());
-    EXPECT_FALSE(sampler.should_sample(ls::log_level::info, "test"));
+    EXPECT_FALSE(sampler.should_sample(kcenon::logger::log_level::info, "test"));
 
     // Disable
     sampler.set_enabled(false);
     EXPECT_FALSE(sampler.is_enabled());
-    EXPECT_TRUE(sampler.should_sample(ls::log_level::info, "test"));  // Now passes
+    EXPECT_TRUE(sampler.should_sample(kcenon::logger::log_level::info, "test"));  // Now passes
 
     // Re-enable
     sampler.set_enabled(true);
     EXPECT_TRUE(sampler.is_enabled());
-    EXPECT_FALSE(sampler.should_sample(ls::log_level::info, "test"));  // Back to dropping
+    EXPECT_FALSE(sampler.should_sample(kcenon::logger::log_level::info, "test"));  // Back to dropping
 }
 
 // =============================================================================
@@ -447,13 +447,13 @@ TEST(LogSamplerTest, EnableDisableToggle) {
 
 TEST(LogSamplerTest, StatsAreAccurate) {
     auto config = sampling_config::random_sampling(0.5);
-    config.always_log_levels = {ls::log_level::error};
+    config.always_log_levels = {kcenon::logger::log_level::error};
     log_sampler sampler(config);
 
     const int iterations = 1000;
     for (int i = 0; i < iterations; ++i) {
-        (void)sampler.should_sample(ls::log_level::info, "info " + std::to_string(i));
-        (void)sampler.should_sample(ls::log_level::error, "error " + std::to_string(i));  // Bypassed
+        (void)sampler.should_sample(kcenon::logger::log_level::info, "info " + std::to_string(i));
+        (void)sampler.should_sample(kcenon::logger::log_level::error, "error " + std::to_string(i));  // Bypassed
     }
 
     auto stats = sampler.get_stats();
@@ -473,7 +473,7 @@ TEST(LogSamplerTest, ResetStats) {
     log_sampler sampler(config);
 
     for (int i = 0; i < 100; ++i) {
-        (void)sampler.should_sample(ls::log_level::info, "test");
+        (void)sampler.should_sample(kcenon::logger::log_level::info, "test");
     }
 
     auto stats = sampler.get_stats();
@@ -534,7 +534,7 @@ TEST(LoggerSamplingTest, LoggerWithSampler) {
 
     // Set a sampler that drops all (rate=0)
     auto config = sampling_config::random_sampling(0.0);
-    config.always_log_levels = {ls::log_level::error, ls::log_level::fatal};
+    config.always_log_levels = {kcenon::logger::log_level::error, kcenon::logger::log_level::critical};
     log.set_sampler(std::make_unique<log_sampler>(config));
 
     // Info messages should be dropped

--- a/tests/routing_integration_test.cpp
+++ b/tests/routing_integration_test.cpp
@@ -114,7 +114,7 @@ TEST_F(RoutingIntegrationTest, NonExclusiveRouting) {
         .with_async(false)
         .add_writer("all", std::make_unique<file_writer>("test_all.log"))
         .add_writer("errors", std::make_unique<file_writer>("test_errors.log"))
-        .route_level(static_cast<logger_system::log_level>(static_cast<int>(ci::log_level::error)), {"errors"})
+        .route_level(static_cast<log_level>(static_cast<int>(ci::log_level::error)), {"errors"})
         .with_exclusive_routing(false)  // Non-exclusive (default)
         .build();
 


### PR DESCRIPTION
## Summary
- Migrate core logger components from `logger_system::log_level` to `common::interfaces::log_level`
- Part of the type unification effort (Part 3 of #339)
- Ensures consistent log level type usage throughout the core module

### Changed Files
**Headers:**
- `include/kcenon/logger/interfaces/log_entry.h` - Core log entry structure
- `include/kcenon/logger/core/logger_config.h` - Configuration structures
- `include/kcenon/logger/core/logger_builder.h` - Builder pattern
- `include/kcenon/logger/core/log_collector.h` - Async log collection
- `include/kcenon/logger/core/filtered_logger.h` - Filtered logger
- `include/kcenon/logger/core/structured_log_builder.h` - Structured logging
- `include/kcenon/logger/filters/log_filter.h` - Filter classes
- `include/kcenon/logger/formatters/base_formatter.h` - Base formatter
- `include/kcenon/logger/formatters/logfmt_formatter.h` - Logfmt formatter
- `include/kcenon/logger/routing/log_router.h` - Log routing
- `include/kcenon/logger/sampling/log_sampler.h` - Log sampling
- `include/kcenon/logger/sampling/sampling_config.h` - Sampling config
- `include/kcenon/logger/analysis/log_analyzer.h` - Log analysis
- `include/kcenon/logger/analysis/realtime_log_analyzer.h` - Realtime analysis
- `include/kcenon/logger/utils/string_utils.h` - String utilities

**Implementations:**
- `src/core/logger.cpp` - Logger implementation
- `src/core/log_collector.cpp` - Collector implementation
- `src/impl/writers/critical_writer.cpp` - Critical writer
- `src/impl/writers/network_writer.cpp` - Network writer
- `src/sampling/log_sampler.cpp` - Sampler implementation

## Test Plan
- [x] Build passes successfully
- [x] 15/16 tests pass (1 unrelated test failure in encrypted_writer_test)
- [x] Verify log level mapping:
  - `trace` → `trace`
  - `debug` → `debug`
  - `info` → `info`
  - `warn` → `warning`
  - `error` → `error`
  - `fatal` → `critical`

Closes #342