### PR TITLE
refactor(writers): add formatted_writer decorator for composable formatting

### DIFF
--- a/include/kcenon/logger/writers/formatted_writer.h
+++ b/include/kcenon/logger/writers/formatted_writer.h
@@ -1,0 +1,209 @@
+#pragma once
+
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file formatted_writer.h
+ * @brief Decorator that applies formatting to wrapped log writers
+ * @author kcenon
+ * @since 4.0.0
+ *
+ * @details This file defines the formatted_writer class, a Decorator pattern
+ * implementation that wraps any log_writer_interface and applies a formatter
+ * before delegating writes. This enables composable formatting at the writer
+ * level, allowing different formats for different output destinations.
+ *
+ * Part of the Decorator pattern refactoring (#356).
+ *
+ * @example Basic usage:
+ * @code
+ * // Create a file writer with JSON formatting
+ * auto writer = std::make_unique<formatted_writer>(
+ *     std::make_unique<file_writer>("app.log"),
+ *     std::make_unique<json_formatter>()
+ * );
+ *
+ * // Compose with other decorators
+ * auto filtered_formatted = std::make_unique<filtered_writer>(
+ *     std::make_unique<formatted_writer>(
+ *         std::make_unique<file_writer>("errors.json"),
+ *         std::make_unique<json_formatter>()
+ *     ),
+ *     std::make_unique<level_filter>(log_level::error)
+ * );
+ * @endcode
+ */
+
+#include "../interfaces/log_formatter_interface.h"
+#include "../interfaces/log_writer_interface.h"
+#include "../interfaces/writer_category.h"
+
+#include <memory>
+
+namespace kcenon::logger {
+
+/**
+ * @class formatted_writer
+ * @brief Decorator that applies a formatter to a wrapped writer
+ *
+ * @details This class implements the Decorator pattern for log writers.
+ * It wraps any log_writer_interface implementation and applies formatting
+ * logic before delegating write operations. The formatted message is stored
+ * in the log entry before passing it to the wrapped writer.
+ *
+ * Key features:
+ * - Composable with any log_writer_interface implementation
+ * - Works with all formatter types (json_formatter, timestamp_formatter, etc.)
+ * - Can be nested with other decorators (filtered_writer, buffered_writer, etc.)
+ * - Thread-safe if the wrapped writer and formatter are thread-safe
+ *
+ * Category: Synchronous (delegates to wrapped writer), Decorator
+ *
+ * @note The formatter is evaluated before each write operation.
+ * @note If no formatter is provided, entries pass through unchanged.
+ *
+ * @since 4.0.0
+ */
+class formatted_writer : public log_writer_interface, public decorator_writer_tag {
+public:
+    /**
+     * @brief Construct a formatted writer
+     *
+     * @param wrapped The writer to wrap with formatting
+     * @param formatter The formatter to apply before writing
+     *
+     * @throws std::invalid_argument if wrapped is nullptr
+     *
+     * @note formatter can be nullptr, in which case all entries pass through unchanged
+     *
+     * @since 4.0.0
+     */
+    explicit formatted_writer(std::unique_ptr<log_writer_interface> wrapped,
+                              std::unique_ptr<log_formatter_interface> formatter);
+
+    /**
+     * @brief Destructor
+     */
+    ~formatted_writer() override = default;
+
+    // Non-copyable
+    formatted_writer(const formatted_writer&) = delete;
+    formatted_writer& operator=(const formatted_writer&) = delete;
+
+    // Movable
+    formatted_writer(formatted_writer&&) noexcept = default;
+    formatted_writer& operator=(formatted_writer&&) noexcept = default;
+
+    /**
+     * @brief Write a log entry after applying the formatter
+     *
+     * @param entry The log entry to write
+     * @return common::VoidResult Success if written successfully,
+     *         error if write operation fails
+     *
+     * @details If the formatter is nullptr, the entry is delegated directly
+     * to the wrapped writer. Otherwise, the formatter is applied to create
+     * a formatted message, which is then stored in a new log entry with
+     * the same metadata.
+     *
+     * @since 4.0.0
+     */
+    common::VoidResult write(const log_entry& entry) override;
+
+    /**
+     * @brief Flush the wrapped writer
+     *
+     * @return common::VoidResult Result from the wrapped writer's flush
+     *
+     * @since 4.0.0
+     */
+    common::VoidResult flush() override;
+
+    /**
+     * @brief Get the name of this writer
+     *
+     * @return String in format "formatted_<wrapped_name>" or
+     *         "formatted(<formatter_name>)_<wrapped_name>" if formatter has a name
+     *
+     * @since 4.0.0
+     */
+    std::string get_name() const override;
+
+    /**
+     * @brief Check if the writer is healthy
+     *
+     * @return Health status of the wrapped writer
+     *
+     * @since 4.0.0
+     */
+    bool is_healthy() const override;
+
+    /**
+     * @brief Get the current formatter
+     *
+     * @return Pointer to the formatter (may be nullptr)
+     *
+     * @since 4.0.0
+     */
+    const log_formatter_interface* get_formatter() const;
+
+    /**
+     * @brief Get the wrapped writer
+     *
+     * @return Pointer to the wrapped writer
+     *
+     * @since 4.0.0
+     */
+    const log_writer_interface* get_wrapped_writer() const;
+
+private:
+    std::unique_ptr<log_writer_interface> wrapped_;
+    std::unique_ptr<log_formatter_interface> formatter_;
+};
+
+/**
+ * @brief Factory function to create a formatted writer
+ *
+ * @param writer The writer to wrap
+ * @param formatter The formatter to apply
+ * @return Unique pointer to the formatted writer
+ *
+ * @throws std::invalid_argument if writer is nullptr
+ *
+ * @since 4.0.0
+ */
+std::unique_ptr<formatted_writer> make_formatted_writer(
+    std::unique_ptr<log_writer_interface> writer,
+    std::unique_ptr<log_formatter_interface> formatter);
+
+}  // namespace kcenon::logger

--- a/src/impl/writers/formatted_writer.cpp
+++ b/src/impl/writers/formatted_writer.cpp
@@ -1,0 +1,102 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <kcenon/logger/writers/formatted_writer.h>
+
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <stdexcept>
+
+namespace kcenon::logger {
+
+formatted_writer::formatted_writer(std::unique_ptr<log_writer_interface> wrapped,
+                                   std::unique_ptr<log_formatter_interface> formatter)
+    : wrapped_(std::move(wrapped)), formatter_(std::move(formatter)) {
+    if (!wrapped_) {
+        throw std::invalid_argument("formatted_writer: wrapped writer cannot be nullptr");
+    }
+}
+
+common::VoidResult formatted_writer::write(const log_entry& entry) {
+    // If no formatter, pass through all entries unchanged
+    if (!formatter_) {
+        return wrapped_->write(entry);
+    }
+
+    // Apply formatter to get formatted message
+    std::string formatted_message = formatter_->format(entry);
+
+    // Create a new log entry with the formatted message
+    log_entry formatted_entry(entry.level, formatted_message, entry.timestamp);
+
+    // Copy optional fields from original entry
+    formatted_entry.location = entry.location;
+    formatted_entry.thread_id = entry.thread_id;
+    formatted_entry.category = entry.category;
+    formatted_entry.otel_ctx = entry.otel_ctx;
+    formatted_entry.fields = entry.fields;
+
+    // Delegate to wrapped writer
+    return wrapped_->write(formatted_entry);
+}
+
+common::VoidResult formatted_writer::flush() {
+    return wrapped_->flush();
+}
+
+std::string formatted_writer::get_name() const {
+    if (formatter_) {
+        return "formatted(" + formatter_->get_name() + ")_" + wrapped_->get_name();
+    }
+    return "formatted_" + wrapped_->get_name();
+}
+
+bool formatted_writer::is_healthy() const {
+    return wrapped_->is_healthy();
+}
+
+const log_formatter_interface* formatted_writer::get_formatter() const {
+    return formatter_.get();
+}
+
+const log_writer_interface* formatted_writer::get_wrapped_writer() const {
+    return wrapped_.get();
+}
+
+// Factory function
+std::unique_ptr<formatted_writer> make_formatted_writer(
+    std::unique_ptr<log_writer_interface> writer,
+    std::unique_ptr<log_formatter_interface> formatter) {
+    return std::make_unique<formatted_writer>(std::move(writer), std::move(formatter));
+}
+
+}  // namespace kcenon::logger

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -416,6 +416,36 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/buffered_writer_test.cp
     message(STATUS "Buffered writer decorator tests: Added")
 endif()
 
+# Formatted writer decorator tests (Issue #365 - Decorator pattern refactoring Part 3)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/formatted_writer_test.cpp")
+    add_executable(logger_formatted_writer_test
+        unit/writers_test/formatted_writer_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main AND TARGET GTest::gmock)
+        target_link_libraries(logger_formatted_writer_test
+            PRIVATE LoggerSystem GTest::gtest_main GTest::gmock
+        )
+    elseif(TARGET GTest::gtest_main)
+        target_link_libraries(logger_formatted_writer_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_formatted_writer_test
+            PRIVATE LoggerSystem gtest_main gmock
+        )
+    endif()
+
+    add_test(NAME logger_formatted_writer_test
+        COMMAND logger_formatted_writer_test
+    )
+    set_target_properties(logger_formatted_writer_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Formatted writer decorator tests: Added")
+endif()
+
 ##################################################
 # Automatic Coverage Registration
 #
@@ -475,6 +505,10 @@ endif()
 
 if(TARGET logger_buffered_writer_test)
     list(APPEND _LOGGER_TEST_TARGETS logger_buffered_writer_test)
+endif()
+
+if(TARGET logger_formatted_writer_test)
+    list(APPEND _LOGGER_TEST_TARGETS logger_formatted_writer_test)
 endif()
 
 # Register all test targets for coverage instrumentation

--- a/tests/unit/writers_test/formatted_writer_test.cpp
+++ b/tests/unit/writers_test/formatted_writer_test.cpp
@@ -1,0 +1,425 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <kcenon/logger/writers/formatted_writer.h>
+#include <kcenon/logger/formatters/json_formatter.h>
+#include <kcenon/logger/formatters/timestamp_formatter.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace kcenon::logger;
+namespace common = kcenon::common;
+using log_level = common::interfaces::log_level;
+
+/**
+ * @brief Mock writer to track write operations
+ */
+class mock_writer : public log_writer_interface {
+public:
+    mock_writer() = default;
+    ~mock_writer() override = default;
+
+    common::VoidResult write(const log_entry& entry) override {
+        entries_.push_back(entry.message.to_string());
+        levels_.push_back(entry.level);
+        write_count_++;
+        return common::ok();
+    }
+
+    common::VoidResult flush() override {
+        flush_count_++;
+        return common::ok();
+    }
+
+    std::string get_name() const override { return "mock_writer"; }
+
+    bool is_healthy() const override { return healthy_; }
+
+    void set_healthy(bool healthy) { healthy_ = healthy; }
+
+    int write_count() const { return write_count_; }
+    int flush_count() const { return flush_count_; }
+    const std::vector<std::string>& entries() const { return entries_; }
+    const std::vector<log_level>& levels() const { return levels_; }
+
+private:
+    std::vector<std::string> entries_;
+    std::vector<log_level> levels_;
+    int write_count_ = 0;
+    int flush_count_ = 0;
+    bool healthy_ = true;
+};
+
+/**
+ * @brief Simple mock formatter for testing
+ */
+class mock_formatter : public log_formatter_interface {
+public:
+    mock_formatter() = default;
+    ~mock_formatter() override = default;
+
+    std::string format(const log_entry& entry) const override {
+        format_count_++;
+        return "[MOCK] " + entry.message.to_string();
+    }
+
+    std::string get_name() const override { return "mock_formatter"; }
+
+    mutable int format_count_ = 0;
+};
+
+/**
+ * @brief Test fixture for formatted_writer tests
+ */
+class FormattedWriterTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mock_ = std::make_unique<mock_writer>();
+        mock_ptr_ = mock_.get();
+    }
+
+    std::unique_ptr<mock_writer> mock_;
+    mock_writer* mock_ptr_ = nullptr;
+};
+
+/**
+ * @test Verify construction with valid arguments
+ */
+TEST_F(FormattedWriterTest, ConstructorValid) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_NE(writer->get_formatter(), nullptr);
+    EXPECT_NE(writer->get_wrapped_writer(), nullptr);
+}
+
+/**
+ * @test Verify construction with nullptr formatter passes all entries unchanged
+ */
+TEST_F(FormattedWriterTest, ConstructorNullFormatter) {
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), nullptr);
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_EQ(writer->get_formatter(), nullptr);
+
+    log_entry entry(log_level::debug, "test message");
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+    EXPECT_EQ(mock_ptr_->entries()[0], "test message");
+}
+
+/**
+ * @test Verify construction with nullptr writer throws
+ */
+TEST_F(FormattedWriterTest, ConstructorNullWriterThrows) {
+    auto formatter = std::make_unique<mock_formatter>();
+
+    EXPECT_THROW(
+        formatted_writer(nullptr, std::move(formatter)),
+        std::invalid_argument);
+}
+
+/**
+ * @test Verify formatter is applied to log entries
+ */
+TEST_F(FormattedWriterTest, FormatterApplied) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto* formatter_ptr = formatter.get();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry(log_level::info, "original message");
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(formatter_ptr->format_count_, 1);
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+    // The message should be formatted by the mock formatter
+    EXPECT_EQ(mock_ptr_->entries()[0], "[MOCK] original message");
+}
+
+/**
+ * @test Verify JSON formatter integration
+ */
+TEST_F(FormattedWriterTest, JsonFormatterIntegration) {
+    auto formatter = std::make_unique<json_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry(log_level::error, "test error");
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+
+    // The formatted message should contain JSON structure
+    const std::string& formatted = mock_ptr_->entries()[0];
+    EXPECT_TRUE(formatted.find("{") != std::string::npos);
+    EXPECT_TRUE(formatted.find("\"message\"") != std::string::npos);
+    EXPECT_TRUE(formatted.find("test error") != std::string::npos);
+    EXPECT_TRUE(formatted.find("\"level\"") != std::string::npos);
+    EXPECT_TRUE(formatted.find("}") != std::string::npos);
+}
+
+/**
+ * @test Verify timestamp formatter integration
+ */
+TEST_F(FormattedWriterTest, TimestampFormatterIntegration) {
+    auto formatter = std::make_unique<timestamp_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry(log_level::warning, "warning message");
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+
+    // The formatted message should contain timestamp format elements
+    const std::string& formatted = mock_ptr_->entries()[0];
+    EXPECT_TRUE(formatted.find("[") != std::string::npos);
+    EXPECT_TRUE(formatted.find("]") != std::string::npos);
+    EXPECT_TRUE(formatted.find("WARNING") != std::string::npos);
+    EXPECT_TRUE(formatted.find("warning message") != std::string::npos);
+}
+
+/**
+ * @test Verify multiple writes with formatter
+ */
+TEST_F(FormattedWriterTest, MultipleWrites) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto* formatter_ptr = formatter.get();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry1(log_level::info, "message 1");
+    log_entry entry2(log_level::warning, "message 2");
+    log_entry entry3(log_level::error, "message 3");
+
+    writer->write(entry1);
+    writer->write(entry2);
+    writer->write(entry3);
+
+    EXPECT_EQ(formatter_ptr->format_count_, 3);
+    EXPECT_EQ(mock_ptr_->write_count(), 3);
+    EXPECT_EQ(mock_ptr_->entries()[0], "[MOCK] message 1");
+    EXPECT_EQ(mock_ptr_->entries()[1], "[MOCK] message 2");
+    EXPECT_EQ(mock_ptr_->entries()[2], "[MOCK] message 3");
+}
+
+/**
+ * @test Verify log level is preserved after formatting
+ */
+TEST_F(FormattedWriterTest, LogLevelPreserved) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry(log_level::critical, "critical message");
+    writer->write(entry);
+
+    EXPECT_EQ(mock_ptr_->levels()[0], log_level::critical);
+}
+
+/**
+ * @test Verify flush is delegated to wrapped writer
+ */
+TEST_F(FormattedWriterTest, FlushDelegates) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    auto result = writer->flush();
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->flush_count(), 1);
+}
+
+/**
+ * @test Verify get_name returns appropriate format
+ */
+TEST_F(FormattedWriterTest, GetNameFormat) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    std::string name = writer->get_name();
+
+    EXPECT_TRUE(name.find("formatted") != std::string::npos);
+    EXPECT_TRUE(name.find("mock_writer") != std::string::npos);
+    EXPECT_TRUE(name.find("mock_formatter") != std::string::npos);
+}
+
+/**
+ * @test Verify get_name with nullptr formatter
+ */
+TEST_F(FormattedWriterTest, GetNameNullFormatter) {
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), nullptr);
+
+    std::string name = writer->get_name();
+
+    EXPECT_EQ(name, "formatted_mock_writer");
+}
+
+/**
+ * @test Verify is_healthy delegates to wrapped writer
+ */
+TEST_F(FormattedWriterTest, IsHealthyDelegates) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    EXPECT_TRUE(writer->is_healthy());
+
+    mock_ptr_->set_healthy(false);
+    EXPECT_FALSE(writer->is_healthy());
+
+    mock_ptr_->set_healthy(true);
+    EXPECT_TRUE(writer->is_healthy());
+}
+
+/**
+ * @test Verify factory function works correctly
+ */
+TEST_F(FormattedWriterTest, FactoryFunction) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = make_formatted_writer(std::move(mock_), std::move(formatter));
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_NE(writer->get_formatter(), nullptr);
+}
+
+/**
+ * @test Verify factory function with nullptr formatter
+ */
+TEST_F(FormattedWriterTest, FactoryFunctionNullFormatter) {
+    auto writer = make_formatted_writer(std::move(mock_), nullptr);
+
+    EXPECT_NE(writer, nullptr);
+    EXPECT_EQ(writer->get_formatter(), nullptr);
+}
+
+/**
+ * @test Verify move semantics work correctly
+ */
+TEST_F(FormattedWriterTest, MoveSemantics) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer1 = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    // Move to another unique_ptr
+    auto writer2 = std::move(writer1);
+
+    EXPECT_NE(writer2, nullptr);
+    EXPECT_EQ(writer1, nullptr);
+
+    log_entry entry(log_level::info, "test");
+    auto result = writer2->write(entry);
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+}
+
+/**
+ * @test Verify optional fields are preserved through formatting
+ */
+TEST_F(FormattedWriterTest, OptionalFieldsPreserved) {
+    auto formatter = std::make_unique<mock_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry(log_level::info, "message", "test.cpp", 42, "test_function");
+    entry.category = "test_category";
+    entry.thread_id = "12345";
+
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+}
+
+/**
+ * @test Verify JSON formatter with structured fields
+ */
+TEST_F(FormattedWriterTest, JsonFormatterWithFields) {
+    auto formatter = std::make_unique<json_formatter>();
+    auto writer = std::make_unique<formatted_writer>(std::move(mock_), std::move(formatter));
+
+    log_entry entry(log_level::info, "structured log");
+    entry.fields = log_fields{
+        {"user_id", int64_t{12345}},
+        {"action", std::string{"login"}},
+        {"success", true}
+    };
+
+    auto result = writer->write(entry);
+
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_EQ(mock_ptr_->write_count(), 1);
+
+    const std::string& formatted = mock_ptr_->entries()[0];
+    EXPECT_TRUE(formatted.find("user_id") != std::string::npos);
+    EXPECT_TRUE(formatted.find("action") != std::string::npos);
+    EXPECT_TRUE(formatted.find("success") != std::string::npos);
+}
+
+/**
+ * @test Verify different formatters produce different outputs
+ */
+TEST_F(FormattedWriterTest, DifferentFormatterOutputs) {
+    // First write with JSON formatter
+    auto json_formatter_ptr = std::make_unique<json_formatter>();
+    auto mock1 = std::make_unique<mock_writer>();
+    auto* mock1_ptr = mock1.get();
+    auto json_writer = std::make_unique<formatted_writer>(std::move(mock1), std::move(json_formatter_ptr));
+
+    // Second write with timestamp formatter
+    auto ts_formatter_ptr = std::make_unique<timestamp_formatter>();
+    auto mock2 = std::make_unique<mock_writer>();
+    auto* mock2_ptr = mock2.get();
+    auto ts_writer = std::make_unique<formatted_writer>(std::move(mock2), std::move(ts_formatter_ptr));
+
+    // Same entry
+    log_entry entry1(log_level::info, "same message");
+    log_entry entry2(log_level::info, "same message");
+
+    json_writer->write(entry1);
+    ts_writer->write(entry2);
+
+    // Outputs should be different
+    EXPECT_NE(mock1_ptr->entries()[0], mock2_ptr->entries()[0]);
+
+    // JSON should have curly braces
+    EXPECT_TRUE(mock1_ptr->entries()[0].find("{") != std::string::npos);
+
+    // Timestamp should have square brackets but not curly braces
+    EXPECT_TRUE(mock2_ptr->entries()[0].find("[") != std::string::npos);
+    EXPECT_TRUE(mock2_ptr->entries()[0].find("{") == std::string::npos);
+}


### PR DESCRIPTION
Closes #365
Part of #356

## Summary
- Add `formatted_writer` decorator that applies formatting before delegating to wrapped writers
- Enables composable formatting at the writer level (e.g., JSON for files, plain text for console)
- Follows established Decorator pattern consistent with `filtered_writer` and `buffered_writer`

## Changes
| File | Description |
|------|-------------|
| `include/kcenon/logger/writers/formatted_writer.h` | Header with class declaration and documentation |
| `src/impl/writers/formatted_writer.cpp` | Implementation of formatted_writer decorator |
| `tests/unit/writers_test/formatted_writer_test.cpp` | 18 unit tests covering all functionality |
| `tests/CMakeLists.txt` | Build configuration for new test target |

## Usage Example
```cpp
// JSON format for file output
auto file_writer = std::make_unique<formatted_writer>(
    std::make_unique<file_writer>("app.json"),
    std::make_unique<json_formatter>()
);

// Plain text for console
auto console_writer = std::make_unique<formatted_writer>(
    std::make_unique<console_writer>(),
    std::make_unique<timestamp_formatter>()
);

// Composable with other decorators
auto filtered_formatted = std::make_unique<filtered_writer>(
    std::make_unique<formatted_writer>(
        std::make_unique<file_writer>("errors.json"),
        std::make_unique<json_formatter>()
    ),
    std::make_unique<level_filter>(log_level::error)
);
```

## Test Plan
- [x] All 18 unit tests pass
- [x] Build succeeds with Release configuration
- [x] Existing filtered_writer and buffered_writer tests still pass
- [x] No regressions in related functionality