### PR TITLE
refactor(core): integrate unified_log_context with logger class

### DIFF
--- a/include/kcenon/logger/core/logger.h
+++ b/include/kcenon/logger/core/logger.h
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/logger/otlp/otel_context.h>
 #include <kcenon/logger/sampling/sampling_config.h>
 #include "structured_log_builder.h"
+#include "unified_log_context.h"
 
 /**
  * @file logger.h
@@ -701,7 +702,48 @@ public:
     [[nodiscard]] structured_log_builder log_structured(log_level level);
 
     // =========================================================================
-    // Context fields management
+    // Unified Context API (NEW)
+    // =========================================================================
+
+    /**
+     * @brief Get the unified context for this logger
+     * @return Reference to the unified log context
+     *
+     * @details Provides access to the unified context management system that
+     * consolidates all context types (custom fields, trace IDs, request IDs,
+     * and OpenTelemetry context) into a single interface.
+     *
+     * @example
+     * @code
+     * // Set various context types
+     * logger->context()
+     *     .set("user_id", int64_t{12345})
+     *     .set_trace("trace-abc", "span-123")
+     *     .set_request("req-456");
+     *
+     * // All structured logs include the context
+     * logger->log_structured(log_level::info)
+     *     .message("Processing request")
+     *     .emit();
+     *
+     * // Clear specific category
+     * logger->context().clear(context_category::trace);
+     * @endcode
+     *
+     * @since 3.5.0
+     */
+    [[nodiscard]] unified_log_context& context();
+
+    /**
+     * @brief Get the unified context for this logger (const version)
+     * @return Const reference to the unified log context
+     *
+     * @since 3.5.0
+     */
+    [[nodiscard]] const unified_log_context& context() const;
+
+    // =========================================================================
+    // Context fields management (legacy API - use context() instead)
     // =========================================================================
 
     /**


### PR DESCRIPTION
## Summary

- Add `context()` method to logger class providing access to `unified_log_context`
- Replace internal `context_fields_` storage with `unified_log_context`
- Delegate existing context APIs to the new unified context system
- Maintain full backward compatibility with existing API

## What

### Changes Made

| File | Description |
|------|-------------|
| `include/kcenon/logger/core/logger.h` | Added `context()` methods and `unified_log_context.h` include |
| `src/core/logger.cpp` | Replaced storage and updated all context methods |

### New API

```cpp
// New unified context API (recommended)
logger->context()
    .set("user_id", int64_t{12345})
    .set_trace("trace-abc", "span-123")
    .set_request("req-456");

// Existing APIs still work (delegates to unified context)
logger->set_context("key", "value");
logger->set_context_id("trace_id", "...");
```

## Why

Part of Epic #374 - Consolidate logger_system context APIs into unified interface.

The logger class had three separate context management APIs causing confusion:
- `set_context()` - custom fields
- `set_context_id()` - trace/request IDs
- `set_otel_context()` - OpenTelemetry context

This PR consolidates internal storage while maintaining backward compatibility.

Closes #378

## Test Plan

- [x] All structured logging tests pass
- [x] Build succeeds on macOS (Apple Clang 17)
- [x] Existing API behavior preserved (backward compatible)
- [x] New `context()` API accessible

### Test Results

```
95% tests passed, 1 tests failed out of 21
(encrypted_writer_test failure is pre-existing, unrelated to this change)
```