### PR TITLE
refactor(cmake): make server and analysis modules optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,3 +401,75 @@ jobs:
           build/Testing/
           build/**/*.log
         retention-days: 7
+
+  # Core-only build test (Issue #357: SRP - ensure core compiles without optional modules)
+  core-only-build:
+    name: Core-Only Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            compiler: gcc
+          - os: macos-14
+            compiler: clang
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        persist-credentials: true
+        clean: true
+        fetch-depth: 1
+
+    - name: Checkout common_system dependency
+      uses: actions/checkout@v4
+      with:
+        repository: kcenon/common_system
+        path: common_system
+
+    - name: Install dependencies (Ubuntu)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt update
+        sudo apt install -y cmake build-essential ninja-build
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install ninja
+
+    - name: Build core-only (without server/analysis modules)
+      run: |
+        mkdir -p build-core-only
+        cd build-core-only
+
+        C_COMPILER="${{ matrix.compiler == 'gcc' && 'gcc' || 'clang' }}"
+        CXX_COMPILER="${{ matrix.compiler == 'gcc' && 'g++' || 'clang++' }}"
+
+        cmake .. \
+          -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTS=OFF \
+          -DBUILD_SAMPLES=OFF \
+          -DLOGGER_WITH_SERVER=OFF \
+          -DLOGGER_WITH_ANALYSIS=OFF \
+          -DUNIFIED_USE_LOCAL=ON \
+          -DCMAKE_C_COMPILER=$C_COMPILER \
+          -DCMAKE_CXX_COMPILER=$CXX_COMPILER
+
+        cmake --build . --parallel
+
+    - name: Verify library was built
+      run: |
+        if [ -f "build-core-only/lib/libLoggerSystem.a" ]; then
+          echo "Core-only build successful!"
+          ls -la build-core-only/lib/
+        else
+          echo "ERROR: libLoggerSystem.a not found"
+          exit 1
+        fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ option(LOGGER_BUILD_INTEGRATION_TESTS "Build integration tests" ON)
 option(LOGGER_ENABLE_COVERAGE "Enable code coverage reporting" OFF)
 option(LOGGER_ENABLE_OTLP "Enable OpenTelemetry (OTLP) integration for observability" OFF)
 
+# Optional module options (Issue #357: SRP - separate server/analysis from core)
+option(LOGGER_WITH_SERVER "Include log server functionality" ON)
+option(LOGGER_WITH_ANALYSIS "Include log analysis functionality" ON)
+
 # C++20 Modules option (requires CMake 3.28+)
 if(LOGGER_CAN_USE_MODULES)
     option(LOGGER_USE_MODULES "Build with C++20 modules support" OFF)
@@ -333,6 +337,28 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
         ${LOGGER_SOURCE_DIR}/*.cpp
     )
 
+    ##################################################
+    # Optional Module Configuration (Issue #357: SRP)
+    ##################################################
+
+    # Filter out server module if disabled
+    if(NOT LOGGER_WITH_SERVER)
+        message(STATUS "Logger System: Server module disabled (LOGGER_WITH_SERVER=OFF)")
+        list(FILTER LOGGER_HEADERS EXCLUDE REGEX ".*/server/.*")
+        # Note: server is header-only, no cpp files to exclude
+    else()
+        message(STATUS "Logger System: Server module enabled")
+    endif()
+
+    # Filter out analysis module if disabled
+    if(NOT LOGGER_WITH_ANALYSIS)
+        message(STATUS "Logger System: Analysis module disabled (LOGGER_WITH_ANALYSIS=OFF)")
+        list(FILTER LOGGER_HEADERS EXCLUDE REGEX ".*/analysis/.*")
+        # Note: analysis is header-only in include/, but has cppm in modules/
+    else()
+        message(STATUS "Logger System: Analysis module enabled")
+    endif()
+
     # Check if we have enough sources in new structure
     list(LENGTH LOGGER_SOURCES SOURCE_COUNT)
     if(SOURCE_COUNT GREATER 5)
@@ -343,6 +369,15 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
                 $<BUILD_INTERFACE:${LOGGER_INCLUDE_DIR}>
                 $<INSTALL_INTERFACE:include>
         )
+
+        # Optional module compile definitions (Issue #357: SRP)
+        if(LOGGER_WITH_SERVER)
+            target_compile_definitions(LoggerSystem PUBLIC LOGGER_WITH_SERVER=1)
+        endif()
+
+        if(LOGGER_WITH_ANALYSIS)
+            target_compile_definitions(LoggerSystem PUBLIC LOGGER_WITH_ANALYSIS=1)
+        endif()
 
         # Suppress warnings inherited from parent project
         if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -439,13 +474,19 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
         if(LOGGER_USE_MODULES AND LOGGER_CAN_USE_MODULES)
             message(STATUS "Logger System: Configuring C++20 module files")
 
-            # Module source files
+            # Module source files (core modules always included)
             set(LOGGER_MODULE_FILES
                 ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/logger.cppm
                 ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/core.cppm
                 ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/backends.cppm
-                ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/analysis.cppm
             )
+
+            # Conditionally include analysis module (Issue #357: SRP)
+            if(LOGGER_WITH_ANALYSIS)
+                list(APPEND LOGGER_MODULE_FILES
+                    ${CMAKE_CURRENT_SOURCE_DIR}/src/modules/analysis.cppm
+                )
+            endif()
 
             # Check if module files exist
             set(MODULES_AVAILABLE TRUE)

--- a/include/kcenon/logger/core/logger.h
+++ b/include/kcenon/logger/core/logger.h
@@ -129,9 +129,11 @@ class base_writer;
 class logger_metrics_collector;
 class log_filter_interface;  // Forward declaration for filtering system
 
+#ifdef LOGGER_WITH_ANALYSIS
 namespace analysis {
 class realtime_log_analyzer;
 }  // namespace analysis
+#endif  // LOGGER_WITH_ANALYSIS
 
 namespace sampling {
 class log_sampler;
@@ -550,9 +552,10 @@ public:
     bool has_routing() const;
 
     // =========================================================================
-    // Real-time analysis
+    // Real-time analysis (optional, requires LOGGER_WITH_ANALYSIS)
     // =========================================================================
 
+#ifdef LOGGER_WITH_ANALYSIS
     /**
      * @brief Set real-time log analyzer for anomaly detection
      * @param analyzer The analyzer instance
@@ -560,6 +563,8 @@ public:
      * @details Sets a real-time analyzer that processes each log entry
      * for anomaly detection. The analyzer is invoked synchronously during
      * log processing.
+     *
+     * @note This API is only available when LOGGER_WITH_ANALYSIS is defined.
      *
      * @example
      * @code
@@ -579,6 +584,8 @@ public:
      * @brief Get the real-time analyzer (if set)
      * @return Pointer to analyzer or nullptr if not set
      *
+     * @note This API is only available when LOGGER_WITH_ANALYSIS is defined.
+     *
      * @since 3.2.0
      */
     [[nodiscard]] analysis::realtime_log_analyzer* get_realtime_analyzer();
@@ -586,6 +593,8 @@ public:
     /**
      * @brief Get the real-time analyzer (const version)
      * @return Pointer to analyzer or nullptr if not set
+     *
+     * @note This API is only available when LOGGER_WITH_ANALYSIS is defined.
      *
      * @since 3.2.0
      */
@@ -595,9 +604,12 @@ public:
      * @brief Check if real-time analysis is enabled
      * @return true if a realtime analyzer is set
      *
+     * @note This API is only available when LOGGER_WITH_ANALYSIS is defined.
+     *
      * @since 3.2.0
      */
     [[nodiscard]] bool has_realtime_analysis() const;
+#endif  // LOGGER_WITH_ANALYSIS
 
     // =========================================================================
     // OpenTelemetry context management


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of issue #357 - making server and analysis modules optional through CMake build options.

### Changes

- Add `LOGGER_WITH_SERVER` CMake option (default: ON) to enable/disable server module
- Add `LOGGER_WITH_ANALYSIS` CMake option (default: ON) to enable/disable analysis module
- Filter header files based on enabled module options
- Add compile definitions for conditional compilation in C++ code
- Wrap analysis-related API in `logger.h` with `#ifdef LOGGER_WITH_ANALYSIS` guards
- Wrap analysis-related implementation in `logger.cpp` with conditional compilation
- Add CI workflow job `core-only-build` to verify core-only builds on Ubuntu and macOS

### Usage

Build with all modules (default behavior - no change):
```bash
cmake -B build
cmake --build build
```

Build core-only library (minimal footprint):
```bash
cmake -B build -DLOGGER_WITH_SERVER=OFF -DLOGGER_WITH_ANALYSIS=OFF
cmake --build build
```

### Benefits

- **Single Responsibility**: Core logger focuses only on logging functionality
- **Reduced footprint**: Users needing only basic logging get a smaller library
- **Backward compatible**: Default behavior unchanged (all modules enabled)
- **Clear API boundaries**: Conditional compilation makes module dependencies explicit

Closes #357

## Test Plan

- [x] Core-only build compiles successfully (`-DLOGGER_WITH_SERVER=OFF -DLOGGER_WITH_ANALYSIS=OFF`)
- [x] Full build compiles successfully (default options)
- [x] Existing tests pass with full build
- [x] CI job added to continuously verify core-only builds