### PR TITLE
refactor(writers): add filtered_writer decorator for composable filtering

### DIFF
--- a/include/kcenon/logger/writers/filtered_writer.h
+++ b/include/kcenon/logger/writers/filtered_writer.h
@@ -1,0 +1,207 @@
+#pragma once
+
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file filtered_writer.h
+ * @brief Decorator that applies filtering to wrapped log writers
+ * @author kcenon
+ * @since 4.0.0
+ *
+ * @details This file defines the filtered_writer class, a Decorator pattern
+ * implementation that wraps any log_writer_interface and applies a filter
+ * before delegating writes. This enables composable filtering at the writer
+ * level, allowing different filters for different output destinations.
+ *
+ * Part of the Decorator pattern refactoring (#356).
+ *
+ * @example Basic usage:
+ * @code
+ * // Create a file writer that only logs errors
+ * auto writer = std::make_unique<filtered_writer>(
+ *     std::make_unique<file_writer>("errors.log"),
+ *     std::make_unique<level_filter>(log_level::error)
+ * );
+ *
+ * // Compose with other decorators
+ * auto async_filtered = std::make_unique<async_writer>(
+ *     std::make_unique<filtered_writer>(
+ *         std::make_unique<console_writer>(),
+ *         std::make_unique<level_filter>(log_level::warning)
+ *     )
+ * );
+ * @endcode
+ */
+
+#include "../interfaces/log_filter_interface.h"
+#include "../interfaces/log_writer_interface.h"
+#include "../interfaces/writer_category.h"
+
+#include <memory>
+
+namespace kcenon::logger {
+
+/**
+ * @class filtered_writer
+ * @brief Decorator that applies a filter to a wrapped writer
+ *
+ * @details This class implements the Decorator pattern for log writers.
+ * It wraps any log_writer_interface implementation and applies filtering
+ * logic before delegating write operations. Log entries that do not pass
+ * the filter are silently dropped (returning success).
+ *
+ * Key features:
+ * - Composable with any log_writer_interface implementation
+ * - Works with all filter types from log_filter.h
+ * - Can be nested with other decorators (async_writer, batch_writer, etc.)
+ * - Thread-safe if the wrapped writer and filter are thread-safe
+ *
+ * Category: Synchronous (delegates to wrapped writer), Decorator
+ *
+ * @note The filter is evaluated before each write operation.
+ * @note Filtered entries return success (not an error).
+ *
+ * @since 4.0.0
+ */
+class filtered_writer : public log_writer_interface, public decorator_writer_tag {
+public:
+    /**
+     * @brief Construct a filtered writer
+     *
+     * @param wrapped The writer to wrap with filtering
+     * @param filter The filter to apply before writing
+     *
+     * @throws std::invalid_argument if wrapped is nullptr
+     *
+     * @note filter can be nullptr, in which case all entries pass through
+     *
+     * @since 4.0.0
+     */
+    explicit filtered_writer(std::unique_ptr<log_writer_interface> wrapped,
+                             std::unique_ptr<log_filter_interface> filter);
+
+    /**
+     * @brief Destructor
+     */
+    ~filtered_writer() override = default;
+
+    // Non-copyable
+    filtered_writer(const filtered_writer&) = delete;
+    filtered_writer& operator=(const filtered_writer&) = delete;
+
+    // Movable
+    filtered_writer(filtered_writer&&) noexcept = default;
+    filtered_writer& operator=(filtered_writer&&) noexcept = default;
+
+    /**
+     * @brief Write a log entry if it passes the filter
+     *
+     * @param entry The log entry to write
+     * @return common::VoidResult Success if filtered out or written successfully,
+     *         error if write operation fails
+     *
+     * @details If the filter is nullptr or the entry passes the filter,
+     * the entry is delegated to the wrapped writer. If the entry does not
+     * pass the filter, this method returns success without writing.
+     *
+     * @since 4.0.0
+     */
+    common::VoidResult write(const log_entry& entry) override;
+
+    /**
+     * @brief Flush the wrapped writer
+     *
+     * @return common::VoidResult Result from the wrapped writer's flush
+     *
+     * @since 4.0.0
+     */
+    common::VoidResult flush() override;
+
+    /**
+     * @brief Get the name of this writer
+     *
+     * @return String in format "filtered_<wrapped_name>" or
+     *         "filtered(<filter_name>)_<wrapped_name>" if filter has a name
+     *
+     * @since 4.0.0
+     */
+    std::string get_name() const override;
+
+    /**
+     * @brief Check if the writer is healthy
+     *
+     * @return Health status of the wrapped writer
+     *
+     * @since 4.0.0
+     */
+    bool is_healthy() const override;
+
+    /**
+     * @brief Get the current filter
+     *
+     * @return Pointer to the filter (may be nullptr)
+     *
+     * @since 4.0.0
+     */
+    const log_filter_interface* get_filter() const;
+
+    /**
+     * @brief Get the wrapped writer
+     *
+     * @return Pointer to the wrapped writer
+     *
+     * @since 4.0.0
+     */
+    const log_writer_interface* get_wrapped_writer() const;
+
+private:
+    std::unique_ptr<log_writer_interface> wrapped_;
+    std::unique_ptr<log_filter_interface> filter_;
+};
+
+/**
+ * @brief Factory function to create a filtered writer
+ *
+ * @param writer The writer to wrap
+ * @param filter The filter to apply
+ * @return Unique pointer to the filtered writer
+ *
+ * @throws std::invalid_argument if writer is nullptr
+ *
+ * @since 4.0.0
+ */
+std::unique_ptr<filtered_writer> make_filtered_writer(
+    std::unique_ptr<log_writer_interface> writer,
+    std::unique_ptr<log_filter_interface> filter);
+
+}  // namespace kcenon::logger

--- a/src/impl/writers/filtered_writer.cpp
+++ b/src/impl/writers/filtered_writer.cpp
@@ -1,0 +1,94 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/logger/writers/filtered_writer.h>
+
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <stdexcept>
+
+namespace kcenon::logger {
+
+filtered_writer::filtered_writer(std::unique_ptr<log_writer_interface> wrapped,
+                                 std::unique_ptr<log_filter_interface> filter)
+    : wrapped_(std::move(wrapped)), filter_(std::move(filter)) {
+    if (!wrapped_) {
+        throw std::invalid_argument("filtered_writer: wrapped writer cannot be nullptr");
+    }
+}
+
+common::VoidResult filtered_writer::write(const log_entry& entry) {
+    // If no filter, pass through all entries
+    if (!filter_) {
+        return wrapped_->write(entry);
+    }
+
+    // Check if entry passes the filter
+    if (filter_->should_log(entry)) {
+        return wrapped_->write(entry);
+    }
+
+    // Entry filtered out - return success (not an error)
+    return common::ok();
+}
+
+common::VoidResult filtered_writer::flush() {
+    return wrapped_->flush();
+}
+
+std::string filtered_writer::get_name() const {
+    if (filter_) {
+        return "filtered(" + filter_->get_name() + ")_" + wrapped_->get_name();
+    }
+    return "filtered_" + wrapped_->get_name();
+}
+
+bool filtered_writer::is_healthy() const {
+    return wrapped_->is_healthy();
+}
+
+const log_filter_interface* filtered_writer::get_filter() const {
+    return filter_.get();
+}
+
+const log_writer_interface* filtered_writer::get_wrapped_writer() const {
+    return wrapped_.get();
+}
+
+// Factory function
+std::unique_ptr<filtered_writer> make_filtered_writer(
+    std::unique_ptr<log_writer_interface> writer,
+    std::unique_ptr<log_filter_interface> filter) {
+    return std::make_unique<filtered_writer>(std::move(writer), std::move(filter));
+}
+
+}  // namespace kcenon::logger

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -334,6 +334,36 @@ set_target_properties(logger_realtime_analyzer_test PROPERTIES
 
 message(STATUS "Real-time analyzer tests: Added")
 
+# Filtered writer decorator tests (Issue #358 - Decorator pattern refactoring)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/filtered_writer_test.cpp")
+    add_executable(logger_filtered_writer_test
+        unit/writers_test/filtered_writer_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main AND TARGET GTest::gmock)
+        target_link_libraries(logger_filtered_writer_test
+            PRIVATE LoggerSystem GTest::gtest_main GTest::gmock
+        )
+    elseif(TARGET GTest::gtest_main)
+        target_link_libraries(logger_filtered_writer_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_filtered_writer_test
+            PRIVATE LoggerSystem gtest_main gmock
+        )
+    endif()
+
+    add_test(NAME logger_filtered_writer_test
+        COMMAND logger_filtered_writer_test
+    )
+    set_target_properties(logger_filtered_writer_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Filtered writer decorator tests: Added")
+endif()
+
 ##################################################
 # Automatic Coverage Registration
 #
@@ -381,6 +411,10 @@ endif()
 
 if(TARGET logger_executor_integration_test)
     list(APPEND _LOGGER_TEST_TARGETS logger_executor_integration_test)
+endif()
+
+if(TARGET logger_filtered_writer_test)
+    list(APPEND _LOGGER_TEST_TARGETS logger_filtered_writer_test)
 endif()
 
 # Register all test targets for coverage instrumentation

--- a/tests/unit/writers_test/filtered_writer_test.cpp
+++ b/tests/unit/writers_test/filtered_writer_test.cpp
@@ -1,0 +1,385 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <kcenon/logger/writers/filtered_writer.h>
+#include <kcenon/logger/filters/log_filter.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace kcenon::logger;
+using namespace kcenon::logger::filters;
+namespace common = kcenon::common;
+using log_level = common::interfaces::log_level;
+
+/**
+ * @brief Mock writer to track write operations
+ */
+class mock_writer : public log_writer_interface {
+public:
+    mock_writer() = default;
+    ~mock_writer() override = default;
+
+    common::VoidResult write(const log_entry& entry) override {
+        entries_.push_back(entry.message.to_string());
+        levels_.push_back(entry.level);
+        write_count_++;
+        return common::ok();
+    }
+
+    common::VoidResult flush() override {
+        flush_count_++;
+        return common::ok();
+    }
+
+    std::string get_name() const override { return "mock_writer"; }
+
+    bool is_healthy() const override { return healthy_; }
+
+    void set_healthy(bool healthy) { healthy_ = healthy; }
+
+    int write_count() const { return write_count_; }
+    int flush_count() const { return flush_count_; }
+    const std::vector<std::string>& entries() const { return entries_; }
+    const std::vector<log_level>& levels() const { return levels_; }
+
+private:
+    std::vector<std::string> entries_;
+    std::vector<log_level> levels_;
+    int write_count_ = 0;
+    int flush_count_ = 0;
+    bool healthy_ = true;
+};
+
+/**
+ * @brief Test fixture for filtered_writer tests
+ */
+class FilteredWriterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mock_ = std::make_unique<mock_writer>();
+        mock_ptr_ = mock_.get();
+    }
+
+    std::unique_ptr<mock_writer> mock_;
+    mock_writer* mock_ptr_ = nullptr;
+};
+
+/**
+ * @test Verify construction with valid arguments
+ */
+TEST_F(FilteredWriterTest, ConstructorValid) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_NE(writer->get_filter(), nullptr);
+    EXPECT_NE(writer->get_wrapped_writer(), nullptr);
+}
+
+/**
+ * @test Verify construction with nullptr filter passes all entries
+ */
+TEST_F(FilteredWriterTest, ConstructorNullFilter) {
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), nullptr);
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_EQ(writer->get_filter(), nullptr);
+
+    log_entry entry(log_level::debug, "test message");
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+}
+
+/**
+ * @test Verify construction with nullptr writer throws
+ */
+TEST_F(FilteredWriterTest, ConstructorNullWriterThrows) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+
+    EXPECT_THROW(
+        filtered_writer(nullptr, std::move(filter)),
+        std::invalid_argument);
+}
+
+/**
+ * @test Verify level filter passes entries at or above threshold
+ */
+TEST_F(FilteredWriterTest, LevelFilterPassesAboveThreshold) {
+    auto filter = std::make_unique<level_filter>(log_level::warning);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    // Below threshold - should be filtered
+    log_entry debug_entry(log_level::debug, "debug message");
+    auto result1 = writer->write(debug_entry);
+    EXPECT_TRUE(result1.is_ok());
+
+    log_entry info_entry(log_level::info, "info message");
+    auto result2 = writer->write(info_entry);
+    EXPECT_TRUE(result2.is_ok());
+
+    // At or above threshold - should pass
+    log_entry warning_entry(log_level::warning, "warning message");
+    auto result3 = writer->write(warning_entry);
+    EXPECT_TRUE(result3.is_ok());
+
+    log_entry error_entry(log_level::error, "error message");
+    auto result4 = writer->write(error_entry);
+    EXPECT_TRUE(result4.is_ok());
+
+    // Verify only warning and error were written
+    EXPECT_EQ(mock_ptr_->write_count(), 2);
+    ASSERT_EQ(mock_ptr_->levels().size(), 2u);
+    EXPECT_EQ(mock_ptr_->levels()[0], log_level::warning);
+    EXPECT_EQ(mock_ptr_->levels()[1], log_level::error);
+}
+
+/**
+ * @test Verify exact level filter only passes specified level
+ */
+TEST_F(FilteredWriterTest, ExactLevelFilterPassesOnlySpecifiedLevel) {
+    auto filter = std::make_unique<exact_level_filter>(log_level::info);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    log_entry debug_entry(log_level::debug, "debug");
+    writer->write(debug_entry);
+
+    log_entry info_entry(log_level::info, "info");
+    writer->write(info_entry);
+
+    log_entry warning_entry(log_level::warning, "warning");
+    writer->write(warning_entry);
+
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+    ASSERT_EQ(mock_ptr_->levels().size(), 1u);
+    EXPECT_EQ(mock_ptr_->levels()[0], log_level::info);
+}
+
+/**
+ * @test Verify composite AND filter requires all conditions
+ */
+TEST_F(FilteredWriterTest, CompositeAndFilterRequiresAll) {
+    auto composite = std::make_unique<composite_filter>(composite_filter::logic_type::AND);
+    composite->add_filter(std::make_unique<level_filter>(log_level::info));
+
+    // Add a function filter that checks for "important" keyword
+    composite->add_filter(std::make_unique<function_filter>([](const log_entry& e) {
+        return e.message.to_string().find("important") != std::string::npos;
+    }));
+
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(composite));
+
+    // Level OK but no "important" - filtered
+    log_entry entry1(log_level::info, "regular message");
+    writer->write(entry1);
+
+    // Has "important" but level too low - filtered
+    log_entry entry2(log_level::debug, "important debug");
+    writer->write(entry2);
+
+    // Both conditions met - passes
+    log_entry entry3(log_level::info, "important info");
+    writer->write(entry3);
+
+    log_entry entry4(log_level::error, "important error");
+    writer->write(entry4);
+
+    EXPECT_EQ(mock_ptr_->write_count(), 2);
+}
+
+/**
+ * @test Verify composite OR filter passes if any condition met
+ */
+TEST_F(FilteredWriterTest, CompositeOrFilterPassesAny) {
+    auto composite = std::make_unique<composite_filter>(composite_filter::logic_type::OR);
+    composite->add_filter(std::make_unique<exact_level_filter>(log_level::error));
+    composite->add_filter(std::make_unique<function_filter>([](const log_entry& e) {
+        return e.message.to_string().find("urgent") != std::string::npos;
+    }));
+
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(composite));
+
+    // Neither condition - filtered
+    log_entry entry1(log_level::info, "normal message");
+    writer->write(entry1);
+
+    // Error level - passes
+    log_entry entry2(log_level::error, "error message");
+    writer->write(entry2);
+
+    // Has "urgent" - passes
+    log_entry entry3(log_level::debug, "urgent debug");
+    writer->write(entry3);
+
+    // Both conditions - passes
+    log_entry entry4(log_level::error, "urgent error");
+    writer->write(entry4);
+
+    EXPECT_EQ(mock_ptr_->write_count(), 3);
+}
+
+/**
+ * @test Verify flush is delegated to wrapped writer
+ */
+TEST_F(FilteredWriterTest, FlushDelegates) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    auto result = writer->flush();
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->flush_count(), 1);
+}
+
+/**
+ * @test Verify get_name returns appropriate format
+ */
+TEST_F(FilteredWriterTest, GetNameFormat) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    std::string name = writer->get_name();
+
+    EXPECT_TRUE(name.find("filtered") != std::string::npos);
+    EXPECT_TRUE(name.find("mock_writer") != std::string::npos);
+    EXPECT_TRUE(name.find("level_filter") != std::string::npos);
+}
+
+/**
+ * @test Verify get_name with nullptr filter
+ */
+TEST_F(FilteredWriterTest, GetNameNullFilter) {
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), nullptr);
+
+    std::string name = writer->get_name();
+
+    EXPECT_EQ(name, "filtered_mock_writer");
+}
+
+/**
+ * @test Verify is_healthy delegates to wrapped writer
+ */
+TEST_F(FilteredWriterTest, IsHealthyDelegates) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    EXPECT_TRUE(writer->is_healthy());
+
+    mock_ptr_->set_healthy(false);
+    EXPECT_FALSE(writer->is_healthy());
+
+    mock_ptr_->set_healthy(true);
+    EXPECT_TRUE(writer->is_healthy());
+}
+
+/**
+ * @test Verify filtered entries return success (not error)
+ */
+TEST_F(FilteredWriterTest, FilteredEntriesReturnSuccess) {
+    auto filter = std::make_unique<level_filter>(log_level::error);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    // This entry should be filtered out
+    log_entry entry(log_level::debug, "should be filtered");
+    auto result = writer->write(entry);
+
+    // Should return success even though filtered
+    EXPECT_TRUE(result.is_ok());
+    // But nothing was written
+    EXPECT_EQ(mock_ptr_->write_count(), 0);
+}
+
+/**
+ * @test Verify factory function works correctly
+ */
+TEST_F(FilteredWriterTest, FactoryFunction) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+    auto writer = make_filtered_writer(std::move(mock_), std::move(filter));
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_NE(writer->get_filter(), nullptr);
+}
+
+/**
+ * @test Verify category filter works with filtered_writer
+ */
+TEST_F(FilteredWriterTest, CategoryFilter) {
+    auto filter = std::make_unique<category_filter>(
+        std::vector<std::string>{"network", "database"}, true);
+    auto writer = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    // Entry without category - filtered
+    log_entry entry1(log_level::info, "no category");
+    writer->write(entry1);
+
+    // Entry with non-matching category - filtered
+    log_entry entry2(log_level::info, "ui message");
+    entry2.category = "ui";
+    writer->write(entry2);
+
+    // Entry with matching category - passes
+    log_entry entry3(log_level::info, "network message");
+    entry3.category = "network";
+    writer->write(entry3);
+
+    log_entry entry4(log_level::info, "database message");
+    entry4.category = "database";
+    writer->write(entry4);
+
+    EXPECT_EQ(mock_ptr_->write_count(), 2);
+}
+
+/**
+ * @test Verify move semantics work correctly
+ */
+TEST_F(FilteredWriterTest, MoveSemantics) {
+    auto filter = std::make_unique<level_filter>(log_level::info);
+    auto writer1 = std::make_unique<filtered_writer>(std::move(mock_), std::move(filter));
+
+    // Move to another unique_ptr
+    auto writer2 = std::move(writer1);
+
+    EXPECT_NE(writer2, nullptr);
+    EXPECT_EQ(writer1, nullptr);
+
+    log_entry entry(log_level::info, "test");
+    auto result = writer2->write(entry);
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+}


### PR DESCRIPTION
## Summary

Implements the `filtered_writer` decorator class as part of the Decorator pattern refactoring (#356). This decorator wraps any `log_writer_interface` and applies filtering logic before delegating writes.

### Key Features
- **Composable filtering**: Apply any `log_filter_interface` (level, category, composite, function) at the writer level
- **Decorator pattern**: Wraps existing writers without modifying their implementation
- **Graceful filtering**: Filtered entries return success (not an error condition)
- **Full delegation**: Flush and health status are delegated to the wrapped writer
- **Move semantics**: Efficient ownership transfer with move-only design

### Files Changed
- `include/kcenon/logger/writers/filtered_writer.h` - Header with class definition
- `src/impl/writers/filtered_writer.cpp` - Implementation
- `tests/unit/writers_test/filtered_writer_test.cpp` - 15 comprehensive unit tests
- `tests/CMakeLists.txt` - Test target registration

### Usage Example
```cpp
// Create a file writer that only logs errors and above
auto writer = std::make_unique<filtered_writer>(
    std::make_unique<file_writer>("errors.log"),
    std::make_unique<level_filter>(log_level::error)
);

// Compose with async for non-blocking filtered writes
auto async_filtered = std::make_unique<async_writer>(
    std::make_unique<filtered_writer>(
        std::make_unique<console_writer>(),
        std::make_unique<level_filter>(log_level::warning)
    )
);
```

## Test Plan
- [x] All 15 unit tests pass
- [x] Build verification successful
- [x] Tests cover: construction, level filtering, exact level filtering, composite AND/OR filters, flush delegation, health checks, category filtering, move semantics, factory function

Closes #358
Part of #356