### PR TITLE
refactor(writers): enable async_writer to wrap log_writer_interface

### DIFF
--- a/include/kcenon/logger/writers/async_writer.h
+++ b/include/kcenon/logger/writers/async_writer.h
@@ -42,12 +42,26 @@ class async_writer : public queued_writer_base<std::queue<log_entry>> {
 
 public:
     /**
-     * @brief Constructor
+     * @brief Constructor accepting base_writer (legacy compatibility)
      * @param wrapped_writer The writer to wrap with async functionality
      * @param queue_size Maximum queue size for pending messages
      * @param flush_timeout Maximum time to wait for flush operation (in seconds)
      */
     explicit async_writer(std::unique_ptr<base_writer> wrapped_writer,
+                         std::size_t queue_size = 10000,
+                         std::chrono::seconds flush_timeout = std::chrono::seconds(5))
+        : base_type(static_cast<std::unique_ptr<log_writer_interface>>(std::move(wrapped_writer)), queue_size)
+        , flush_timeout_(flush_timeout)
+        , running_(false) {
+    }
+
+    /**
+     * @brief Constructor accepting log_writer_interface (Decorator pattern)
+     * @param wrapped_writer The writer to wrap with async functionality
+     * @param queue_size Maximum queue size for pending messages
+     * @param flush_timeout Maximum time to wait for flush operation (in seconds)
+     */
+    explicit async_writer(std::unique_ptr<log_writer_interface> wrapped_writer,
                          std::size_t queue_size = 10000,
                          std::chrono::seconds flush_timeout = std::chrono::seconds(5))
         : base_type(std::move(wrapped_writer), queue_size)


### PR DESCRIPTION
Closes #403

## Summary
- Enabled async_writer to accept log_writer_interface as Decorator pattern
- Added constructor overload accepting log_writer_interface
- Updated queued_writer_base to support both base_writer and log_writer_interface
- Modified set_use_color to safely handle log_writer_interface types

## Changes Made

### async_writer.h
- Added new constructor accepting `std::unique_ptr<log_writer_interface>`
- Maintained backward compatibility with existing `base_writer` constructor
- Updated documentation to clarify Decorator pattern usage

### queued_writer_base.h
- Added constructor overload for `log_writer_interface`
- Changed internal member type from `base_writer*` to `log_writer_interface*`
- Updated `set_use_color()` with dynamic_cast safety check for base_writer methods

## Impact
- **Backward Compatible**: Existing code using base_writer continues to work
- **Decorator Pattern**: Now supports composition with any log_writer_interface implementation
- **Type Safety**: Safe type casting with runtime checks

## Test Plan
- Verify existing async_writer tests pass
- Test composition with file_writer and console_writer
- Verify no regression in async processing functionality
- Build verification completed successfully