### PR TITLE
refactor(writers): remove dual write interface from base_writer

### DIFF
--- a/examples/custom_writer_example.cpp
+++ b/examples/custom_writer_example.cpp
@@ -114,19 +114,8 @@ protected:
      * @warning Do not call public methods on 'this' inside *_impl methods
      *          as it would cause deadlock.
      */
-    kcenon::common::VoidResult write_impl(
-        kcenon::common::interfaces::log_level level,
-        const std::string& message,
-        const std::string& file,
-        int line,
-        const std::string& function,
-        const std::chrono::system_clock::time_point& timestamp) override
+    kcenon::common::VoidResult write_entry_impl(const log_entry& entry) override
     {
-        // Create and format log entry
-        log_entry entry = (!file.empty() || line != 0 || !function.empty())
-            ? log_entry(level, message, file, line, function, timestamp)
-            : log_entry(level, message, timestamp);
-
         std::string formatted = format_log_entry(entry);
 
         // Store in memory - already protected by base class mutex
@@ -205,19 +194,15 @@ public:
     }
 
 protected:
-    kcenon::common::VoidResult write_impl(
-        kcenon::common::interfaces::log_level level,
-        const std::string& message,
-        const std::string& file,
-        int line,
-        const std::string& function,
-        const std::chrono::system_clock::time_point& timestamp) override
+    kcenon::common::VoidResult write_entry_impl(const log_entry& entry) override
     {
+        // Convert log_level from logger_system to common::interfaces
+        auto level = static_cast<kcenon::common::interfaces::log_level>(static_cast<int>(entry.level));
+
         // Increment counter for this level
         counts_[level]++;
 
-        // Create and format log entry
-        log_entry entry = log_entry(level, message, timestamp);
+        // Format log entry
         std::string formatted = format_log_entry(entry);
 
         // Output to console with color based on level

--- a/include/kcenon/logger/writers/base_writer.h
+++ b/include/kcenon/logger/writers/base_writer.h
@@ -139,56 +139,24 @@ public:
     virtual ~base_writer() = default;
     
     /**
-     * @brief Write a log entry using the new interface
+     * @brief Write a log entry using the modern interface
      * @param entry The log entry to write
      * @return common::VoidResult Success or error code
      *
-     * @details This method provides compatibility with the modern log_entry structure.
-     * The default implementation converts the entry to the legacy API format for
-     * backward compatibility. Derived classes can override this for optimized handling.
+     * @details This is the primary method that derived classes must implement.
+     * It receives a complete log_entry structure with all log information
+     * including structured fields, OpenTelemetry context, and category info.
      *
-     * @note This method extracts source location information if present in the entry.
-     *
-     * @since 1.0.0
-     */
-    common::VoidResult write(const log_entry& entry) override {
-        // Convert to old API for backward compatibility
-        std::string file = entry.location ? entry.location->file.to_string() : "";
-        int line = entry.location ? entry.location->line : 0;
-        std::string function = entry.location ? entry.location->function.to_string() : "";
-
-        // Convert logger_system::log_level to common::interfaces::log_level
-        auto level = static_cast<common::interfaces::log_level>(static_cast<int>(entry.level));
-        return write(level, entry.message.to_string(), file, line, function, entry.timestamp);
-    }
-
-    /**
-     * @brief Write a log entry (legacy API for backward compatibility)
-     * @param level Log severity level
-     * @param message Log message text
-     * @param file Source file path (empty if not available)
-     * @param line Source line number (0 if not available)
-     * @param function Function name (empty if not available)
-     * @param timestamp Time when the log entry was created
-     * @return common::VoidResult Success or error code
-     *
-     * @details This is the main method that derived classes must implement.
-     * It receives all log information and is responsible for outputting it
-     * to the writer's specific destination.
-     *
-     * @note Implementations should handle empty file/function strings gracefully.
+     * @note Derived classes should implement this method directly for optimal
+     * performance. The log_entry structure provides all necessary information.
      *
      * @warning This method may be called from multiple threads in async mode.
      * Implementations must be thread-safe.
      *
      * @since 1.0.0
+     * @since 3.5.0 Changed to pure virtual - implementations must override this
      */
-    virtual common::VoidResult write(common::interfaces::log_level level,
-                                     const std::string& message,
-                                     const std::string& file,
-                                     int line,
-                                     const std::string& function,
-                                     const std::chrono::system_clock::time_point& timestamp) = 0;
+    common::VoidResult write(const log_entry& entry) override = 0;
 
     /**
      * @brief Flush any buffered data to the destination

--- a/include/kcenon/logger/writers/batch_writer.h
+++ b/include/kcenon/logger/writers/batch_writer.h
@@ -91,20 +91,11 @@ public:
     
     /**
      * @brief Write a log entry to the batch
-     * @param level Log level
-     * @param message Log message
-     * @param file Source file
-     * @param line Source line
-     * @param function Function name
-     * @param timestamp Time of log entry
+     * @param entry The log entry to write
      * @return common::VoidResult indicating success or error
+     * @since 3.5.0 Changed to use log_entry directly
      */
-    common::VoidResult write(common::interfaces::log_level level,
-                             const std::string& message,
-                             const std::string& file,
-                             int line,
-                             const std::string& function,
-                             const std::chrono::system_clock::time_point& timestamp) override;
+    common::VoidResult write(const log_entry& entry) override;
 
     /**
      * @brief Flush the batch to the underlying writer
@@ -159,26 +150,6 @@ public:
     void reset_stats();
     
 private:
-    /**
-     * @brief Internal structure to store batch entry
-     */
-    struct batch_entry {
-        common::interfaces::log_level level;
-        std::string message;
-        std::string file;
-        int line;
-        std::string function;
-        std::chrono::system_clock::time_point timestamp;
-        
-        batch_entry(common::interfaces::log_level lvl,
-                   const std::string& msg,
-                   const std::string& f,
-                   int l,
-                   const std::string& func,
-                   const std::chrono::system_clock::time_point& ts)
-            : level(lvl), message(msg), file(f), line(l), 
-              function(func), timestamp(ts) {}
-    };
     
     /**
      * @brief Flush batch without locking (caller must hold lock)
@@ -206,7 +177,7 @@ private:
     
     // Batch storage
     mutable std::mutex batch_mutex_;
-    std::vector<batch_entry> batch_;
+    std::vector<log_entry> batch_;
     std::chrono::steady_clock::time_point last_flush_time_;
     
     // Statistics

--- a/include/kcenon/logger/writers/console_writer.h
+++ b/include/kcenon/logger/writers/console_writer.h
@@ -82,19 +82,9 @@ protected:
      * @param entry The log entry to write (includes structured fields)
      * @note Called by thread_safe_writer::write(const log_entry&) while holding the mutex
      * @since 3.4.0
+     * @since 3.5.0 This is now the only write implementation (legacy API removed)
      */
     common::VoidResult write_entry_impl(const log_entry& entry) override;
-
-    /**
-     * @brief Implementation of write operation (legacy)
-     * @note Called by thread_safe_writer::write() while holding the mutex
-     */
-    common::VoidResult write_impl(common::interfaces::log_level level,
-                                  const std::string& message,
-                                  const std::string& file,
-                                  int line,
-                                  const std::string& function,
-                                  const std::chrono::system_clock::time_point& timestamp) override;
 
     /**
      * @brief Implementation of flush operation

--- a/include/kcenon/logger/writers/critical_writer.h
+++ b/include/kcenon/logger/writers/critical_writer.h
@@ -123,13 +123,8 @@ public:
     ~critical_writer() override;
 
     /**
-     * @brief Write a log message with critical handling
-     * @param level Log level
-     * @param message Log message
-     * @param file Source file
-     * @param line Source line
-     * @param function Function name
-     * @param timestamp Timestamp
+     * @brief Write a log entry with critical handling
+     * @param entry The log entry to write
      * @return common::VoidResult indicating success or error
      *
      * @details For critical/fatal messages:
@@ -140,15 +135,10 @@ public:
      * - Syncs file descriptor (if configured)
      *
      * For non-critical messages, delegates to wrapped writer normally.
+     *
+     * @since 3.5.0 Changed to use log_entry directly
      */
-    common::VoidResult write(
-        common::interfaces::log_level level,
-        const std::string& message,
-        const std::string& file,
-        int line,
-        const std::string& function,
-        const std::chrono::system_clock::time_point& timestamp
-    ) override;
+    common::VoidResult write(const log_entry& entry) override;
 
     /**
      * @brief Flush all pending messages
@@ -209,21 +199,9 @@ private:
 
     /**
      * @brief Write to write-ahead log
-     * @param level Log level
-     * @param message Message
-     * @param file Source file
-     * @param line Line number
-     * @param function Function name
-     * @param timestamp Timestamp
+     * @param entry Log entry to write to WAL
      */
-    void write_to_wal(
-        common::interfaces::log_level level,
-        const std::string& message,
-        const std::string& file,
-        int line,
-        const std::string& function,
-        const std::chrono::system_clock::time_point& timestamp
-    );
+    void write_to_wal(const log_entry& entry);
 
     /**
      * @brief Force sync of underlying file descriptor
@@ -312,14 +290,13 @@ public:
 
     ~hybrid_writer() override;
 
-    common::VoidResult write(
-        common::interfaces::log_level level,
-        const std::string& message,
-        const std::string& file,
-        int line,
-        const std::string& function,
-        const std::chrono::system_clock::time_point& timestamp
-    ) override;
+    /**
+     * @brief Write a log entry
+     * @param entry The log entry to write
+     * @return common::VoidResult indicating success or error
+     * @since 3.5.0 Changed to use log_entry directly
+     */
+    common::VoidResult write(const log_entry& entry) override;
 
     common::VoidResult flush() override;
     bool is_healthy() const override;

--- a/include/kcenon/logger/writers/encrypted_writer.h
+++ b/include/kcenon/logger/writers/encrypted_writer.h
@@ -258,22 +258,11 @@ public:
 
     /**
      * @brief Write encrypted log entry
-     * @param level Log severity level
-     * @param message Log message text
-     * @param file Source file path
-     * @param line Source line number
-     * @param function Function name
-     * @param timestamp Time when log was created
+     * @param entry The log entry to write
      * @return common::VoidResult Success or error code
+     * @since 3.5.0 Changed to use log_entry directly
      */
-    common::VoidResult write(
-        common::interfaces::log_level level,
-        const std::string& message,
-        const std::string& file,
-        int line,
-        const std::string& function,
-        const std::chrono::system_clock::time_point& timestamp
-    ) override;
+    common::VoidResult write(const log_entry& entry) override;
 
     /**
      * @brief Flush underlying writer

--- a/include/kcenon/logger/writers/file_writer.h
+++ b/include/kcenon/logger/writers/file_writer.h
@@ -70,19 +70,9 @@ protected:
      * @param entry The log entry to write (includes structured fields)
      * @note Called by thread_safe_writer::write(const log_entry&) while holding the mutex
      * @since 3.4.0
+     * @since 3.5.0 This is now the only write implementation (legacy API removed)
      */
     common::VoidResult write_entry_impl(const log_entry& entry) override;
-
-    /**
-     * @brief Implementation of write operation (legacy)
-     * @note Called by thread_safe_writer::write() while holding the mutex
-     */
-    common::VoidResult write_impl(common::interfaces::log_level level,
-                                  const std::string& message,
-                                  const std::string& file,
-                                  int line,
-                                  const std::string& function,
-                                  const std::chrono::system_clock::time_point& timestamp) override;
 
     /**
      * @brief Implementation of flush operation

--- a/include/kcenon/logger/writers/legacy_writer_adapter.h
+++ b/include/kcenon/logger/writers/legacy_writer_adapter.h
@@ -1,0 +1,212 @@
+#pragma once
+
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file legacy_writer_adapter.h
+ * @brief Adapter for legacy writer implementations
+ * @since 3.5.0
+ *
+ * @details This file provides adapter classes for backward compatibility
+ * with legacy writer implementations that use the old parameter-based
+ * write API instead of the modern log_entry-based API.
+ *
+ * @note This adapter is provided for migration purposes. New implementations
+ * should use the modern write(const log_entry&) API directly.
+ */
+
+#include "../interfaces/log_writer_interface.h"
+#include "../interfaces/log_entry.h"
+#include "../interfaces/writer_category.h"
+#include <kcenon/common/patterns/result.h>
+#include <memory>
+#include <string>
+#include <chrono>
+
+namespace kcenon::logger {
+
+/**
+ * @interface legacy_writer_interface
+ * @brief Interface for legacy writer implementations
+ *
+ * @details This interface defines the legacy parameter-based write API.
+ * Implementations of this interface can be wrapped with legacy_writer_adapter
+ * to use them with the modern logging system.
+ *
+ * @deprecated New implementations should directly implement log_writer_interface
+ * using the write(const log_entry&) method.
+ *
+ * @since 3.5.0
+ */
+class legacy_writer_interface {
+public:
+    virtual ~legacy_writer_interface() = default;
+
+    /**
+     * @brief Write a log entry using legacy parameter-based API
+     * @param level Log severity level
+     * @param message Log message text
+     * @param file Source file path (empty if not available)
+     * @param line Source line number (0 if not available)
+     * @param function Function name (empty if not available)
+     * @param timestamp Time when the log entry was created
+     * @return common::VoidResult Success or error code
+     */
+    virtual common::VoidResult write(common::interfaces::log_level level,
+                                     const std::string& message,
+                                     const std::string& file,
+                                     int line,
+                                     const std::string& function,
+                                     const std::chrono::system_clock::time_point& timestamp) = 0;
+
+    /**
+     * @brief Flush any buffered data
+     * @return common::VoidResult Success or error code
+     */
+    virtual common::VoidResult flush() = 0;
+
+    /**
+     * @brief Get the name of this writer
+     * @return Writer name for identification
+     */
+    virtual std::string get_name() const = 0;
+
+    /**
+     * @brief Check if the writer is healthy
+     * @return true if the writer is operational
+     */
+    virtual bool is_healthy() const { return true; }
+};
+
+/**
+ * @class legacy_writer_adapter
+ * @brief Adapter that wraps legacy writers for use with modern API
+ *
+ * @details This adapter converts the modern write(const log_entry&) calls
+ * to the legacy parameter-based API. Use this to integrate existing legacy
+ * writer implementations with the modern logging system.
+ *
+ * Category: Decorator (wraps legacy writer to provide modern API)
+ *
+ * @example Wrapping a legacy writer:
+ * @code
+ * class my_legacy_writer : public legacy_writer_interface {
+ *     common::VoidResult write(common::interfaces::log_level level,
+ *                              const std::string& message, ...) override {
+ *         // Legacy implementation
+ *         return common::ok();
+ *     }
+ *     // ... other methods
+ * };
+ *
+ * auto legacy = std::make_unique<my_legacy_writer>();
+ * auto modern = std::make_unique<legacy_writer_adapter>(std::move(legacy));
+ * logger->add_writer("my_writer", std::move(modern));
+ * @endcode
+ *
+ * @since 3.5.0
+ */
+class legacy_writer_adapter : public log_writer_interface, public decorator_writer_tag {
+public:
+    /**
+     * @brief Construct adapter with legacy writer
+     * @param legacy_writer The legacy writer to wrap
+     * @throws std::invalid_argument if legacy_writer is null
+     */
+    explicit legacy_writer_adapter(std::unique_ptr<legacy_writer_interface> legacy_writer)
+        : legacy_writer_(std::move(legacy_writer))
+    {
+        if (!legacy_writer_) {
+            throw std::invalid_argument("Legacy writer cannot be null");
+        }
+    }
+
+    /**
+     * @brief Write using modern API, delegates to legacy writer
+     * @param entry The log entry to write
+     * @return common::VoidResult Success or error code
+     *
+     * @details Extracts fields from log_entry and delegates to legacy API.
+     * This involves conversion overhead but maintains backward compatibility.
+     */
+    common::VoidResult write(const log_entry& entry) override {
+        // Extract source location if present
+        std::string file = entry.location ? entry.location->file.to_string() : "";
+        int line = entry.location ? entry.location->line : 0;
+        std::string function = entry.location ? entry.location->function.to_string() : "";
+
+        // Convert log_level from logger_system to common::interfaces
+        auto level = static_cast<common::interfaces::log_level>(static_cast<int>(entry.level));
+
+        return legacy_writer_->write(level,
+                                     entry.message.to_string(),
+                                     file,
+                                     line,
+                                     function,
+                                     entry.timestamp);
+    }
+
+    /**
+     * @brief Flush the legacy writer
+     */
+    common::VoidResult flush() override {
+        return legacy_writer_->flush();
+    }
+
+    /**
+     * @brief Get writer name with adapter prefix
+     */
+    std::string get_name() const override {
+        return "legacy_adapter_" + legacy_writer_->get_name();
+    }
+
+    /**
+     * @brief Check if legacy writer is healthy
+     */
+    bool is_healthy() const override {
+        return legacy_writer_->is_healthy();
+    }
+
+    /**
+     * @brief Get access to the underlying legacy writer
+     * @return Non-owning pointer to the legacy writer
+     */
+    legacy_writer_interface* get_legacy_writer() const {
+        return legacy_writer_.get();
+    }
+
+private:
+    std::unique_ptr<legacy_writer_interface> legacy_writer_;
+};
+
+} // namespace kcenon::logger

--- a/include/kcenon/logger/writers/network_writer.h
+++ b/include/kcenon/logger/writers/network_writer.h
@@ -8,6 +8,7 @@ All rights reserved.
 *****************************************************************************/
 
 #include "base_writer.h"
+#include "../interfaces/log_entry.h"
 #include "../interfaces/writer_category.h"
 #include <queue>
 #include <condition_variable>
@@ -58,13 +59,11 @@ public:
     
     /**
      * @brief Write log entry
+     * @param entry The log entry to write
+     * @return common::VoidResult indicating success or error
+     * @since 3.5.0 Changed to use log_entry directly
      */
-    common::VoidResult write(common::interfaces::log_level level,
-                             const std::string& message,
-                             const std::string& file,
-                             int line,
-                             const std::string& function,
-                             const std::chrono::system_clock::time_point& timestamp) override;
+    common::VoidResult write(const log_entry& entry) override;
 
     /**
      * @brief Flush pending logs
@@ -96,15 +95,6 @@ public:
     connection_stats get_stats() const;
     
 private:
-    // Log entry for buffering
-    struct buffered_log {
-        common::interfaces::log_level level;
-        std::string message;
-        std::string file;
-        int line;
-        std::string function;
-        std::chrono::system_clock::time_point timestamp;
-    };
     
     // Network operations
     bool connect();
@@ -114,7 +104,7 @@ private:
     void attempt_reconnect();
     
     // Format log for network transmission
-    std::string format_for_network(const buffered_log& log);
+    std::string format_for_network(const log_entry& entry);
     
 private:
     std::string host_;
@@ -129,7 +119,7 @@ private:
     std::atomic<bool> running_{false};
     
     // Buffering
-    std::queue<buffered_log> buffer_;
+    std::queue<log_entry> buffer_;
     mutable std::mutex buffer_mutex_;
     std::condition_variable buffer_cv_;
     

--- a/include/kcenon/logger/writers/rotating_file_writer.h
+++ b/include/kcenon/logger/writers/rotating_file_writer.h
@@ -107,19 +107,9 @@ protected:
      * @param entry The log entry to write (includes structured fields)
      * @note Called by thread_safe_writer::write(const log_entry&) while holding the mutex
      * @since 3.4.0
+     * @since 3.5.0 This is now the only write implementation (legacy API removed)
      */
     common::VoidResult write_entry_impl(const log_entry& entry) override;
-
-    /**
-     * @brief Implementation of write operation with automatic rotation check (legacy)
-     * @note Called by thread_safe_writer::write() while holding the mutex
-     */
-    common::VoidResult write_impl(common::interfaces::log_level level,
-                                  const std::string& message,
-                                  const std::string& file,
-                                  int line,
-                                  const std::string& function,
-                                  const std::chrono::system_clock::time_point& timestamp) override;
 
 private:
     /**

--- a/include/kcenon/logger/writers/thread_safe_writer.h
+++ b/include/kcenon/logger/writers/thread_safe_writer.h
@@ -133,36 +133,13 @@ public:
      * This method preserves all log entry data including structured fields,
      * OpenTelemetry context, and category information.
      *
-     * @note This is the preferred method for writing logs as it preserves
+     * @note This is the primary method for writing logs. It preserves
      * all structured logging information.
      *
      * @since 3.4.0
+     * @since 3.5.0 This is now the only write method (legacy API removed)
      */
     common::VoidResult write(const log_entry& entry) final;
-
-    /**
-     * @brief Thread-safe write operation (legacy API)
-     * @param level Log severity level
-     * @param message Log message text
-     * @param file Source file path
-     * @param line Source line number
-     * @param function Function name
-     * @param timestamp Time when the log entry was created
-     * @return common::VoidResult Success or error code
-     *
-     * @details Acquires the mutex and delegates to write_impl().
-     * This method is final to ensure thread-safety is not bypassed.
-     *
-     * @note For structured logging, prefer using write(const log_entry&).
-     *
-     * @since 1.3.0
-     */
-    common::VoidResult write(common::interfaces::log_level level,
-                             const std::string& message,
-                             const std::string& file,
-                             int line,
-                             const std::string& function,
-                             const std::chrono::system_clock::time_point& timestamp) final;
 
     /**
      * @brief Thread-safe flush operation
@@ -182,43 +159,15 @@ protected:
      * @return common::VoidResult Success or error code
      *
      * @details Called by write(const log_entry&) while holding the mutex.
-     * Derived classes should override this method to support structured logging.
-     * The default implementation calls the legacy write_impl() for backward
-     * compatibility, but derived classes should override this to preserve
-     * structured fields.
+     * Derived classes must override this method to implement their output logic.
      *
      * @note The mutex is held when this method is called.
      * @note Do not call public methods on 'this' (would cause deadlock).
      *
      * @since 3.4.0
+     * @since 3.5.0 Now pure virtual - implementations must override this
      */
-    virtual common::VoidResult write_entry_impl(const log_entry& entry);
-
-    /**
-     * @brief Implementation of write operation (legacy, override in derived classes)
-     * @param level Log severity level
-     * @param message Log message text
-     * @param file Source file path
-     * @param line Source line number
-     * @param function Function name
-     * @param timestamp Time when the log entry was created
-     * @return common::VoidResult Success or error code
-     *
-     * @details Called by legacy write() while holding the mutex.
-     * Derived classes implement their output-specific logic here.
-     *
-     * @note The mutex is held when this method is called.
-     * @note Do not call public methods on 'this' (would cause deadlock).
-     * @note For structured logging support, override write_entry_impl() instead.
-     *
-     * @since 1.3.0
-     */
-    virtual common::VoidResult write_impl(common::interfaces::log_level level,
-                                          const std::string& message,
-                                          const std::string& file,
-                                          int line,
-                                          const std::string& function,
-                                          const std::chrono::system_clock::time_point& timestamp) = 0;
+    virtual common::VoidResult write_entry_impl(const log_entry& entry) = 0;
 
     /**
      * @brief Implementation of flush operation (override in derived classes)

--- a/src/core/log_collector.cpp
+++ b/src/core/log_collector.cpp
@@ -259,16 +259,10 @@ private:
             }
         }
 
-        // Extract entry fields
-        std::string file = entry.location ? entry.location->file.to_string() : "";
-        int line = entry.location ? entry.location->line : 0;
-        std::string function = entry.location ? entry.location->function.to_string() : "";
-
         // Write to all writers without holding mutex
         for (auto& writer : writers_snapshot) {
             try {
-                writer->write(entry.level, entry.message.to_string(), file,
-                             line, function, entry.timestamp);
+                writer->write(entry);
             } catch (...) {
                 // Swallow exceptions to prevent thread termination
             }
@@ -434,16 +428,10 @@ private:
             }
         }
 
-        // Extract entry fields
-        std::string file = entry.location ? entry.location->file.to_string() : "";
-        int line = entry.location ? entry.location->line : 0;
-        std::string function = entry.location ? entry.location->function.to_string() : "";
-
         // Write to all writers without holding mutex
         for (auto& writer : writers_snapshot) {
             try {
-                writer->write(entry.level, entry.message.to_string(), file,
-                             line, function, entry.timestamp);
+                writer->write(entry);
             } catch (...) {
                 // Swallow exceptions to prevent issues
             }

--- a/src/core/logger.cpp
+++ b/src/core/logger.cpp
@@ -198,10 +198,13 @@ public:
                     local_named_writers = named_writers_;
                 }
 
+                // Create log_entry for routing
+                log_entry entry(level, message, file, line, function, now);
+
                 for (const auto& writer_name : routed_writer_names) {
                     auto it = local_named_writers.find(writer_name);
                     if (it != local_named_writers.end() && it->second) {
-                        it->second->write(level, message, file, line, function, now);
+                        it->second->write(entry);
                     }
                 }
             }
@@ -214,9 +217,12 @@ public:
                 local_writers = writers_;
             }
 
+            // Create log_entry once for all writers
+            log_entry entry(level, message, file, line, function, now);
+
             for (auto& writer : local_writers) {
                 if (writer) {
-                    writer->write(level, message, file, line, function, now);
+                    writer->write(entry);
                 }
             }
         }

--- a/src/impl/async/batch_processor.cpp
+++ b/src/impl/async/batch_processor.cpp
@@ -291,8 +291,11 @@ size_t batch_processor::process_batch(std::vector<batch_entry>& batch) {
 
     size_t processed = 0;
     for (const auto& entry : batch) {
-        auto result = writer_->write(entry.level, entry.message, entry.file,
-                                     entry.line, entry.function, entry.timestamp);
+        // Create log_entry from batch_entry
+        log_entry log_ent(entry.level, entry.message, entry.file,
+                         entry.line, entry.function, entry.timestamp);
+
+        auto result = writer_->write(log_ent);
         if (result.is_ok()) {
             ++processed;
         }

--- a/src/impl/async/high_performance_async_writer.h
+++ b/src/impl/async/high_performance_async_writer.h
@@ -20,6 +20,7 @@ All rights reserved.
 #include "../memory/object_pool.h"
 #include "../memory/log_entry_pool.h"
 #include <kcenon/logger/writers/base_writer.h>
+#include <kcenon/logger/interfaces/log_entry.h>
 #include <kcenon/logger/core/error_codes.h>
 #include <memory>
 #include <thread>
@@ -129,21 +130,12 @@ public:
     void stop(bool flush_remaining = true);
 
     /**
-     * @brief Write a log message asynchronously
-     * @param level Log level
-     * @param message Log message
-     * @param file Source file
-     * @param line Source line
-     * @param function Function name
-     * @param timestamp Timestamp
+     * @brief Write a log entry asynchronously
+     * @param entry The log entry to write
      * @return common::VoidResult indicating success or error
+     * @since 3.5.0 Changed to use log_entry directly
      */
-    common::VoidResult write(common::interfaces::log_level level,
-                             const std::string& message,
-                             const std::string& file,
-                             int line,
-                             const std::string& function,
-                             const std::chrono::system_clock::time_point& timestamp) override;
+    common::VoidResult write(const log_entry& entry) override;
 
     /**
      * @brief Flush all pending messages
@@ -225,12 +217,7 @@ private:
     /**
      * @brief Write directly to the underlying writer (fallback mode)
      */
-    common::VoidResult write_direct(common::interfaces::log_level level,
-                                    const std::string& message,
-                                    const std::string& file,
-                                    int line,
-                                    const std::string& function,
-                                    const std::chrono::system_clock::time_point& timestamp);
+    common::VoidResult write_direct(const log_entry& entry);
 
     /**
      * @brief Update performance statistics

--- a/src/impl/writers/console_writer.cpp
+++ b/src/impl/writers/console_writer.cpp
@@ -108,20 +108,6 @@ common::VoidResult console_writer::write_entry_impl(const log_entry& entry) {
     }, logger_error_code::processing_failed);
 }
 
-common::VoidResult console_writer::write_impl(common::interfaces::log_level level,
-                                              const std::string& message,
-                                              const std::string& file,
-                                              int line,
-                                              const std::string& function,
-                                              const std::chrono::system_clock::time_point& timestamp) {
-    // Legacy API: create a log_entry and delegate to write_entry_impl
-    log_entry entry = (!file.empty() || line != 0 || !function.empty())
-        ? log_entry(level, message, file, line, function, timestamp)
-        : log_entry(level, message, timestamp);
-
-    return write_entry_impl(entry);
-}
-
 common::VoidResult console_writer::flush_impl() {
     // Note: Mutex is already held by thread_safe_writer::flush()
     return utils::try_write_operation([&]() -> common::VoidResult {

--- a/src/impl/writers/file_writer.cpp
+++ b/src/impl/writers/file_writer.cpp
@@ -43,20 +43,6 @@ common::VoidResult file_writer::write_entry_impl(const log_entry& entry) {
     });
 }
 
-common::VoidResult file_writer::write_impl(common::interfaces::log_level level,
-                                           const std::string& message,
-                                           const std::string& file,
-                                           int line,
-                                           const std::string& function,
-                                           const std::chrono::system_clock::time_point& timestamp) {
-    // Legacy API: create a log_entry and delegate to write_entry_impl
-    log_entry entry = (!file.empty() || line != 0 || !function.empty())
-        ? log_entry(level, message, file, line, function, timestamp)
-        : log_entry(level, message, timestamp);
-
-    return write_entry_impl(entry);
-}
-
 common::VoidResult file_writer::flush_impl() {
     // Note: Mutex is already held by thread_safe_writer::flush()
     return utils::try_write_operation([&]() -> common::VoidResult {

--- a/src/impl/writers/rotating_file_writer.cpp
+++ b/src/impl/writers/rotating_file_writer.cpp
@@ -113,20 +113,6 @@ common::VoidResult rotating_file_writer::write_entry_impl(const log_entry& entry
     return common::ok();
 }
 
-common::VoidResult rotating_file_writer::write_impl(common::interfaces::log_level level,
-                                                    const std::string& message,
-                                                    const std::string& file,
-                                                    int line,
-                                                    const std::string& function,
-                                                    const std::chrono::system_clock::time_point& timestamp) {
-    // Legacy API: create a log_entry and delegate to write_entry_impl
-    log_entry entry = (!file.empty() || line != 0 || !function.empty())
-        ? log_entry(level, message, file, line, function, timestamp)
-        : log_entry(level, message, timestamp);
-
-    return write_entry_impl(entry);
-}
-
 void rotating_file_writer::rotate() {
     // Public API for manual rotation
     std::lock_guard<std::mutex> lock(get_mutex());

--- a/src/impl/writers/thread_safe_writer.cpp
+++ b/src/impl/writers/thread_safe_writer.cpp
@@ -44,26 +44,6 @@ common::VoidResult thread_safe_writer::write(const log_entry& entry) {
     return write_entry_impl(entry);
 }
 
-common::VoidResult thread_safe_writer::write(common::interfaces::log_level level,
-                                             const std::string& message,
-                                             const std::string& file,
-                                             int line,
-                                             const std::string& function,
-                                             const std::chrono::system_clock::time_point& timestamp) {
-    std::lock_guard<std::mutex> lock(write_mutex_);
-    return write_impl(level, message, file, line, function, timestamp);
-}
-
-common::VoidResult thread_safe_writer::write_entry_impl(const log_entry& entry) {
-    // Default implementation: delegate to legacy API for backward compatibility
-    std::string file = entry.location ? entry.location->file.to_string() : "";
-    int line = entry.location ? entry.location->line : 0;
-    std::string function = entry.location ? entry.location->function.to_string() : "";
-    // Convert logger_system::log_level to common::interfaces::log_level
-    auto level = static_cast<common::interfaces::log_level>(static_cast<int>(entry.level));
-    return write_impl(level, entry.message.to_string(), file, line, function, entry.timestamp);
-}
-
 common::VoidResult thread_safe_writer::flush() {
     std::lock_guard<std::mutex> lock(write_mutex_);
     return flush_impl();

--- a/tests/log_sampling_test.cpp
+++ b/tests/log_sampling_test.cpp
@@ -58,15 +58,10 @@ public:
         std::string message;
     };
 
-    kcenon::common::VoidResult write(kcenon::common::interfaces::log_level level,
-                                     const std::string& message,
-                                     [[maybe_unused]] const std::string& file,
-                                     [[maybe_unused]] int line,
-                                     [[maybe_unused]] const std::string& function,
-                                     [[maybe_unused]] const std::chrono::system_clock::time_point& timestamp) override {
+    kcenon::common::VoidResult write(const log_entry& entry) override {
         entry_record rec;
-        rec.level = level;
-        rec.message = message;
+        rec.level = static_cast<kcenon::common::interfaces::log_level>(static_cast<int>(entry.level));
+        rec.message = entry.message.to_string();
         records_.push_back(std::move(rec));
         return kcenon::common::ok();
     }

--- a/tests/min_level_filter_test.cpp
+++ b/tests/min_level_filter_test.cpp
@@ -54,18 +54,12 @@ public:
         std::string message;
     };
 
-    // Implement the legacy write interface required by base_writer
-    // Note: base_writer::write uses kcenon::common::interfaces::log_level for backward compatibility
-    kcenon::common::VoidResult write(kcenon::common::interfaces::log_level level,
-                                     const std::string& message,
-                                     [[maybe_unused]] const std::string& file,
-                                     [[maybe_unused]] int line,
-                                     [[maybe_unused]] const std::string& function,
-                                     [[maybe_unused]] const std::chrono::system_clock::time_point& timestamp) override {
+    // Implement the modern write interface required by base_writer
+    kcenon::common::VoidResult write(const kcenon::logger::log_entry& entry) override {
         entry_record rec;
         // Convert to kcenon::common::interfaces::log_level for storage
-        rec.level = static_cast<ci::log_level>(static_cast<int>(level));
-        rec.message = message;
+        rec.level = static_cast<ci::log_level>(static_cast<int>(entry.level));
+        rec.message = entry.message.to_string();
         records_.push_back(std::move(rec));
         return kcenon::common::ok();
     }

--- a/tests/otlp_test.cpp
+++ b/tests/otlp_test.cpp
@@ -291,14 +291,13 @@ TEST_F(OtlpWriterTest, WriteLogsQueued) {
     // Write some logs
     auto now = std::chrono::system_clock::now();
     for (int i = 0; i < 10; ++i) {
-        auto result = writer.write(
-            kcenon::common::interfaces::log_level::info,
-            "Test message " + std::to_string(i),
-            __FILE__,
-            __LINE__,
-            __FUNCTION__,
-            now
-        );
+        log_entry entry(kcenon::common::interfaces::log_level::info,
+                       "Test message " + std::to_string(i),
+                       __FILE__,
+                       __LINE__,
+                       __FUNCTION__,
+                       now);
+        auto result = writer.write(entry);
         EXPECT_TRUE(result.is_ok());
     }
 
@@ -317,14 +316,15 @@ TEST_F(OtlpWriterTest, FlushWritesImmediately) {
 
     // Write and flush
     auto now = std::chrono::system_clock::now();
-    writer.write(
-        kcenon::common::interfaces::log_level::error,
-        "Error message",
-        __FILE__,
-        __LINE__,
-        __FUNCTION__,
-        now
-    );
+    {
+        log_entry entry(kcenon::common::interfaces::log_level::error,
+                       "Error message",
+                       __FILE__,
+                       __LINE__,
+                       __FUNCTION__,
+                       now);
+        writer.write(entry);
+    }
 
     auto result = writer.flush();
     EXPECT_TRUE(result.is_ok());
@@ -348,14 +348,13 @@ TEST_F(OtlpWriterTest, WriteWithOtelContext) {
 
     // Write log - should pick up context
     auto now = std::chrono::system_clock::now();
-    auto result = writer.write(
-        kcenon::common::interfaces::log_level::info,
-        "Message with trace context",
-        __FILE__,
-        __LINE__,
-        __FUNCTION__,
-        now
-    );
+    log_entry entry(kcenon::common::interfaces::log_level::info,
+                   "Message with trace context",
+                   __FILE__,
+                   __LINE__,
+                   __FUNCTION__,
+                   now);
+    auto result = writer.write(entry);
 
     EXPECT_TRUE(result.is_ok());
     writer.flush();
@@ -460,14 +459,13 @@ TEST_F(OtlpWriterTest, ConcurrentWrites) {
         threads.emplace_back([&writer, t]() {
             auto now = std::chrono::system_clock::now();
             for (int i = 0; i < logs_per_thread; ++i) {
-                writer.write(
-                    kcenon::common::interfaces::log_level::info,
-                    "Thread " + std::to_string(t) + " message " + std::to_string(i),
-                    __FILE__,
-                    __LINE__,
-                    __FUNCTION__,
-                    now
-                );
+                log_entry entry(kcenon::common::interfaces::log_level::info,
+                               "Thread " + std::to_string(t) + " message " + std::to_string(i),
+                               __FILE__,
+                               __LINE__,
+                               __FUNCTION__,
+                               now);
+                writer.write(entry);
             }
         });
     }

--- a/tests/structured_logging_test.cpp
+++ b/tests/structured_logging_test.cpp
@@ -36,14 +36,16 @@ namespace {
 // Test writer that captures log output
 class capture_writer : public base_writer {
 public:
-    VoidResult write(kcenon::common::interfaces::log_level level,
-               const std::string& message,
-               const std::string& file,
-               int line,
-               const std::string& function,
-               const std::chrono::system_clock::time_point& timestamp) override {
+    VoidResult write(const log_entry& log_ent) override {
         std::lock_guard<std::mutex> lock(mutex_);
-        entries_.push_back({level, message, file, line, function, timestamp});
+        entries_.push_back({
+            static_cast<kcenon::common::interfaces::log_level>(static_cast<int>(log_ent.level)),
+            log_ent.message.to_string(),
+            log_ent.location ? log_ent.location->file.to_string() : "",
+            log_ent.location ? static_cast<int>(log_ent.location->line) : 0,
+            log_ent.location ? log_ent.location->function.to_string() : "",
+            log_ent.timestamp
+        });
         return ok();
     }
 


### PR DESCRIPTION
## Summary

- Remove legacy 6-parameter `write()` method from `base_writer` and all derived writers
- Keep only modern `write(const log_entry&)` interface
- Create `legacy_writer_adapter` for backward compatibility with existing custom writers

## Changes

### Breaking Changes
- `base_writer::write(const log_entry&)` is now pure virtual
- `thread_safe_writer::write_entry_impl(const log_entry&)` is now pure virtual
- All custom writers must implement `write(const log_entry&)` instead of the legacy 6-parameter method

### New Files
- `legacy_writer_adapter.h`: Provides backward compatibility adapter for legacy writer implementations

### Modified Writers
- Core writers: `console_writer`, `file_writer`, `rotating_file_writer`
- Async/batch writers: `async_writer`, `batch_writer`, `network_writer`
- Decorator writers: `encrypted_writer`, `critical_writer`, `otlp_writer`
- High-performance: `high_performance_async_writer`

### Core Changes
- `logger.cpp`: Creates `log_entry` and passes to writers
- `log_collector.cpp`: Uses `writer->write(entry)` directly
- `batch_processor.cpp`: Creates `log_entry` from `batch_entry`

## Test plan

- [x] Build passes (`cmake --build build --config Release`)
- [x] Tests pass (15/16 - 1 failure is unrelated OpenSSL env issue)
- [x] Existing tests updated to use new API
- [x] Custom writer example updated

## Migration Guide

### Before (Legacy API)
```cpp
class my_writer : public base_writer {
    VoidResult write(log_level level, const std::string& message,
                     const std::string& file, int line,
                     const std::string& function,
                     const time_point& timestamp) override {
        // implementation
    }
};
```

### After (Modern API)
```cpp
class my_writer : public base_writer {
    VoidResult write(const log_entry& entry) override {
        auto level = entry.level;
        auto message = entry.message.to_string();
        auto file = entry.location ? entry.location->file.to_string() : "";
        // implementation
    }
};
```

### Using Legacy Adapter
```cpp
class my_legacy_writer : public legacy_writer_interface {
    // Keep existing implementation
};

auto writer = std::make_unique<legacy_writer_adapter>(
    std::make_unique<my_legacy_writer>());
```

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)