### PR TITLE
refactor(writers): migrate filtered_writer to use decorator_writer_base

### DIFF
--- a/include/kcenon/logger/writers/filtered_writer.h
+++ b/include/kcenon/logger/writers/filtered_writer.h
@@ -63,9 +63,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @endcode
  */
 
+#include "decorator_writer_base.h"
 #include "../interfaces/log_filter_interface.h"
-#include "../interfaces/log_writer_interface.h"
-#include "../interfaces/writer_category.h"
 
 #include <memory>
 
@@ -92,8 +91,9 @@ namespace kcenon::logger {
  * @note Filtered entries return success (not an error).
  *
  * @since 4.0.0
+ * @since 4.1.0 Migrated to use decorator_writer_base for code reuse
  */
-class filtered_writer : public log_writer_interface, public decorator_writer_tag {
+class filtered_writer : public decorator_writer_base {
 public:
     /**
      * @brief Construct a filtered writer
@@ -139,32 +139,16 @@ public:
     common::VoidResult write(const log_entry& entry) override;
 
     /**
-     * @brief Flush the wrapped writer
-     *
-     * @return common::VoidResult Result from the wrapped writer's flush
-     *
-     * @since 4.0.0
-     */
-    common::VoidResult flush() override;
-
-    /**
      * @brief Get the name of this writer
      *
      * @return String in format "filtered_<wrapped_name>" or
      *         "filtered(<filter_name>)_<wrapped_name>" if filter has a name
      *
+     * @details Overrides base class to include filter name when available.
+     *
      * @since 4.0.0
      */
     std::string get_name() const override;
-
-    /**
-     * @brief Check if the writer is healthy
-     *
-     * @return Health status of the wrapped writer
-     *
-     * @since 4.0.0
-     */
-    bool is_healthy() const override;
 
     /**
      * @brief Get the current filter
@@ -175,17 +159,7 @@ public:
      */
     const log_filter_interface* get_filter() const;
 
-    /**
-     * @brief Get the wrapped writer
-     *
-     * @return Pointer to the wrapped writer
-     *
-     * @since 4.0.0
-     */
-    const log_writer_interface* get_wrapped_writer() const;
-
 private:
-    std::unique_ptr<log_writer_interface> wrapped_;
     std::unique_ptr<log_filter_interface> filter_;
 };
 


### PR DESCRIPTION
## Summary

- Migrate `filtered_writer` to inherit from `decorator_writer_base` instead of directly implementing `log_writer_interface`
- Eliminate code duplication by leveraging base class implementations for common decorator operations
- Maintain full API and behavioral compatibility

Closes #369
Part of #356

## Changes

| Change | Description |
|--------|-------------|
| Inheritance | `log_writer_interface` → `decorator_writer_base` |
| `wrapped_` member | Removed (managed by base class) |
| `flush()` | Removed (inherited from base) |
| `is_healthy()` | Removed (inherited from base) |
| `get_wrapped_writer()` | Removed (use base class `get_wrapped_writer()`) |
| Constructor | Updated to initialize base class with decorator name |
| `get_name()` | Preserved custom filter name formatting |

## Code Reduction

- **Header**: -19 lines (36 → 17 lines of class definition)
- **Implementation**: -14 lines (removed redundant methods)
- **Total**: ~40 lines removed

## Test Plan

- [x] All `filtered_writer` tests pass
- [x] All `decorator_writer_base` tests pass
- [x] All `buffered_writer` tests pass
- [x] All `formatted_writer` tests pass
- [x] Full test suite passes (except unrelated OpenSSL/encrypted tests due to build config)

## Breaking Changes

None - existing code using `filtered_writer` will continue to work without modification.