### PR TITLE
refactor(writers): add decorator_writer_base class for common decorator logic

### DIFF
--- a/include/kcenon/logger/writers/decorator_writer_base.h
+++ b/include/kcenon/logger/writers/decorator_writer_base.h
@@ -1,0 +1,215 @@
+#pragma once
+
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file decorator_writer_base.h
+ * @brief Base class for decorator pattern writers
+ * @author kcenon
+ * @since 4.0.0
+ *
+ * @details This file defines decorator_writer_base, a common base class for
+ * all decorator pattern implementations in the writer hierarchy. It eliminates
+ * code duplication across decorator writers by providing default implementations
+ * for wrapped writer management, health status propagation, name delegation,
+ * and flush operations.
+ *
+ * Part of the Decorator pattern refactoring (#356).
+ *
+ * @example Basic usage:
+ * @code
+ * // Create a custom decorator by inheriting from decorator_writer_base
+ * class my_decorator : public decorator_writer_base {
+ * public:
+ *     explicit my_decorator(std::unique_ptr<log_writer_interface> wrapped)
+ *         : decorator_writer_base(std::move(wrapped), "my_decorator") {}
+ *
+ *     common::VoidResult write(const log_entry& entry) override {
+ *         // Add custom behavior before/after delegation
+ *         return wrapped().write(entry);
+ *     }
+ * };
+ * @endcode
+ */
+
+#include "../interfaces/log_writer_interface.h"
+#include "../interfaces/writer_category.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace kcenon::logger {
+
+/**
+ * @class decorator_writer_base
+ * @brief Abstract base class for decorator pattern log writers
+ *
+ * @details This class provides common functionality for all decorator writers:
+ * - Wrapped writer storage and lifecycle management
+ * - Default implementations for get_name(), is_healthy(), and flush()
+ * - Protected access to wrapped writer for derived classes
+ *
+ * Derived classes only need to implement write() with their specific behavior.
+ *
+ * Key features:
+ * - Accepts any log_writer_interface implementation (not just base_writer)
+ * - Enables unlimited decorator stacking
+ * - Thread-safety depends on the wrapped writer
+ * - Follows Liskov Substitution Principle
+ *
+ * Category: Decorator (wraps another writer)
+ *
+ * @note This is an abstract class; derived classes must implement write().
+ *
+ * @since 4.0.0
+ */
+class decorator_writer_base : public log_writer_interface, public decorator_writer_tag {
+public:
+    /**
+     * @brief Construct a decorator writer base
+     *
+     * @param wrapped The writer to wrap with this decorator
+     * @param decorator_name Name prefix for this decorator (e.g., "async", "filtered")
+     *
+     * @throws std::invalid_argument if wrapped is nullptr
+     *
+     * @since 4.0.0
+     */
+    explicit decorator_writer_base(std::unique_ptr<log_writer_interface> wrapped,
+                                   std::string_view decorator_name);
+
+    /**
+     * @brief Virtual destructor for proper cleanup
+     */
+    ~decorator_writer_base() override = default;
+
+    // Non-copyable
+    decorator_writer_base(const decorator_writer_base&) = delete;
+    decorator_writer_base& operator=(const decorator_writer_base&) = delete;
+
+    // Movable
+    decorator_writer_base(decorator_writer_base&&) noexcept = default;
+    decorator_writer_base& operator=(decorator_writer_base&&) noexcept = default;
+
+    /**
+     * @brief Write a log entry (must be implemented by derived classes)
+     *
+     * @param entry The log entry to write
+     * @return common::VoidResult indicating success or failure
+     *
+     * @since 4.0.0
+     */
+    common::VoidResult write(const log_entry& entry) override = 0;
+
+    /**
+     * @brief Flush the wrapped writer
+     *
+     * @return common::VoidResult from the wrapped writer's flush operation
+     *
+     * @details Default implementation delegates to wrapped writer.
+     * Override if additional flush behavior is needed.
+     *
+     * @since 4.0.0
+     */
+    common::VoidResult flush() override;
+
+    /**
+     * @brief Get the name of this writer
+     *
+     * @return String in format "<decorator_name>_<wrapped_name>"
+     *
+     * @details Default implementation combines decorator name with wrapped
+     * writer's name. Override for custom naming behavior.
+     *
+     * @since 4.0.0
+     */
+    std::string get_name() const override;
+
+    /**
+     * @brief Check if the writer is healthy
+     *
+     * @return Health status of the wrapped writer
+     *
+     * @details Default implementation delegates to wrapped writer.
+     * Override to add additional health checks.
+     *
+     * @since 4.0.0
+     */
+    bool is_healthy() const override;
+
+    /**
+     * @brief Get the wrapped writer (const version)
+     *
+     * @return Const pointer to the wrapped writer
+     *
+     * @since 4.0.0
+     */
+    const log_writer_interface* get_wrapped_writer() const noexcept;
+
+protected:
+    /**
+     * @brief Access the wrapped writer (non-const)
+     *
+     * @return Reference to the wrapped writer
+     *
+     * @note Use this in derived classes to delegate operations
+     *
+     * @since 4.0.0
+     */
+    log_writer_interface& wrapped() noexcept;
+
+    /**
+     * @brief Access the wrapped writer (const)
+     *
+     * @return Const reference to the wrapped writer
+     *
+     * @since 4.0.0
+     */
+    const log_writer_interface& wrapped() const noexcept;
+
+    /**
+     * @brief Get the decorator name
+     *
+     * @return The decorator name string
+     *
+     * @since 4.0.0
+     */
+    const std::string& decorator_name() const noexcept;
+
+private:
+    std::unique_ptr<log_writer_interface> wrapped_;
+    std::string decorator_name_;
+};
+
+}  // namespace kcenon::logger

--- a/src/impl/writers/decorator_writer_base.cpp
+++ b/src/impl/writers/decorator_writer_base.cpp
@@ -1,0 +1,82 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file decorator_writer_base.cpp
+ * @brief Implementation of decorator_writer_base
+ * @author kcenon
+ * @since 4.0.0
+ */
+
+#include <kcenon/logger/writers/decorator_writer_base.h>
+
+#include <stdexcept>
+
+namespace kcenon::logger {
+
+decorator_writer_base::decorator_writer_base(std::unique_ptr<log_writer_interface> wrapped,
+                                             std::string_view decorator_name)
+    : wrapped_(std::move(wrapped)), decorator_name_(decorator_name) {
+    if (!wrapped_) {
+        throw std::invalid_argument("decorator_writer_base: wrapped writer cannot be nullptr");
+    }
+}
+
+common::VoidResult decorator_writer_base::flush() {
+    return wrapped_->flush();
+}
+
+std::string decorator_writer_base::get_name() const {
+    return decorator_name_ + "_" + wrapped_->get_name();
+}
+
+bool decorator_writer_base::is_healthy() const {
+    return wrapped_->is_healthy();
+}
+
+const log_writer_interface* decorator_writer_base::get_wrapped_writer() const noexcept {
+    return wrapped_.get();
+}
+
+log_writer_interface& decorator_writer_base::wrapped() noexcept {
+    return *wrapped_;
+}
+
+const log_writer_interface& decorator_writer_base::wrapped() const noexcept {
+    return *wrapped_;
+}
+
+const std::string& decorator_writer_base::decorator_name() const noexcept {
+    return decorator_name_;
+}
+
+}  // namespace kcenon::logger

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -364,6 +364,32 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/filtered_writer_test.cp
     message(STATUS "Filtered writer decorator tests: Added")
 endif()
 
+# Decorator writer base tests (Issue #361 - Decorator pattern refactoring Part 1)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/decorator_writer_base_test.cpp")
+    add_executable(logger_decorator_writer_base_test
+        unit/writers_test/decorator_writer_base_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_decorator_writer_base_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_decorator_writer_base_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_decorator_writer_base_test
+        COMMAND logger_decorator_writer_base_test
+    )
+    set_target_properties(logger_decorator_writer_base_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Decorator writer base tests: Added")
+endif()
+
 ##################################################
 # Automatic Coverage Registration
 #
@@ -415,6 +441,10 @@ endif()
 
 if(TARGET logger_filtered_writer_test)
     list(APPEND _LOGGER_TEST_TARGETS logger_filtered_writer_test)
+endif()
+
+if(TARGET logger_decorator_writer_base_test)
+    list(APPEND _LOGGER_TEST_TARGETS logger_decorator_writer_base_test)
 endif()
 
 # Register all test targets for coverage instrumentation

--- a/tests/unit/writers_test/decorator_writer_base_test.cpp
+++ b/tests/unit/writers_test/decorator_writer_base_test.cpp
@@ -1,0 +1,363 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file decorator_writer_base_test.cpp
+ * @brief Unit tests for decorator_writer_base class
+ * @author kcenon
+ * @since 4.0.0
+ *
+ * Part of the Decorator pattern refactoring (#356, #361).
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/writers/decorator_writer_base.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/logger/interfaces/writer_category.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace kcenon::logger;
+namespace common = kcenon::common;
+using log_level = common::interfaces::log_level;
+
+/**
+ * @brief Mock writer to track operations for testing
+ */
+class mock_writer : public log_writer_interface {
+public:
+    mock_writer() = default;
+    ~mock_writer() override = default;
+
+    common::VoidResult write(const log_entry& entry) override {
+        entries_.push_back(entry.message.to_string());
+        write_count_++;
+        return common::ok();
+    }
+
+    common::VoidResult flush() override {
+        flush_count_++;
+        return common::ok();
+    }
+
+    std::string get_name() const override { return "mock_writer"; }
+
+    bool is_healthy() const override { return healthy_; }
+
+    void set_healthy(bool healthy) { healthy_ = healthy; }
+
+    int write_count() const { return write_count_; }
+    int flush_count() const { return flush_count_; }
+    const std::vector<std::string>& entries() const { return entries_; }
+
+private:
+    std::vector<std::string> entries_;
+    int write_count_ = 0;
+    int flush_count_ = 0;
+    bool healthy_ = true;
+};
+
+/**
+ * @brief Concrete test decorator implementation
+ *
+ * This class demonstrates how to create a decorator using decorator_writer_base.
+ * It simply delegates all writes with an optional prefix.
+ */
+class test_decorator : public decorator_writer_base {
+public:
+    explicit test_decorator(std::unique_ptr<log_writer_interface> wrapped,
+                            std::string prefix = "")
+        : decorator_writer_base(std::move(wrapped), "test")
+        , prefix_(std::move(prefix)) {}
+
+    common::VoidResult write(const log_entry& entry) override {
+        if (prefix_.empty()) {
+            return wrapped().write(entry);
+        }
+
+        // Create a new entry with prefixed message (log_entry is non-copyable)
+        log_entry prefixed_entry(entry.level, prefix_ + entry.message.to_string());
+        prefixed_entry.category = entry.category;
+        prefixed_entry.location = entry.location;
+        return wrapped().write(prefixed_entry);
+    }
+
+private:
+    std::string prefix_;
+};
+
+/**
+ * @brief Decorator that tracks additional health state
+ */
+class health_tracking_decorator : public decorator_writer_base {
+public:
+    explicit health_tracking_decorator(std::unique_ptr<log_writer_interface> wrapped)
+        : decorator_writer_base(std::move(wrapped), "health_tracking")
+        , self_healthy_(true) {}
+
+    common::VoidResult write(const log_entry& entry) override {
+        return wrapped().write(entry);
+    }
+
+    bool is_healthy() const override {
+        // Combine self health with wrapped health
+        return self_healthy_ && decorator_writer_base::is_healthy();
+    }
+
+    void set_self_healthy(bool healthy) { self_healthy_ = healthy; }
+
+private:
+    bool self_healthy_;
+};
+
+/**
+ * @brief Test fixture for decorator_writer_base tests
+ */
+class DecoratorWriterBaseTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mock_ = std::make_unique<mock_writer>();
+        mock_ptr_ = mock_.get();
+    }
+
+    std::unique_ptr<mock_writer> mock_;
+    mock_writer* mock_ptr_ = nullptr;
+};
+
+/**
+ * @test Verify construction with valid arguments
+ */
+TEST_F(DecoratorWriterBaseTest, ConstructorValid) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_));
+
+    EXPECT_NE(decorator, nullptr);
+    EXPECT_NE(decorator->get_wrapped_writer(), nullptr);
+}
+
+/**
+ * @test Verify construction with nullptr throws
+ */
+TEST_F(DecoratorWriterBaseTest, ConstructorNullWriterThrows) {
+    EXPECT_THROW(
+        test_decorator(nullptr),
+        std::invalid_argument);
+}
+
+/**
+ * @test Verify get_name returns correct format
+ */
+TEST_F(DecoratorWriterBaseTest, GetNameFormat) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_));
+
+    std::string name = decorator->get_name();
+
+    EXPECT_EQ(name, "test_mock_writer");
+}
+
+/**
+ * @test Verify nested decorators produce correct name chain
+ */
+TEST_F(DecoratorWriterBaseTest, NestedDecoratorNames) {
+    auto inner = std::make_unique<test_decorator>(std::move(mock_));
+    auto outer = std::make_unique<health_tracking_decorator>(std::move(inner));
+
+    std::string name = outer->get_name();
+
+    EXPECT_EQ(name, "health_tracking_test_mock_writer");
+}
+
+/**
+ * @test Verify is_healthy delegates to wrapped writer
+ */
+TEST_F(DecoratorWriterBaseTest, IsHealthyDelegates) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_));
+
+    EXPECT_TRUE(decorator->is_healthy());
+
+    mock_ptr_->set_healthy(false);
+    EXPECT_FALSE(decorator->is_healthy());
+
+    mock_ptr_->set_healthy(true);
+    EXPECT_TRUE(decorator->is_healthy());
+}
+
+/**
+ * @test Verify is_healthy can be overridden for composite health
+ */
+TEST_F(DecoratorWriterBaseTest, IsHealthyOverridable) {
+    auto decorator = std::make_unique<health_tracking_decorator>(std::move(mock_));
+
+    // Both healthy
+    EXPECT_TRUE(decorator->is_healthy());
+
+    // Self unhealthy, wrapped healthy
+    decorator->set_self_healthy(false);
+    EXPECT_FALSE(decorator->is_healthy());
+
+    // Self healthy, wrapped unhealthy
+    decorator->set_self_healthy(true);
+    mock_ptr_->set_healthy(false);
+    EXPECT_FALSE(decorator->is_healthy());
+
+    // Both unhealthy
+    decorator->set_self_healthy(false);
+    EXPECT_FALSE(decorator->is_healthy());
+}
+
+/**
+ * @test Verify flush delegates to wrapped writer
+ */
+TEST_F(DecoratorWriterBaseTest, FlushDelegates) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_));
+
+    auto result = decorator->flush();
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->flush_count(), 1);
+}
+
+/**
+ * @test Verify write is delegated through decorated write()
+ */
+TEST_F(DecoratorWriterBaseTest, WriteDelegates) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_));
+
+    log_entry entry(log_level::info, "test message");
+    auto result = decorator->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+    ASSERT_EQ(mock_ptr_->entries().size(), 1u);
+    EXPECT_EQ(mock_ptr_->entries()[0], "test message");
+}
+
+/**
+ * @test Verify decorator can modify entries
+ */
+TEST_F(DecoratorWriterBaseTest, DecoratorCanModifyEntries) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_), "[PREFIX] ");
+
+    log_entry entry(log_level::info, "original");
+    auto result = decorator->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    ASSERT_EQ(mock_ptr_->entries().size(), 1u);
+    EXPECT_EQ(mock_ptr_->entries()[0], "[PREFIX] original");
+}
+
+/**
+ * @test Verify get_wrapped_writer returns correct pointer
+ */
+TEST_F(DecoratorWriterBaseTest, GetWrappedWriter) {
+    auto decorator = std::make_unique<test_decorator>(std::move(mock_));
+
+    const log_writer_interface* wrapped = decorator->get_wrapped_writer();
+
+    EXPECT_EQ(wrapped, mock_ptr_);
+}
+
+/**
+ * @test Verify decorator has decorator_writer_tag
+ */
+TEST_F(DecoratorWriterBaseTest, HasDecoratorWriterTag) {
+    // Verify type trait works
+    EXPECT_TRUE(is_decorator_writer_v<test_decorator>);
+    EXPECT_TRUE(is_decorator_writer_v<health_tracking_decorator>);
+}
+
+/**
+ * @test Verify move semantics work correctly
+ */
+TEST_F(DecoratorWriterBaseTest, MoveSemantics) {
+    auto decorator1 = std::make_unique<test_decorator>(std::move(mock_));
+
+    auto decorator2 = std::move(decorator1);
+
+    EXPECT_NE(decorator2, nullptr);
+    EXPECT_EQ(decorator1, nullptr);
+
+    log_entry entry(log_level::info, "test");
+    auto result = decorator2->write(entry);
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+}
+
+/**
+ * @test Verify decorator stacking works
+ */
+TEST_F(DecoratorWriterBaseTest, DecoratorStacking) {
+    auto level1 = std::make_unique<test_decorator>(std::move(mock_), "[L1] ");
+    auto level2 = std::make_unique<test_decorator>(std::move(level1), "[L2] ");
+    auto level3 = std::make_unique<test_decorator>(std::move(level2), "[L3] ");
+
+    log_entry entry(log_level::info, "msg");
+    auto result = level3->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    ASSERT_EQ(mock_ptr_->entries().size(), 1u);
+    // Each decorator adds its prefix, innermost decorator applies first
+    EXPECT_EQ(mock_ptr_->entries()[0], "[L1] [L2] [L3] msg");
+
+    // Verify name chain
+    EXPECT_EQ(level3->get_name(), "test_test_test_mock_writer");
+}
+
+/**
+ * @test Verify flush propagates through decorator chain
+ */
+TEST_F(DecoratorWriterBaseTest, FlushPropagatesThroughChain) {
+    auto level1 = std::make_unique<test_decorator>(std::move(mock_));
+    auto level2 = std::make_unique<test_decorator>(std::move(level1));
+    auto level3 = std::make_unique<test_decorator>(std::move(level2));
+
+    auto result = level3->flush();
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->flush_count(), 1);
+}
+
+/**
+ * @test Verify is_healthy propagates through decorator chain
+ */
+TEST_F(DecoratorWriterBaseTest, HealthPropagatesThroughChain) {
+    auto level1 = std::make_unique<test_decorator>(std::move(mock_));
+    auto level2 = std::make_unique<test_decorator>(std::move(level1));
+    auto level3 = std::make_unique<test_decorator>(std::move(level2));
+
+    EXPECT_TRUE(level3->is_healthy());
+
+    mock_ptr_->set_healthy(false);
+    EXPECT_FALSE(level3->is_healthy());
+}


### PR DESCRIPTION
## Summary

- Create `decorator_writer_base` class as common base for all decorator pattern writers
- Add unit tests for the new base class
- Update CMakeLists.txt to include new test target

## Background

This is **Part 1** of the Decorator pattern refactoring effort (#356). Current decorator implementations (`async_writer`, `batch_writer`, `filtered_writer`, `encrypted_writer`) independently manage wrapped writer storage, health status propagation, name delegation, and flush operations. This results in ~50 lines of duplicated code per decorator.

## Changes

### New Files
- `include/kcenon/logger/writers/decorator_writer_base.h` - Header with class declaration
- `src/impl/writers/decorator_writer_base.cpp` - Implementation
- `tests/unit/writers_test/decorator_writer_base_test.cpp` - Unit tests

### Key Features
- Wrapped writer storage and lifecycle management via `std::unique_ptr<log_writer_interface>`
- Default implementations for `get_name()`, `is_healthy()`, and `flush()`
- Protected `wrapped()` accessor for derived classes
- Accepts any `log_writer_interface` (not just `base_writer`) for unlimited decorator stacking
- Tagged with `decorator_writer_tag` for type trait support

### Usage Example
```cpp
class my_decorator : public decorator_writer_base {
public:
    explicit my_decorator(std::unique_ptr<log_writer_interface> wrapped)
        : decorator_writer_base(std::move(wrapped), "my_decorator") {}

    common::VoidResult write(const log_entry& entry) override {
        // Add custom behavior before/after delegation
        return wrapped().write(entry);
    }
};
```

## Test Plan
- [x] Unit tests for `decorator_writer_base` class
- [x] Build passes on macOS (local verification)
- [x] All existing tests pass (except pre-existing `encrypted_writer_test` failures)

## Related Issues
- Closes #361
- Part of #356

## Next Steps (Future PRs)
- Part 2: Migrate existing decorators (`filtered_writer`, etc.) to use `decorator_writer_base`
- Part 3: Simplify leaf writers and update `logger_builder`