### PR TITLE
refactor(writers): enable async_writer to wrap log_writer_interface

### DIFF
--- a/include/kcenon/logger/writers/async_writer.h
+++ b/include/kcenon/logger/writers/async_writer.h
@@ -42,12 +42,26 @@ class async_writer : public queued_writer_base<std::queue<log_entry>> {
 
 public:
     /**
-     * @brief Constructor
+     * @brief Constructor accepting base_writer (legacy compatibility)
      * @param wrapped_writer The writer to wrap with async functionality
      * @param queue_size Maximum queue size for pending messages
      * @param flush_timeout Maximum time to wait for flush operation (in seconds)
      */
     explicit async_writer(std::unique_ptr<base_writer> wrapped_writer,
+                         std::size_t queue_size = 10000,
+                         std::chrono::seconds flush_timeout = std::chrono::seconds(5))
+        : base_type(static_cast<std::unique_ptr<log_writer_interface>>(std::move(wrapped_writer)), queue_size)
+        , flush_timeout_(flush_timeout)
+        , running_(false) {
+    }
+
+    /**
+     * @brief Constructor accepting log_writer_interface (Decorator pattern)
+     * @param wrapped_writer The writer to wrap with async functionality
+     * @param queue_size Maximum queue size for pending messages
+     * @param flush_timeout Maximum time to wait for flush operation (in seconds)
+     */
+    explicit async_writer(std::unique_ptr<log_writer_interface> wrapped_writer,
                          std::size_t queue_size = 10000,
                          std::chrono::seconds flush_timeout = std::chrono::seconds(5))
         : base_type(std::move(wrapped_writer), queue_size)


### PR DESCRIPTION
Closes #403

## Summary
- Updated async_writer to support wrapping log_writer_interface
- Modified queued_writer_base to accept both base_writer and log_writer_interface
- Maintains full backward compatibility with existing code
- Enables true Decorator pattern composition

## Changes Made

### queued_writer_base.h
- Added overloaded constructor accepting log_writer_interface
- Changed wrapped_writer_ type from base_writer* to log_writer_interface*
- Updated set_use_color to safely downcast when needed

### async_writer.h
- Added overloaded constructor accepting log_writer_interface
- Enables composability: async_writer(other_decorator(core_writer))

## Test Plan
- [x] All existing tests pass (22/23, 1 pre-existing failure)
- [x] Build succeeds without warnings
- [x] Backward compatibility verified (base_writer still works)
- [x] New log_writer_interface path tested

## Technical Details

The refactoring enables flexible writer composition:

```cpp
// Old way (fixed classes)
auto writer = std::make_unique<async_file_writer>("log.txt");

// New way (composable decorators)
auto writer = std::make_unique<async_writer>(
    std::make_unique<buffered_writer>(
        std::make_unique<file_writer>("log.txt")
    )
);
```

This is a critical step toward the Decorator pattern architecture outlined in #391.

## Breaking Changes
None - fully backward compatible.

## Next Steps
- Create buffered_decorator (#404)
- Create encrypted_decorator (#405)
- Implement writer_builder for fluent API (#406)