### PR TITLE
refactor(writers): migrate formatted_writer to use decorator_writer_base

### DIFF
--- a/include/kcenon/logger/writers/formatted_writer.h
+++ b/include/kcenon/logger/writers/formatted_writer.h
@@ -64,9 +64,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @endcode
  */
 
+#include "decorator_writer_base.h"
 #include "../interfaces/log_formatter_interface.h"
-#include "../interfaces/log_writer_interface.h"
-#include "../interfaces/writer_category.h"
 
 #include <memory>
 
@@ -93,8 +92,9 @@ namespace kcenon::logger {
  * @note If no formatter is provided, entries pass through unchanged.
  *
  * @since 4.0.0
+ * @since 4.1.0 Migrated to use decorator_writer_base for code reuse
  */
-class formatted_writer : public log_writer_interface, public decorator_writer_tag {
+class formatted_writer : public decorator_writer_base {
 public:
     /**
      * @brief Construct a formatted writer
@@ -141,32 +141,16 @@ public:
     common::VoidResult write(const log_entry& entry) override;
 
     /**
-     * @brief Flush the wrapped writer
-     *
-     * @return common::VoidResult Result from the wrapped writer's flush
-     *
-     * @since 4.0.0
-     */
-    common::VoidResult flush() override;
-
-    /**
      * @brief Get the name of this writer
      *
      * @return String in format "formatted_<wrapped_name>" or
      *         "formatted(<formatter_name>)_<wrapped_name>" if formatter has a name
      *
+     * @details Overrides base class to include formatter name when available.
+     *
      * @since 4.0.0
      */
     std::string get_name() const override;
-
-    /**
-     * @brief Check if the writer is healthy
-     *
-     * @return Health status of the wrapped writer
-     *
-     * @since 4.0.0
-     */
-    bool is_healthy() const override;
 
     /**
      * @brief Get the current formatter
@@ -177,17 +161,7 @@ public:
      */
     const log_formatter_interface* get_formatter() const;
 
-    /**
-     * @brief Get the wrapped writer
-     *
-     * @return Pointer to the wrapped writer
-     *
-     * @since 4.0.0
-     */
-    const log_writer_interface* get_wrapped_writer() const;
-
 private:
-    std::unique_ptr<log_writer_interface> wrapped_;
     std::unique_ptr<log_formatter_interface> formatter_;
 };
 


### PR DESCRIPTION
## Summary
- Migrate `formatted_writer` to inherit from `decorator_writer_base` for consistency
- Remove duplicate code by reusing base class implementations
- Ensures all decorator writers follow the same pattern

Closes #371
Part of #356

## Changes
| File | Change |
|------|--------|
| `formatted_writer.h` | Change inheritance, remove redundant declarations |
| `formatted_writer.cpp` | Remove duplicate implementations, use base class |

## Technical Details
- Inherit from `decorator_writer_base` instead of `log_writer_interface`
- Remove `decorator_writer_tag` (inherited from base)
- Remove `wrapped_` member (managed by base class)
- Remove `flush()` and `is_healthy()` (use base defaults)
- Remove `get_wrapped_writer()` (use base accessor)
- Use `wrapped()` method instead of `wrapped_` pointer

## Test Plan
- [x] All formatted_writer tests pass (18 tests)
- [x] All decorator_writer_base tests pass (15 tests)
- [x] All filtered_writer tests pass (15 tests)
- [x] All buffered_writer tests pass (20 tests)
- [x] Build succeeds with no warnings

## Impact
- **Code reduction**: -39 lines (12 added, 51 removed)
- **API compatible**: No breaking changes to public API
- **Consistency**: All decorator writers now use the same base class