### PR TITLE
refactor(interfaces): enhance log_writer_interface for Decorator pattern

### DIFF
--- a/include/kcenon/logger/interfaces/log_writer_interface.h
+++ b/include/kcenon/logger/interfaces/log_writer_interface.h
@@ -9,6 +9,7 @@ All rights reserved.
 
 #include <string>
 #include <chrono>
+#include <memory>
 #include <kcenon/common/patterns/result.h>
 #include <kcenon/logger/core/error_codes.h>
 
@@ -19,10 +20,28 @@ struct log_entry;
 
 /**
  * @interface log_writer_interface
- * @brief Interface for log writers
+ * @brief Base interface for all log writers and decorators
  *
- * This interface defines the contract for all log writers.
+ * @details This interface defines the contract for all log writers.
+ * It serves as the foundation for the Decorator pattern, enabling composable
+ * log writer pipelines where writers can be wrapped with additional functionality
+ * (e.g., buffering, encryption, async processing).
+ *
  * Follows the Single Responsibility Principle - only responsible for writing logs.
+ * All methods use Result-based error handling for consistent error propagation.
+ *
+ * @note Implementations should be thread-safe when used in concurrent contexts.
+ *
+ * Example: Implementations must override write(), flush(), close(), is_open(),
+ * get_name(), and is_healthy() methods. See file_writer or console_writer for
+ * concrete examples.
+ *
+ * Decorator pattern usage: Writers can be composed by wrapping a base writer
+ * with decorators (e.g., buffered_writer wraps base writer, async_writer wraps
+ * buffered_writer) to create composable log processing pipelines.
+ *
+ * @since 1.0.0
+ * @since 4.0.0 Added close() and is_open() for Decorator pattern support
  */
 class log_writer_interface {
 public:
@@ -32,26 +51,99 @@ public:
      * @brief Write a log entry
      * @param entry The log entry to write
      * @return common::VoidResult indicating success or failure
+     *
+     * @details This method should write the provided log entry to the underlying
+     * output destination (file, console, network, etc.). The implementation may
+     * buffer the data and defer actual I/O until flush() is called.
+     *
+     * @note Thread-safety is implementation-dependent. Consult specific writer
+     * documentation for thread-safety guarantees.
      */
     virtual common::VoidResult write(const log_entry& entry) = 0;
 
     /**
      * @brief Flush any buffered data
      * @return common::VoidResult indicating success or failure
+     *
+     * @details Forces any buffered log entries to be written to the underlying
+     * output destination immediately. This method should be called before
+     * program termination or when immediate persistence is required.
+     *
+     * @note Some writers may perform synchronous I/O in this method, which
+     * could block for an extended period.
      */
     virtual common::VoidResult flush() = 0;
 
     /**
+     * @brief Close the writer and release resources
+     * @return common::VoidResult indicating success or failure
+     *
+     * @details Closes the writer, flushing any remaining buffered data and
+     * releasing all associated resources (file handles, network connections, etc.).
+     * After calling close(), the writer should not be used for further operations.
+     *
+     * @note Implementations should be idempotent - calling close() multiple times
+     * should not cause errors. Subsequent write() calls after close() may fail.
+     *
+     * Default implementation calls flush() and returns success. Subclasses with
+     * resources (file handles, connections) should override to release them.
+     *
+     * @since 4.0.0
+     */
+    virtual common::VoidResult close() {
+        return flush();
+    }
+
+    /**
+     * @brief Check if writer is open and ready
+     * @return true if the writer is open and ready to accept writes
+     *
+     * @details Returns whether the writer is in an operational state.
+     * A writer is considered open if:
+     * - Resources have been successfully initialized
+     * - close() has not been called
+     * - No fatal errors have occurred
+     *
+     * @note This method should be fast and non-blocking.
+     *
+     * Default implementation returns true (assumes always open). Subclasses with
+     * closeable resources should override to check actual state.
+     *
+     * @since 4.0.0
+     */
+    [[nodiscard]] virtual auto is_open() const -> bool {
+        return true;
+    }
+
+    /**
      * @brief Get the name of this writer
      * @return Writer name for identification
+     *
+     * @details Returns a human-readable name identifying this writer type.
+     * Useful for debugging, logging, and configuration.
+     *
+     * @example "file", "console", "network", "async", "buffered"
      */
     virtual std::string get_name() const = 0;
 
     /**
      * @brief Check if the writer is healthy
      * @return true if the writer is operational
+     *
+     * @details Returns whether the writer is functioning correctly.
+     * Unlike is_open(), this method may perform additional health checks
+     * such as verifying disk space, network connectivity, or buffer status.
+     *
+     * @note This method may be slower than is_open() due to additional checks.
      */
     virtual bool is_healthy() const = 0;
 };
+
+/**
+ * @brief Type alias for writer unique pointer
+ * @details Convenience alias for managing writer lifetime and ownership
+ * @since 4.0.0
+ */
+using log_writer_ptr = std::unique_ptr<log_writer_interface>;
 
 } // namespace kcenon::logger

--- a/include/kcenon/logger/writers/file_writer.h
+++ b/include/kcenon/logger/writers/file_writer.h
@@ -52,7 +52,7 @@ public:
     /**
      * @brief Check if file is open
      */
-    bool is_open() const { return file_stream_.is_open(); }
+    bool is_open() const override { return file_stream_.is_open(); }
 
     /**
      * @brief Get current file size
@@ -81,10 +81,10 @@ protected:
     common::VoidResult flush_impl() override;
 
     /**
-     * @brief Close the current file
+     * @brief Close the current file (internal)
      * @note Caller must hold the mutex
      */
-    void close();
+    void close_internal();
 
     /**
      * @brief Open the file

--- a/src/impl/writers/file_writer.cpp
+++ b/src/impl/writers/file_writer.cpp
@@ -22,7 +22,7 @@ file_writer::file_writer(const std::string& filename, bool append, size_t buffer
 }
 
 file_writer::~file_writer() {
-    close();
+    close_internal();
 }
 
 common::VoidResult file_writer::write_entry_impl(const log_entry& entry) {
@@ -56,11 +56,11 @@ common::VoidResult file_writer::flush_impl() {
 
 common::VoidResult file_writer::reopen() {
     std::lock_guard<std::mutex> lock(get_mutex());
-    close();
+    close_internal();
     return open();
 }
 
-void file_writer::close() {
+void file_writer::close_internal() {
     // IMPORTANT: Caller must hold the mutex before calling this method
     // This ensures thread safety with concurrent write() operations
 

--- a/src/impl/writers/network_writer.cpp
+++ b/src/impl/writers/network_writer.cpp
@@ -350,7 +350,7 @@ bool network_writer::connect() {
     struct hostent* server = gethostbyname(host_.c_str());
     if (!server) {
         std::cerr << "Failed to resolve host: " << host_ << std::endl;
-        close(socket_fd_);
+        ::close(socket_fd_);
         socket_fd_ = -1;
         return false;
     }
@@ -366,7 +366,7 @@ bool network_writer::connect() {
         if (::connect(socket_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
             std::cerr << "Failed to connect to " << host_ << ":" << port_
                      << " - " << strerror(errno) << std::endl;
-            close(socket_fd_);
+            ::close(socket_fd_);
             socket_fd_ = -1;
 
             std::lock_guard<std::mutex> lock(stats_mutex_);
@@ -378,7 +378,7 @@ bool network_writer::connect() {
         // For UDP, just save the server address
         if (::connect(socket_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
             std::cerr << "Failed to set UDP destination: " << strerror(errno) << std::endl;
-            close(socket_fd_);
+            ::close(socket_fd_);
             socket_fd_ = -1;
             return false;
         }
@@ -397,7 +397,7 @@ bool network_writer::connect() {
 
 void network_writer::disconnect() {
     if (socket_fd_ >= 0) {
-        close(socket_fd_);
+        ::close(socket_fd_);
         socket_fd_ = -1;
     }
     connected_ = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -571,6 +571,32 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/core_test/scoped_context_guard_test.
     message(STATUS "Scoped context guard tests: Added")
 endif()
 
+# Log entry structure tests (Issue #392)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/interfaces_test/log_entry_test.cpp")
+    add_executable(logger_log_entry_test
+        unit/interfaces_test/log_entry_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_log_entry_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_log_entry_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_log_entry_test
+        COMMAND logger_log_entry_test
+    )
+    set_target_properties(logger_log_entry_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Log entry structure tests: Added")
+endif()
+
 # Cleanup
 unset(_LOGGER_TEST_TARGETS)
 unset(_test_target)

--- a/tests/unit/interfaces_test/log_entry_test.cpp
+++ b/tests/unit/interfaces_test/log_entry_test.cpp
@@ -1,0 +1,283 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file log_entry_test.cpp
+ * @brief Unit tests for log_entry structure
+ * @details Tests log_entry construction, serialization, and field handling
+ * as required by Issue #392
+ */
+
+#include <gtest/gtest.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/logger/interfaces/log_writer_interface.h>
+#include <chrono>
+#include <thread>
+
+using namespace kcenon::logger;
+
+class LogEntryTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        timestamp_ = std::chrono::system_clock::now();
+    }
+
+    std::chrono::system_clock::time_point timestamp_;
+};
+
+// Test log_entry construction with all log levels
+TEST_F(LogEntryTest, AllLogLevelsRepresentation) {
+    // Test TRACE level
+    {
+        log_entry entry(log_level::trace, "Trace message", timestamp_);
+        EXPECT_EQ(entry.level, log_level::trace);
+        EXPECT_EQ(std::string(entry.message), "Trace message");
+        EXPECT_EQ(entry.timestamp, timestamp_);
+    }
+
+    // Test DEBUG level
+    {
+        log_entry entry(log_level::debug, "Debug message", timestamp_);
+        EXPECT_EQ(entry.level, log_level::debug);
+    }
+
+    // Test INFO level
+    {
+        log_entry entry(log_level::info, "Info message", timestamp_);
+        EXPECT_EQ(entry.level, log_level::info);
+    }
+
+    // Test WARN level
+    {
+        log_entry entry(log_level::warn, "Warn message", timestamp_);
+        EXPECT_EQ(entry.level, log_level::warn);
+    }
+
+    // Test ERROR level
+    {
+        log_entry entry(log_level::error, "Error message", timestamp_);
+        EXPECT_EQ(entry.level, log_level::error);
+    }
+
+    // Test FATAL level
+    {
+        log_entry entry(log_level::fatal, "Fatal message", timestamp_);
+        EXPECT_EQ(entry.level, log_level::fatal);
+    }
+}
+
+// Test log_entry construction with source location
+TEST_F(LogEntryTest, ConstructionWithSourceLocation) {
+    log_entry entry(
+        log_level::info,
+        "Test message",
+        __FILE__,
+        __LINE__,
+        __FUNCTION__,
+        timestamp_
+    );
+
+    EXPECT_EQ(entry.level, log_level::info);
+    EXPECT_EQ(std::string(entry.message), "Test message");
+    EXPECT_EQ(entry.timestamp, timestamp_);
+    EXPECT_TRUE(entry.location.has_value());
+
+    if (entry.location) {
+        EXPECT_FALSE(std::string(entry.location->file).empty());
+        EXPECT_GT(entry.location->line, 0);
+        EXPECT_FALSE(std::string(entry.location->function).empty());
+    }
+}
+
+// Test timestamp serialization and comparison
+TEST_F(LogEntryTest, TimestampSerialization) {
+    auto now = std::chrono::system_clock::now();
+    auto later = now + std::chrono::seconds(5);
+
+    log_entry entry1(log_level::info, "First message", now);
+    log_entry entry2(log_level::info, "Second message", later);
+
+    // Verify timestamps are preserved
+    EXPECT_EQ(entry1.timestamp, now);
+    EXPECT_EQ(entry2.timestamp, later);
+
+    // Verify chronological ordering
+    EXPECT_LT(entry1.timestamp, entry2.timestamp);
+
+    // Test timestamp duration
+    auto duration = std::chrono::duration_cast<std::chrono::seconds>(
+        entry2.timestamp - entry1.timestamp
+    );
+    EXPECT_EQ(duration.count(), 5);
+}
+
+// Test structured fields handling
+TEST_F(LogEntryTest, StructuredFieldsHandling) {
+    log_entry entry(log_level::info, "Structured message", timestamp_);
+
+    // Initially fields should not be present
+    EXPECT_FALSE(entry.fields.has_value());
+
+    // Add structured fields
+    log_fields fields;
+    fields["user_id"] = std::string("12345");
+    fields["count"] = static_cast<int64_t>(42);
+    fields["ratio"] = 3.14;
+    fields["enabled"] = true;
+
+    entry.fields = fields;
+
+    // Verify fields are present
+    EXPECT_TRUE(entry.fields.has_value());
+    EXPECT_EQ(entry.fields->size(), 4u);
+
+    // Verify field values
+    EXPECT_EQ(std::get<std::string>((*entry.fields)["user_id"]), "12345");
+    EXPECT_EQ(std::get<int64_t>((*entry.fields)["count"]), 42);
+    EXPECT_DOUBLE_EQ(std::get<double>((*entry.fields)["ratio"]), 3.14);
+    EXPECT_TRUE(std::get<bool>((*entry.fields)["enabled"]));
+}
+
+// Test move semantics
+TEST_F(LogEntryTest, MoveSemantics) {
+    log_entry original(log_level::warn, "Original message", timestamp_);
+    original.category = small_string_128("test_category");
+    original.thread_id = small_string_64("thread_123");
+
+    // Move construction
+    log_entry moved(std::move(original));
+
+    EXPECT_EQ(moved.level, log_level::warn);
+    EXPECT_EQ(std::string(moved.message), "Original message");
+    EXPECT_TRUE(moved.category.has_value());
+    EXPECT_TRUE(moved.thread_id.has_value());
+
+    if (moved.category) {
+        EXPECT_EQ(std::string(*moved.category), "test_category");
+    }
+    if (moved.thread_id) {
+        EXPECT_EQ(std::string(*moved.thread_id), "thread_123");
+    }
+}
+
+// Test optional fields
+TEST_F(LogEntryTest, OptionalFields) {
+    log_entry entry(log_level::debug, "Test", timestamp_);
+
+    // All optional fields should be empty initially
+    EXPECT_FALSE(entry.location.has_value());
+    EXPECT_FALSE(entry.thread_id.has_value());
+    EXPECT_FALSE(entry.category.has_value());
+    EXPECT_FALSE(entry.otel_ctx.has_value());
+    EXPECT_FALSE(entry.fields.has_value());
+
+    // Set optional fields
+    entry.thread_id = small_string_64("thread_456");
+    entry.category = small_string_128("network");
+
+    EXPECT_TRUE(entry.thread_id.has_value());
+    EXPECT_TRUE(entry.category.has_value());
+    EXPECT_EQ(std::string(*entry.thread_id), "thread_456");
+    EXPECT_EQ(std::string(*entry.category), "network");
+}
+
+// Test small_string optimization
+TEST_F(LogEntryTest, SmallStringOptimization) {
+    // Short message - should use SSO
+    {
+        std::string short_msg = "Short";
+        log_entry entry(log_level::info, short_msg, timestamp_);
+        EXPECT_EQ(std::string(entry.message), short_msg);
+    }
+
+    // Long message - may use heap allocation
+    {
+        std::string long_msg(512, 'x'); // Exceeds SSO threshold
+        log_entry entry(log_level::info, long_msg, timestamp_);
+        EXPECT_EQ(entry.message.size(), long_msg.size());
+        EXPECT_EQ(std::string(entry.message), long_msg);
+    }
+}
+
+// Test log_value variant types
+TEST_F(LogEntryTest, LogValueVariantTypes) {
+    log_value string_val = std::string("text");
+    log_value int_val = static_cast<int64_t>(100);
+    log_value double_val = 2.718;
+    log_value bool_val = false;
+
+    EXPECT_EQ(std::get<std::string>(string_val), "text");
+    EXPECT_EQ(std::get<int64_t>(int_val), 100);
+    EXPECT_DOUBLE_EQ(std::get<double>(double_val), 2.718);
+    EXPECT_FALSE(std::get<bool>(bool_val));
+
+    // Test variant index
+    EXPECT_EQ(string_val.index(), 0u); // std::string
+    EXPECT_EQ(int_val.index(), 1u);    // int64_t
+    EXPECT_EQ(double_val.index(), 2u); // double
+    EXPECT_EQ(bool_val.index(), 3u);   // bool
+}
+
+// Test source_location structure
+TEST_F(LogEntryTest, SourceLocationStructure) {
+    // Test construction from std::string
+    {
+        source_location loc("file.cpp", 42, "function_name");
+        EXPECT_EQ(std::string(loc.file), "file.cpp");
+        EXPECT_EQ(loc.line, 42);
+        EXPECT_EQ(std::string(loc.function), "function_name");
+    }
+
+    // Test construction from C-strings
+    {
+        source_location loc("main.cpp", 100, "main");
+        EXPECT_EQ(std::string(loc.file), "main.cpp");
+        EXPECT_EQ(loc.line, 100);
+        EXPECT_EQ(std::string(loc.function), "main");
+    }
+
+    // Test default construction
+    {
+        source_location loc("", 0, "");
+        EXPECT_TRUE(std::string(loc.file).empty());
+        EXPECT_EQ(loc.line, 0);
+        EXPECT_TRUE(std::string(loc.function).empty());
+    }
+}
+
+// Test log_writer_ptr type alias
+TEST_F(LogEntryTest, WriterPtrTypeAlias) {
+    // This test verifies the log_writer_ptr type alias exists and is usable
+    // We cannot instantiate it directly since log_writer_interface is abstract
+    using ptr_type = decltype(log_writer_ptr());
+    EXPECT_TRUE((std::is_same_v<ptr_type, std::unique_ptr<log_writer_interface>>));
+}


### PR DESCRIPTION
## Summary
Enhances `log_writer_interface` to support the Decorator pattern by adding resource management and state tracking methods.

### Key Changes
- Added `close()` method with default implementation for resource cleanup
- Added `is_open()` method with default implementation for state tracking
- Added `log_writer_ptr` type alias for ownership management
- Enhanced documentation with Decorator pattern usage examples

### Implementation Details
- `close()` provides default implementation that calls `flush()` and returns success
- `is_open()` provides default implementation that returns `true`
- Subclasses with resources (file handles, network connections) should override both methods
- Default implementations ensure backward compatibility with existing writers

### Bug Fixes
- Renamed `file_writer::close()` to `close_internal()` to avoid naming conflicts
- Added namespace resolution `::close()` for POSIX calls in `network_writer`

### Testing
- Added comprehensive unit tests for `log_entry` structure (/tests/unit/interfaces_test/log_entry_test.cpp:1)
- All tests pass successfully (verified with ctest)
- Tests cover:
  - All log levels representation
  - Timestamp serialization and ordering
  - Structured fields with variant types
  - Move semantics and optional fields
  - Small string optimization
  - Source location structure

Closes #392

## Test Plan
- [x] Unit tests pass (`ctest -R logger_log_entry_test`)
- [x] Full build succeeds
- [x] No regressions in existing tests