### PR TITLE
refactor(core): implement scoped_context_guard for RAII context management

### DIFF
--- a/include/kcenon/logger/core/scoped_context_guard.h
+++ b/include/kcenon/logger/core/scoped_context_guard.h
@@ -1,0 +1,239 @@
+#pragma once
+
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file scoped_context_guard.h
+ * @brief RAII guard for automatic context restoration
+ * @author kcenon
+ * @since 3.3.0
+ *
+ * @details This file provides the scoped_context_guard class that enables
+ * RAII-based context management with automatic restoration on scope exit.
+ * It works with the unified_log_context API to provide exception-safe
+ * context handling.
+ *
+ * @example
+ * @code
+ * void handle_request(logger& log, const Request& req) {
+ *     scoped_context_guard guard(log);
+ *     guard.set_request(req.id())
+ *          .set("user_id", req.user_id());
+ *
+ *     log.info_structured()
+ *         .message("Processing request")
+ *         .emit();
+ * } // Context automatically restored here
+ * @endcode
+ */
+
+#include "unified_log_context.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace kcenon::logger {
+
+// Forward declaration
+class logger;
+
+/**
+ * @class scoped_context_guard
+ * @brief RAII guard for automatic context management
+ *
+ * @details Provides exception-safe context management by saving the current
+ * context state on construction and restoring it on destruction. Supports
+ * chainable setters for convenient context configuration.
+ *
+ * The guard tracks which keys were added during its lifetime and removes
+ * only those keys on destruction, while restoring any values that were
+ * overridden.
+ *
+ * Thread Safety: Each instance is tied to a specific logger instance and
+ * should only be used from a single thread. However, multiple threads can
+ * use separate guards with the same logger safely.
+ *
+ * @example
+ * @code
+ * // Example 1: Request context
+ * void handle_request(logger& log, const Request& req) {
+ *     scoped_context_guard guard(log);
+ *     guard.set_request(req.id(), req.correlation_id())
+ *          .set("user_id", req.user_id())
+ *          .set("endpoint", req.path());
+ *
+ *     log.info("Processing request");
+ * } // Context automatically restored
+ *
+ * // Example 2: Nested scopes
+ * void process_order(logger& log, int order_id) {
+ *     scoped_context_guard order_ctx(log);
+ *     order_ctx.set("order_id", int64_t{order_id});
+ *
+ *     log.info("Processing order");
+ *
+ *     {
+ *         scoped_context_guard step_ctx(log);
+ *         step_ctx.set("step", "payment");
+ *         log.info("Processing payment");
+ *     } // "step" removed
+ *
+ *     log.info("Order complete");
+ * } // "order_id" removed
+ *
+ * // Example 3: Exception safety
+ * void risky_operation(logger& log) {
+ *     scoped_context_guard guard(log);
+ *     guard.set("operation", "risky");
+ *
+ *     might_throw(); // Context restored even if exception thrown
+ * }
+ * @endcode
+ *
+ * @since 3.3.0
+ */
+class scoped_context_guard {
+public:
+    /**
+     * @brief Construct guard and save current context
+     * @param log Logger whose context to manage
+     *
+     * @details Saves the current state of the logger's context.
+     * On destruction, the context will be restored to this state.
+     */
+    explicit scoped_context_guard(logger& log);
+
+    /**
+     * @brief Construct guard and set a single context field
+     * @param log Logger whose context to manage
+     * @param key Field name to set
+     * @param value Field value to set
+     * @param category Context category (default: custom)
+     *
+     * @details Convenience constructor for setting a single field.
+     * Equivalent to constructing with logger and then calling set().
+     */
+    scoped_context_guard(logger& log,
+                        std::string_view key,
+                        context_value value,
+                        context_category category = context_category::custom);
+
+    /**
+     * @brief Destructor - restores previous context
+     *
+     * @details Removes all keys that were added by this guard and restores
+     * any values that were overridden. This ensures the logger's context
+     * is returned to its state before the guard was constructed.
+     */
+    ~scoped_context_guard();
+
+    // Non-copyable
+    scoped_context_guard(const scoped_context_guard&) = delete;
+    scoped_context_guard& operator=(const scoped_context_guard&) = delete;
+
+    // Movable
+    scoped_context_guard(scoped_context_guard&& other) noexcept;
+    scoped_context_guard& operator=(scoped_context_guard&& other) noexcept;
+
+    // =========================================================================
+    // Setters (chainable)
+    // =========================================================================
+
+    /**
+     * @brief Set a context value
+     * @param key Field name
+     * @param value Field value
+     * @param category Context category (default: custom)
+     * @return Reference to this guard for chaining
+     *
+     * @details Sets a key-value pair in the logger's context. If the key
+     * already exists, its value is overridden and the previous value is
+     * saved for restoration.
+     */
+    scoped_context_guard& set(std::string_view key,
+                              context_value value,
+                              context_category category = context_category::custom);
+
+    /**
+     * @brief Set trace context
+     * @param trace_id Trace identifier
+     * @param span_id Span identifier
+     * @param parent_span_id Optional parent span identifier
+     * @return Reference to this guard for chaining
+     *
+     * @details Convenience method for setting distributed tracing context.
+     * Sets trace_id, span_id, and optionally parent_span_id with
+     * context_category::trace.
+     */
+    scoped_context_guard& set_trace(std::string_view trace_id,
+                                    std::string_view span_id,
+                                    std::optional<std::string_view> parent_span_id = std::nullopt);
+
+    /**
+     * @brief Set request context
+     * @param request_id Request identifier
+     * @param correlation_id Optional correlation identifier
+     * @return Reference to this guard for chaining
+     *
+     * @details Convenience method for setting request tracking context.
+     * Sets request_id and optionally correlation_id with
+     * context_category::request.
+     */
+    scoped_context_guard& set_request(std::string_view request_id,
+                                      std::optional<std::string_view> correlation_id = std::nullopt);
+
+    /**
+     * @brief Set OpenTelemetry context
+     * @param ctx OpenTelemetry context structure
+     * @return Reference to this guard for chaining
+     *
+     * @details Imports all fields from an otel_context structure with
+     * context_category::otel.
+     */
+    scoped_context_guard& set_otel(const otlp::otel_context& ctx);
+
+private:
+    /**
+     * @brief Track a key as added or overridden
+     * @param key Key that was set
+     */
+    void track_key(std::string_view key);
+
+    logger* logger_;                          // Logger whose context we're managing
+    unified_log_context saved_context_;       // Saved context state
+    std::vector<std::string> tracked_keys_;   // Keys added/modified by this guard
+};
+
+} // namespace kcenon::logger

--- a/src/core/scoped_context_guard.cpp
+++ b/src/core/scoped_context_guard.cpp
@@ -1,0 +1,150 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#include "kcenon/logger/core/scoped_context_guard.h"
+#include "kcenon/logger/core/logger.h"
+
+#include <algorithm>
+
+namespace kcenon::logger {
+
+scoped_context_guard::scoped_context_guard(logger& log)
+    : logger_(&log), saved_context_(log.context()) {
+    // Save current context state for restoration
+}
+
+scoped_context_guard::scoped_context_guard(logger& log,
+                                          std::string_view key,
+                                          context_value value,
+                                          context_category category)
+    : scoped_context_guard(log) {
+    set(key, value, category);
+}
+
+scoped_context_guard::~scoped_context_guard() {
+    if (!logger_) {
+        return; // Moved-from state
+    }
+
+    // Get current context
+    auto& ctx = logger_->context();
+
+    // Remove all tracked keys from current context
+    for (const auto& key : tracked_keys_) {
+        ctx.remove(key);
+    }
+
+    // Restore values from saved context
+    for (const auto& key : saved_context_.keys()) {
+        auto value = saved_context_.get(key);
+        auto category = saved_context_.get_category(key);
+        if (value && category) {
+            ctx.set(key, *value, *category);
+        }
+    }
+}
+
+scoped_context_guard::scoped_context_guard(scoped_context_guard&& other) noexcept
+    : logger_(other.logger_),
+      saved_context_(std::move(other.saved_context_)),
+      tracked_keys_(std::move(other.tracked_keys_)) {
+    other.logger_ = nullptr; // Mark other as moved-from
+}
+
+scoped_context_guard& scoped_context_guard::operator=(scoped_context_guard&& other) noexcept {
+    if (this != &other) {
+        // First, restore our current state (like destructor)
+        if (logger_) {
+            auto& ctx = logger_->context();
+            for (const auto& key : tracked_keys_) {
+                ctx.remove(key);
+            }
+            for (const auto& key : saved_context_.keys()) {
+                auto value = saved_context_.get(key);
+                auto category = saved_context_.get_category(key);
+                if (value && category) {
+                    ctx.set(key, *value, *category);
+                }
+            }
+        }
+
+        // Transfer ownership from other
+        logger_ = other.logger_;
+        saved_context_ = std::move(other.saved_context_);
+        tracked_keys_ = std::move(other.tracked_keys_);
+        other.logger_ = nullptr;
+    }
+    return *this;
+}
+
+scoped_context_guard& scoped_context_guard::set(std::string_view key,
+                                                context_value value,
+                                                context_category category) {
+    if (logger_) {
+        logger_->context().set(key, value, category);
+        track_key(key);
+    }
+    return *this;
+}
+
+scoped_context_guard& scoped_context_guard::set_trace(
+    std::string_view trace_id,
+    std::string_view span_id,
+    std::optional<std::string_view> parent_span_id) {
+    if (logger_) {
+        logger_->context().set_trace(trace_id, span_id, parent_span_id);
+        track_key("trace_id");
+        track_key("span_id");
+        if (parent_span_id) {
+            track_key("parent_span_id");
+        }
+    }
+    return *this;
+}
+
+scoped_context_guard& scoped_context_guard::set_request(
+    std::string_view request_id,
+    std::optional<std::string_view> correlation_id) {
+    if (logger_) {
+        logger_->context().set_request(request_id, correlation_id);
+        track_key("request_id");
+        if (correlation_id) {
+            track_key("correlation_id");
+        }
+    }
+    return *this;
+}
+
+scoped_context_guard& scoped_context_guard::set_otel(const otlp::otel_context& ctx) {
+    if (logger_) {
+        logger_->context().set_otel(ctx);
+        // Track all OTEL context keys
+        if (!ctx.trace_id.empty()) {
+            track_key("otel_trace_id");
+        }
+        if (!ctx.span_id.empty()) {
+            track_key("otel_span_id");
+        }
+        if (!ctx.trace_flags.empty()) {
+            track_key("otel_trace_flags");
+        }
+        if (!ctx.trace_state.empty()) {
+            track_key("otel_trace_state");
+        }
+    }
+    return *this;
+}
+
+void scoped_context_guard::track_key(std::string_view key) {
+    std::string key_str(key);
+    // Only add if not already tracked (avoid duplicates)
+    if (std::find(tracked_keys_.begin(), tracked_keys_.end(), key_str) == tracked_keys_.end()) {
+        tracked_keys_.push_back(std::move(key_str));
+    }
+}
+
+} // namespace kcenon::logger

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -545,6 +545,32 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/core_test/unified_log_context_test.c
     message(STATUS "Unified log context tests: Added")
 endif()
 
+# Scoped context guard tests (Issue #387)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/core_test/scoped_context_guard_test.cpp")
+    add_executable(logger_scoped_context_guard_test
+        unit/core_test/scoped_context_guard_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_scoped_context_guard_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_scoped_context_guard_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_scoped_context_guard_test
+        COMMAND logger_scoped_context_guard_test
+    )
+    set_target_properties(logger_scoped_context_guard_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Scoped context guard tests: Added")
+endif()
+
 # Cleanup
 unset(_LOGGER_TEST_TARGETS)
 unset(_test_target)

--- a/tests/unit/core_test/scoped_context_guard_test.cpp
+++ b/tests/unit/core_test/scoped_context_guard_test.cpp
@@ -1,0 +1,347 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "kcenon/logger/core/logger.h"
+#include "kcenon/logger/core/scoped_context_guard.h"
+#include "kcenon/logger/writers/console_writer.h"
+
+#include <memory>
+
+using namespace kcenon::logger;
+
+/**
+ * @brief Test fixture for scoped_context_guard tests
+ */
+class ScopedContextGuardTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        log = std::make_unique<logger>();
+        log->start();
+    }
+
+    void TearDown() override {
+        if (log) {
+            log->stop();
+        }
+    }
+
+    std::unique_ptr<logger> log;
+};
+
+// =========================================================================
+// Constructor and Destructor Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, DefaultConstructorSavesContext) {
+    // Set initial context
+    log->context().set("initial_key", std::string("initial_value"));
+
+    {
+        scoped_context_guard guard(*log);
+        // Context should still have initial_key
+        EXPECT_TRUE(log->context().has("initial_key"));
+    }
+
+    // After guard destruction, context should still have initial_key
+    EXPECT_TRUE(log->context().has("initial_key"));
+}
+
+TEST_F(ScopedContextGuardTest, SingleValueConstructorSetsValue) {
+    {
+        scoped_context_guard guard(*log, "test_key", std::string("test_value"));
+
+        // Value should be set
+        auto value = log->context().get_as<std::string>("test_key");
+        ASSERT_TRUE(value.has_value());
+        EXPECT_EQ(*value, "test_value");
+    }
+
+    // After guard destruction, key should be removed
+    EXPECT_FALSE(log->context().has("test_key"));
+}
+
+TEST_F(ScopedContextGuardTest, DestructorRestoresPreviousContext) {
+    // Set initial context
+    log->context().set("key", std::string("original"));
+
+    {
+        scoped_context_guard guard(*log);
+        guard.set("key", std::string("modified"));
+
+        // Value should be modified
+        auto value = log->context().get_as<std::string>("key");
+        ASSERT_TRUE(value.has_value());
+        EXPECT_EQ(*value, "modified");
+    }
+
+    // After guard destruction, original value should be restored
+    auto value = log->context().get_as<std::string>("key");
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, "original");
+}
+
+TEST_F(ScopedContextGuardTest, DestructorRemovesAddedKeys) {
+    {
+        scoped_context_guard guard(*log);
+        guard.set("new_key", std::string("value"));
+
+        // Key should be set
+        EXPECT_TRUE(log->context().has("new_key"));
+    }
+
+    // After guard destruction, key should be removed
+    EXPECT_FALSE(log->context().has("new_key"));
+}
+
+// =========================================================================
+// Setter Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, SetMethodWorks) {
+    scoped_context_guard guard(*log);
+    guard.set("string_key", std::string("value"))
+         .set("int_key", int64_t{123})
+         .set("double_key", 3.14)
+         .set("bool_key", true);
+
+    EXPECT_EQ(*log->context().get_as<std::string>("string_key"), "value");
+    EXPECT_EQ(*log->context().get_as<int64_t>("int_key"), 123);
+    EXPECT_DOUBLE_EQ(*log->context().get_as<double>("double_key"), 3.14);
+    EXPECT_TRUE(*log->context().get_as<bool>("bool_key"));
+}
+
+TEST_F(ScopedContextGuardTest, SetMethodIsChainable) {
+    scoped_context_guard guard(*log);
+
+    auto& result = guard.set("key1", std::string("value1"))
+                        .set("key2", int64_t{42});
+
+    // Should return reference to guard for chaining
+    EXPECT_EQ(&result, &guard);
+}
+
+TEST_F(ScopedContextGuardTest, SetTraceMethodWorks) {
+    scoped_context_guard guard(*log);
+    guard.set_trace("trace123", "span456");
+
+    EXPECT_EQ(*log->context().get_as<std::string>("trace_id"), "trace123");
+    EXPECT_EQ(*log->context().get_as<std::string>("span_id"), "span456");
+}
+
+TEST_F(ScopedContextGuardTest, SetTraceWithParentSpanWorks) {
+    scoped_context_guard guard(*log);
+    guard.set_trace("trace123", "span456", "parent789");
+
+    EXPECT_EQ(*log->context().get_as<std::string>("trace_id"), "trace123");
+    EXPECT_EQ(*log->context().get_as<std::string>("span_id"), "span456");
+    EXPECT_EQ(*log->context().get_as<std::string>("parent_span_id"), "parent789");
+}
+
+TEST_F(ScopedContextGuardTest, SetRequestMethodWorks) {
+    scoped_context_guard guard(*log);
+    guard.set_request("req-123");
+
+    EXPECT_EQ(*log->context().get_as<std::string>("request_id"), "req-123");
+}
+
+TEST_F(ScopedContextGuardTest, SetRequestWithCorrelationIdWorks) {
+    scoped_context_guard guard(*log);
+    guard.set_request("req-123", "corr-456");
+
+    EXPECT_EQ(*log->context().get_as<std::string>("request_id"), "req-123");
+    EXPECT_EQ(*log->context().get_as<std::string>("correlation_id"), "corr-456");
+}
+
+TEST_F(ScopedContextGuardTest, SetOtelMethodWorks) {
+    otlp::otel_context otel_ctx;
+    otel_ctx.trace_id = "otel_trace_123";
+    otel_ctx.span_id = "otel_span_456";
+    otel_ctx.trace_flags = "01";
+    otel_ctx.trace_state = "state";
+
+    scoped_context_guard guard(*log);
+    guard.set_otel(otel_ctx);
+
+    EXPECT_EQ(*log->context().get_as<std::string>("otel_trace_id"), "otel_trace_123");
+    EXPECT_EQ(*log->context().get_as<std::string>("otel_span_id"), "otel_span_456");
+    EXPECT_EQ(*log->context().get_as<std::string>("otel_trace_flags"), "01");
+    EXPECT_EQ(*log->context().get_as<std::string>("otel_trace_state"), "state");
+}
+
+// =========================================================================
+// Nested Scopes Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, NestedScopesWork) {
+    {
+        scoped_context_guard outer(*log);
+        outer.set("level", std::string("outer"));
+        outer.set("outer_only", std::string("value"));
+
+        EXPECT_EQ(*log->context().get_as<std::string>("level"), "outer");
+        EXPECT_TRUE(log->context().has("outer_only"));
+
+        {
+            scoped_context_guard inner(*log);
+            inner.set("level", std::string("inner"));
+            inner.set("inner_only", std::string("value"));
+
+            // Inner scope should override outer
+            EXPECT_EQ(*log->context().get_as<std::string>("level"), "inner");
+            EXPECT_TRUE(log->context().has("outer_only"));
+            EXPECT_TRUE(log->context().has("inner_only"));
+        }
+
+        // After inner scope, level should be restored to outer
+        EXPECT_EQ(*log->context().get_as<std::string>("level"), "outer");
+        EXPECT_TRUE(log->context().has("outer_only"));
+        EXPECT_FALSE(log->context().has("inner_only"));
+    }
+
+    // After outer scope, all should be removed
+    EXPECT_FALSE(log->context().has("level"));
+    EXPECT_FALSE(log->context().has("outer_only"));
+}
+
+TEST_F(ScopedContextGuardTest, DeeplyNestedScopesWork) {
+    {
+        scoped_context_guard level1(*log);
+        level1.set("depth", int64_t{1});
+
+        {
+            scoped_context_guard level2(*log);
+            level2.set("depth", int64_t{2});
+
+            {
+                scoped_context_guard level3(*log);
+                level3.set("depth", int64_t{3});
+
+                EXPECT_EQ(*log->context().get_as<int64_t>("depth"), 3);
+            }
+
+            EXPECT_EQ(*log->context().get_as<int64_t>("depth"), 2);
+        }
+
+        EXPECT_EQ(*log->context().get_as<int64_t>("depth"), 1);
+    }
+
+    EXPECT_FALSE(log->context().has("depth"));
+}
+
+// =========================================================================
+// Exception Safety Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, ExceptionInScopeRestoresContext) {
+    log->context().set("key", std::string("original"));
+
+    try {
+        scoped_context_guard guard(*log);
+        guard.set("key", std::string("modified"));
+        guard.set("temp_key", std::string("temp"));
+
+        // Simulate exception
+        throw std::runtime_error("test exception");
+    } catch (const std::runtime_error&) {
+        // Exception caught
+    }
+
+    // Context should be restored despite exception
+    auto value = log->context().get_as<std::string>("key");
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, "original");
+    EXPECT_FALSE(log->context().has("temp_key"));
+}
+
+// =========================================================================
+// Move Semantics Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, MoveConstructorWorks) {
+    {
+        scoped_context_guard guard1(*log);
+        guard1.set("key", std::string("value"));
+
+        scoped_context_guard guard2(std::move(guard1));
+
+        // Context should still have the key
+        EXPECT_TRUE(log->context().has("key"));
+    }
+
+    // After both guards destroyed, key should be removed
+    EXPECT_FALSE(log->context().has("key"));
+}
+
+TEST_F(ScopedContextGuardTest, MoveAssignmentWorks) {
+    {
+        scoped_context_guard guard1(*log);
+        guard1.set("key1", std::string("value1"));
+
+        scoped_context_guard guard2(*log);
+        guard2.set("key2", std::string("value2"));
+
+        guard2 = std::move(guard1);
+
+        // guard2 now manages key1, key2 should be removed
+        EXPECT_TRUE(log->context().has("key1"));
+        EXPECT_FALSE(log->context().has("key2"));
+    }
+
+    EXPECT_FALSE(log->context().has("key1"));
+}
+
+// =========================================================================
+// Category Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, CategoryIsPreservedOnRestore) {
+    log->context().set("key", std::string("original"), context_category::trace);
+
+    {
+        scoped_context_guard guard(*log);
+        guard.set("key", std::string("modified"), context_category::custom);
+
+        // Value should be modified with custom category
+        EXPECT_EQ(*log->context().get_category("key"), context_category::custom);
+    }
+
+    // After restoration, original category should be restored
+    EXPECT_EQ(*log->context().get_category("key"), context_category::trace);
+}
+
+// =========================================================================
+// Multiple Keys Tests
+// =========================================================================
+
+TEST_F(ScopedContextGuardTest, MultipleKeysAreRemovedCorrectly) {
+    {
+        scoped_context_guard guard(*log);
+        guard.set("key1", std::string("value1"))
+             .set("key2", int64_t{42})
+             .set("key3", true)
+             .set_trace("trace", "span")
+             .set_request("request");
+
+        // All keys should be set
+        EXPECT_TRUE(log->context().has("key1"));
+        EXPECT_TRUE(log->context().has("key2"));
+        EXPECT_TRUE(log->context().has("key3"));
+        EXPECT_TRUE(log->context().has("trace_id"));
+        EXPECT_TRUE(log->context().has("span_id"));
+        EXPECT_TRUE(log->context().has("request_id"));
+    }
+
+    // All keys should be removed
+    EXPECT_FALSE(log->context().has("key1"));
+    EXPECT_FALSE(log->context().has("key2"));
+    EXPECT_FALSE(log->context().has("key3"));
+    EXPECT_FALSE(log->context().has("trace_id"));
+    EXPECT_FALSE(log->context().has("span_id"));
+    EXPECT_FALSE(log->context().has("request_id"));
+}


### PR DESCRIPTION
## Summary

Implements `scoped_context_guard` class for RAII-based automatic context management with the unified context API.

## Key Features

- **RAII Pattern**: Automatically saves and restores context on scope exit
- **Chainable Setters**: Fluent interface for convenient context configuration
- **Exception-Safe**: Guarantees context restoration even on exceptions
- **Move Semantics**: Supports returning from functions and transfer of ownership
- **Convenience Methods**: `set_trace()`, `set_request()`, `set_otel()`

## Implementation Details

```cpp
// Example 1: Request scoping
void handle_request(logger& log, const Request& req) {
    scoped_context_guard guard(log);
    guard.set_request(req.id(), req.correlation_id())
         .set("user_id", req.user_id());
    
    log.info("Processing request");
} // Context automatically restored

// Example 2: Nested scopes
void process_order(logger& log, int order_id) {
    scoped_context_guard order_ctx(log, "order_id", int64_t{order_id});
    
    {
        scoped_context_guard step_ctx(log, "step", "payment");
        log.info("Processing payment");
    } // "step" removed
    
    log.info("Order complete");
} // "order_id" removed
```

## Files Added

- `include/kcenon/logger/core/scoped_context_guard.h` - Class declaration
- `src/core/scoped_context_guard.cpp` - Implementation
- `tests/unit/core_test/scoped_context_guard_test.cpp` - Unit tests (18 test cases)
- `tests/CMakeLists.txt` - Updated to include new tests

## Test Coverage

All 18 unit tests passing:
- ✅ Basic constructor/destructor behavior
- ✅ Single value constructor
- ✅ Chainable setter methods
- ✅ Convenience methods (set_trace, set_request, set_otel)
- ✅ Nested scopes with proper restoration
- ✅ Exception safety
- ✅ Move constructor and assignment
- ✅ Category preservation
- ✅ Multiple key management

## Related Issues

Closes #387  
Part of #374 (EPIC: Consolidate logger_system context APIs)

## Test Plan

```bash
# Build
cmake --build build --config Release

# Run tests
cd build && ctest -R scoped_context_guard --output-on-failure
```

Result: 100% tests passed (1/1)