### PR TITLE
refactor(analysis): migrate analysis, routing, sampling to common::interfaces::log_level

### DIFF
--- a/include/kcenon/logger/adapters/logger_adapter.h
+++ b/include/kcenon/logger/adapters/logger_adapter.h
@@ -31,6 +31,7 @@
 
 #include <kcenon/logger/core/logger.h>
 #include <kcenon/logger/core/thread_integration_detector.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <memory>
 #include <sstream>
 #include <string_view>
@@ -39,6 +40,9 @@
 // adapters for kcenon::common::interfaces::ILogger
 
 namespace kcenon::logger::adapters {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @brief Standalone logger adapter
@@ -67,7 +71,7 @@ public:
      * @param level Log level
      * @param message Message to log
      */
-    void log(logger_system::log_level level, std::string_view message) {
+    void log(log_level level, std::string_view message) {
         if (!logger_) {
             return;
         }
@@ -124,7 +128,7 @@ public:
      * @brief Set minimum log level
      * @param level Minimum level to log
      */
-    void set_level(logger_system::log_level level) {
+    void set_level(log_level level) {
         if (logger_) {
             logger_->set_level(level);
         }

--- a/include/kcenon/logger/backends/integration_backend.h
+++ b/include/kcenon/logger/backends/integration_backend.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include <string>
-#include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 
 /**
  * @file integration_backend.h
@@ -55,6 +55,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 namespace kcenon::logger::backends {
+
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
 
 /**
  * @class integration_backend
@@ -79,8 +82,8 @@ public:
      * @param external_level External system's log level (as integer)
      * @return Normalized log_level for internal use
      *
-     * @details Converts log levels from external systems to the logger_system's
-     * log_level enumeration. Different systems may use different level schemes
+     * @details Converts log levels from external systems to the common::interfaces::log_level
+     * enumeration. Different systems may use different level schemes
      * (ascending, descending, different naming), and this method handles the conversion.
      *
      * @note The external_level is passed as int to avoid compile-time dependencies
@@ -88,7 +91,7 @@ public:
      *
      * @since 1.2.0
      */
-    virtual logger_system::log_level normalize_level(int external_level) const = 0;
+    virtual log_level normalize_level(int external_level) const = 0;
 
     /**
      * @brief Get the backend name

--- a/include/kcenon/logger/backends/monitoring_backend.h
+++ b/include/kcenon/logger/backends/monitoring_backend.h
@@ -91,19 +91,19 @@ public:
     ~monitoring_backend() override = default;
 
     /**
-     * @brief Normalize monitoring_system log level to logger_system level
+     * @brief Normalize monitoring_system log level to internal level
      * @param external_level monitoring_system log level as integer
-     * @return Corresponding logger_system::log_level
+     * @return Corresponding log_level
      *
      * @details monitoring_system uses the same ascending level scheme as
-     * logger_system, so this is a direct cast. If the systems diverge in
-     * the future, conversion logic can be added here.
+     * common::interfaces::log_level, so this is a direct cast. If the systems
+     * diverge in the future, conversion logic can be added here.
      *
      * @since 1.2.0
      */
-    logger_system::log_level normalize_level(int external_level) const override {
-        // monitoring_system uses same level scheme as logger_system
-        return static_cast<logger_system::log_level>(external_level);
+    log_level normalize_level(int external_level) const override {
+        // monitoring_system uses same level scheme as common::interfaces::log_level
+        return static_cast<log_level>(external_level);
     }
 
     /**

--- a/include/kcenon/logger/backends/standalone_backend.h
+++ b/include/kcenon/logger/backends/standalone_backend.h
@@ -29,7 +29,7 @@ namespace kcenon::logger::backends {
  * @brief Integration backend for standalone logger operation
  *
  * @details This is the default backend when no external integration is required.
- * It assumes the external level values match the logger_system::log_level enumeration,
+ * It assumes the external level values match the common::interfaces::log_level enumeration,
  * providing a simple pass-through conversion.
  *
  * Usage:
@@ -55,16 +55,16 @@ public:
     /**
      * @brief Normalize external log level (pass-through)
      * @param external_level External log level as integer
-     * @return The same level cast to logger_system::log_level
+     * @return The same level cast to log_level
      *
      * @details In standalone mode, the external level is assumed to already
-     * be in logger_system::log_level format, so this is a simple cast.
+     * be in common::interfaces::log_level format, so this is a simple cast.
      *
      * @since 1.2.0
      */
-    logger_system::log_level normalize_level(int external_level) const override {
-        // Direct cast - assumes external level is already logger_system::log_level
-        return static_cast<logger_system::log_level>(external_level);
+    log_level normalize_level(int external_level) const override {
+        // Direct cast - assumes external level is already common::interfaces::log_level
+        return static_cast<log_level>(external_level);
     }
 
     /**

--- a/include/kcenon/logger/factories/filter_factory.h
+++ b/include/kcenon/logger/factories/filter_factory.h
@@ -23,6 +23,7 @@ All rights reserved.
 
 #include "../interfaces/log_filter_interface.h"
 #include "../filters/log_filter.h"
+#include "../interfaces/log_entry.h"
 
 namespace kcenon::logger {
 
@@ -49,7 +50,7 @@ public:
      * @return Unique pointer to level filter
      */
     static std::unique_ptr<log_filter_interface> create_level(
-        logger_system::log_level min_level
+        log_level min_level
     ) {
         return std::make_unique<filters::level_filter>(min_level);
     }
@@ -107,7 +108,7 @@ public:
      * @return Filter that passes all messages (trace and above)
      */
     static std::unique_ptr<log_filter_interface> create_development() {
-        return create_level(logger_system::log_level::trace);
+        return create_level(log_level::trace);
     }
 
     /**
@@ -116,7 +117,7 @@ public:
      */
     static std::unique_ptr<log_filter_interface> create_production() {
         auto composite = create_composite_and();
-        composite->add_filter(create_level(logger_system::log_level::warn));
+        composite->add_filter(create_level(log_level::warning));
         composite->add_filter(create_regex("password|secret|token|api.?key", false));
         return composite;
     }
@@ -126,7 +127,7 @@ public:
      * @return Filter that only passes error and fatal messages
      */
     static std::unique_ptr<log_filter_interface> create_errors_only() {
-        return create_level(logger_system::log_level::error);
+        return create_level(log_level::error);
     }
 
     /**
@@ -163,7 +164,7 @@ public:
         /**
          * @brief Set minimum log level
          */
-        builder& with_min_level(logger_system::log_level level) {
+        builder& with_min_level(log_level level) {
             filters_.push_back(create_level(level));
             return *this;
         }

--- a/include/kcenon/logger/structured/structured_logger.h
+++ b/include/kcenon/logger/structured/structured_logger.h
@@ -34,7 +34,7 @@
 
 #pragma once
 
-#include <kcenon/logger/interfaces/logger_types.h>
+#include <kcenon/common/interfaces/logger_interface.h>
 #include <string>
 #include <unordered_map>
 #include <variant>
@@ -47,6 +47,9 @@
 
 namespace kcenon::logger::structured {
 
+// Type alias for log_level
+using log_level = common::interfaces::log_level;
+
 /**
  * @brief Value type for structured logging
  */
@@ -56,7 +59,7 @@ using log_value = std::variant<std::string, int, double, bool>;
  * @brief Structured log entry
  */
 struct structured_log_entry {
-    logger_system::log_level level;
+    log_level level;
     std::string message;
     std::unordered_map<std::string, log_value> fields;
     std::chrono::system_clock::time_point timestamp;
@@ -79,7 +82,7 @@ public:
     /**
      * @brief Start building a structured log entry
      */
-    virtual class log_builder start_log(logger_system::log_level level) = 0;
+    virtual class log_builder start_log(log_level level) = 0;
 };
 
 /**
@@ -91,7 +94,7 @@ private:
     structured_logger_interface* logger_;
 
 public:
-    log_builder(logger_system::log_level level, structured_logger_interface* logger)
+    log_builder(log_level level, structured_logger_interface* logger)
         : logger_(logger) {
         entry_.level = level;
     }
@@ -144,7 +147,7 @@ enum class structured_format {
 /**
  * @brief Output callback type for structured logger
  */
-using structured_output_callback = std::function<void(logger_system::log_level, const std::string&)>;
+using structured_output_callback = std::function<void(log_level, const std::string&)>;
 
 /**
  * @brief Basic structured logger implementation
@@ -216,7 +219,7 @@ public:
         }
     }
 
-    log_builder start_log(logger_system::log_level level) override {
+    log_builder start_log(log_level level) override {
         return log_builder(level, this);
     }
 
@@ -253,15 +256,15 @@ private:
         return oss.str();
     }
 
-    static std::string level_to_string(logger_system::log_level level) {
+    static std::string level_to_string(log_level level) {
         switch (level) {
-            case logger_system::log_level::trace: return "trace";
-            case logger_system::log_level::debug: return "debug";
-            case logger_system::log_level::info: return "info";
-            case logger_system::log_level::warn: return "warn";
-            case logger_system::log_level::error: return "error";
-            case logger_system::log_level::fatal: return "fatal";
-            case logger_system::log_level::off: return "off";
+            case log_level::trace: return "trace";
+            case log_level::debug: return "debug";
+            case log_level::info: return "info";
+            case log_level::warning: return "warn";
+            case log_level::error: return "error";
+            case log_level::critical: return "fatal";
+            case log_level::off: return "off";
             default: return "unknown";
         }
     }
@@ -347,15 +350,15 @@ public:
     }
 
 private:
-    static std::string level_to_string(logger_system::log_level level) {
+    static std::string level_to_string(log_level level) {
         switch (level) {
-            case logger_system::log_level::trace: return "TRACE";
-            case logger_system::log_level::debug: return "DEBUG";
-            case logger_system::log_level::info: return "INFO";
-            case logger_system::log_level::warn: return "WARN";
-            case logger_system::log_level::error: return "ERROR";
-            case logger_system::log_level::fatal: return "FATAL";
-            case logger_system::log_level::off: return "OFF";
+            case log_level::trace: return "TRACE";
+            case log_level::debug: return "DEBUG";
+            case log_level::info: return "INFO";
+            case log_level::warning: return "WARN";
+            case log_level::error: return "ERROR";
+            case log_level::critical: return "FATAL";
+            case log_level::off: return "OFF";
             default: return "UNKNOWN";
         }
     }


### PR DESCRIPTION
Closes #343

## Summary
- Migrate analysis, routing, and sampling components from deprecated `logger_system::log_level` to `common::interfaces::log_level`
- Remove converter functions (`from_common_level`, `to_common_level`) from `service_registration.h` since they are no longer needed
- Add namespace-local type aliases for cleaner code

## Files Modified
- `include/kcenon/logger/structured/structured_logger.h`
- `include/kcenon/logger/factories/filter_factory.h`
- `include/kcenon/logger/backends/integration_backend.h`
- `include/kcenon/logger/backends/monitoring_backend.h`
- `include/kcenon/logger/backends/standalone_backend.h`
- `include/kcenon/logger/adapters/logger_adapter.h`
- `include/kcenon/logger/di/service_registration.h`

## Test Plan
- [x] Build succeeds with CMake
- [x] All relevant tests pass (15/16, the failing test is unrelated OpenSSL issue)