### PR TITLE
refactor(sampling): consolidate sampling configuration methods

### DIFF
--- a/include/kcenon/logger/core/logger_builder.h
+++ b/include/kcenon/logger/core/logger_builder.h
@@ -900,25 +900,27 @@ public:
      * @param always_log_levels Levels that bypass sampling
      * @return Reference to builder for chaining
      *
+     * @deprecated Use with_sampling(sampling_config::random_sampling(rate).with_always_log(levels)) instead
+     *
      * @example
      * @code
      * auto logger = logger_builder()
-     *     .with_random_sampling(0.1)  // 10% sampling
+     *     .with_sampling(sampling::sampling_config::random_sampling(0.1))
      *     .build();
      * @endcode
      *
      * @since 3.3.0
      */
+    [[deprecated("Use with_sampling(sampling_config::random_sampling(rate).with_always_log(levels)) instead")]]
     logger_builder& with_random_sampling(
         double rate,
         std::vector<log_level> always_log_levels = {
             log_level::error,
             log_level::critical
         }) {
-        sampling::sampling_config config = sampling::sampling_config::random_sampling(rate);
-        config.always_log_levels = std::move(always_log_levels);
-        sampler_ = std::make_unique<sampling::log_sampler>(config);
-        return *this;
+        return with_sampling(
+            sampling::sampling_config::random_sampling(rate)
+                .with_always_log(std::move(always_log_levels)));
     }
 
     /**
@@ -927,25 +929,27 @@ public:
      * @param always_log_levels Levels that bypass sampling
      * @return Reference to builder for chaining
      *
+     * @deprecated Use with_sampling(sampling_config::rate_limited(max_per_second).with_always_log(levels)) instead
+     *
      * @example
      * @code
      * auto logger = logger_builder()
-     *     .with_rate_limiting(1000)  // Max 1000 logs/sec
+     *     .with_sampling(sampling::sampling_config::rate_limited(1000))
      *     .build();
      * @endcode
      *
      * @since 3.3.0
      */
+    [[deprecated("Use with_sampling(sampling_config::rate_limited(max_per_second).with_always_log(levels)) instead")]]
     logger_builder& with_rate_limiting(
         std::size_t max_per_second,
         std::vector<log_level> always_log_levels = {
             log_level::error,
             log_level::critical
         }) {
-        sampling::sampling_config config = sampling::sampling_config::rate_limited(max_per_second);
-        config.always_log_levels = std::move(always_log_levels);
-        sampler_ = std::make_unique<sampling::log_sampler>(config);
-        return *this;
+        return with_sampling(
+            sampling::sampling_config::rate_limited(max_per_second)
+                .with_always_log(std::move(always_log_levels)));
     }
 
     /**
@@ -955,15 +959,18 @@ public:
      * @param always_log_levels Levels that bypass sampling
      * @return Reference to builder for chaining
      *
+     * @deprecated Use with_sampling(sampling_config::adaptive(threshold, min_rate).with_always_log(levels)) instead
+     *
      * @example
      * @code
      * auto logger = logger_builder()
-     *     .with_adaptive_sampling(50000, 0.01)  // Adapt when >50k/sec
+     *     .with_sampling(sampling::sampling_config::adaptive(50000, 0.01))
      *     .build();
      * @endcode
      *
      * @since 3.3.0
      */
+    [[deprecated("Use with_sampling(sampling_config::adaptive(threshold, min_rate).with_always_log(levels)) instead")]]
     logger_builder& with_adaptive_sampling(
         std::size_t threshold = 10000,
         double min_rate = 0.01,
@@ -972,10 +979,9 @@ public:
             log_level::error,
             log_level::critical
         }) {
-        sampling::sampling_config config = sampling::sampling_config::adaptive(threshold, min_rate);
-        config.always_log_levels = std::move(always_log_levels);
-        sampler_ = std::make_unique<sampling::log_sampler>(config);
-        return *this;
+        return with_sampling(
+            sampling::sampling_config::adaptive(threshold, min_rate)
+                .with_always_log(std::move(always_log_levels)));
     }
 
     /**

--- a/include/kcenon/logger/sampling/sampling_config.h
+++ b/include/kcenon/logger/sampling/sampling_config.h
@@ -288,6 +288,37 @@ struct sampling_config {
         config.hash_seed = seed;
         return config;
     }
+
+    /**
+     * @brief Set log levels that bypass sampling (fluent interface)
+     * @param levels Log levels that should always be logged
+     * @return Modified configuration for chaining
+     *
+     * @example
+     * @code
+     * auto config = sampling_config::random_sampling(0.1)
+     *     .with_always_log({log_level::warning, log_level::error, log_level::critical});
+     * @endcode
+     *
+     * @since 3.4.0
+     */
+    sampling_config with_always_log(std::vector<log_level> levels) && {
+        always_log_levels = std::move(levels);
+        return std::move(*this);
+    }
+
+    /**
+     * @brief Set log levels that bypass sampling (fluent interface, lvalue overload)
+     * @param levels Log levels that should always be logged
+     * @return Modified configuration for chaining
+     *
+     * @since 3.4.0
+     */
+    sampling_config with_always_log(std::vector<log_level> levels) const & {
+        sampling_config copy = *this;
+        copy.always_log_levels = std::move(levels);
+        return copy;
+    }
 };
 
 /**


### PR DESCRIPTION
Closes #352

## Summary
- Add `with_always_log()` fluent method to `sampling_config` for chaining with factory methods
- Mark `with_random_sampling()`, `with_rate_limiting()`, `with_adaptive_sampling()` as deprecated in `logger_builder`
- Deprecated methods now delegate to `with_sampling()` internally, reducing code duplication

## Migration Guide
```cpp
// Before (deprecated)
auto logger = logger_builder()
    .with_random_sampling(0.1)
    .build();

// After (recommended)
auto logger = logger_builder()
    .with_sampling(sampling::sampling_config::random_sampling(0.1))
    .build();

// With custom always_log levels
auto logger = logger_builder()
    .with_sampling(
        sampling::sampling_config::random_sampling(0.1)
            .with_always_log({log_level::error, log_level::critical}))
    .build();
```

## Test Plan
- [x] All 38 sampling tests pass
- [x] Build succeeds with expected deprecation warnings
- [x] Deprecated methods work correctly via delegation