### PR TITLE
test(server,analysis,writers): add unit tests for log_server, log_analyzer, and rotating_file_writer

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -678,6 +678,104 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/thread_safe_writer_test
     message(STATUS "Thread-safe writer tests: Added")
 endif()
 
+# Log server tests (Issue #441 - log_server unit tests)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/server_test/log_server_test.cpp")
+    add_executable(logger_log_server_test
+        unit/server_test/log_server_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_log_server_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_log_server_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_log_server_test
+        COMMAND logger_log_server_test
+    )
+    set_target_properties(logger_log_server_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Log server tests: Added")
+endif()
+
+# Log analyzer tests (Issue #441 - log_analyzer unit tests)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/analysis_test/log_analyzer_test.cpp")
+    add_executable(logger_log_analyzer_test
+        unit/analysis_test/log_analyzer_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_log_analyzer_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_log_analyzer_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_log_analyzer_test
+        COMMAND logger_log_analyzer_test
+    )
+    set_target_properties(logger_log_analyzer_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Log analyzer tests: Added")
+endif()
+
+# Rotating file writer tests (Issue #441 - rotation logic unit tests)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/rotating_file_writer_test.cpp")
+    add_executable(logger_rotating_file_writer_test
+        unit/writers_test/rotating_file_writer_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_rotating_file_writer_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_rotating_file_writer_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_rotating_file_writer_test
+        COMMAND logger_rotating_file_writer_test
+    )
+    set_target_properties(logger_rotating_file_writer_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Rotating file writer tests: Added")
+endif()
+
+# Coverage registration for Issue #441 test targets
+if(TARGET logger_log_server_test)
+    list(APPEND _LOGGER_TEST_TARGETS logger_log_server_test)
+endif()
+
+if(TARGET logger_log_analyzer_test)
+    list(APPEND _LOGGER_TEST_TARGETS logger_log_analyzer_test)
+endif()
+
+if(TARGET logger_rotating_file_writer_test)
+    list(APPEND _LOGGER_TEST_TARGETS logger_rotating_file_writer_test)
+endif()
+
+# Register Issue #441 targets for coverage
+foreach(_test_target IN ITEMS logger_log_server_test logger_log_analyzer_test logger_rotating_file_writer_test)
+    if(TARGET ${_test_target} AND COMMAND logger_register_coverage_target)
+        logger_register_coverage_target(${_test_target})
+    endif()
+endforeach()
+
 # Cleanup
 unset(_LOGGER_TEST_TARGETS)
 unset(_test_target)

--- a/tests/unit/analysis_test/log_analyzer_test.cpp
+++ b/tests/unit/analysis_test/log_analyzer_test.cpp
@@ -1,0 +1,361 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file log_analyzer_test.cpp
+ * @brief Unit tests for log_analyzer (stats caching, filtering, search, error rate)
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/analysis/log_analyzer.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+using namespace kcenon::logger::analysis;
+
+// =============================================================================
+// Helper: create analyzed_log_entry with a given level, message, and timestamp
+// =============================================================================
+
+namespace {
+
+analyzed_log_entry make_entry(
+    log_level level,
+    const std::string& message,
+    std::chrono::system_clock::time_point ts = std::chrono::system_clock::now()) {
+    return analyzed_log_entry{level, message, ts, "test.cpp", 1, "test_func"};
+}
+
+} // namespace
+
+// =============================================================================
+// Test fixture
+// =============================================================================
+
+class LogAnalyzerTest : public ::testing::Test {
+protected:
+    log_analyzer analyzer_;
+};
+
+// =============================================================================
+// add_entry / add_entries
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, AddSingleEntry) {
+    analyzer_.add_entry(make_entry(log_level::info, "test message"));
+
+    const auto& stats = analyzer_.get_stats();
+    EXPECT_EQ(stats.total_entries, 1u);
+}
+
+TEST_F(LogAnalyzerTest, AddMultipleEntries) {
+    std::vector<analyzed_log_entry> entries;
+    entries.push_back(make_entry(log_level::info, "msg1"));
+    entries.push_back(make_entry(log_level::warn, "msg2"));
+    entries.push_back(make_entry(log_level::error, "msg3"));
+
+    analyzer_.add_entries(entries);
+
+    const auto& stats = analyzer_.get_stats();
+    EXPECT_EQ(stats.total_entries, 3u);
+}
+
+TEST_F(LogAnalyzerTest, AddEntriesAccumulates) {
+    analyzer_.add_entry(make_entry(log_level::info, "first"));
+
+    std::vector<analyzed_log_entry> batch;
+    batch.push_back(make_entry(log_level::debug, "second"));
+    batch.push_back(make_entry(log_level::trace, "third"));
+    analyzer_.add_entries(batch);
+
+    EXPECT_EQ(analyzer_.get_stats().total_entries, 3u);
+}
+
+// =============================================================================
+// clear
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, ClearRemovesAllEntries) {
+    analyzer_.add_entry(make_entry(log_level::info, "a"));
+    analyzer_.add_entry(make_entry(log_level::error, "b"));
+    EXPECT_EQ(analyzer_.get_stats().total_entries, 2u);
+
+    analyzer_.clear();
+    EXPECT_EQ(analyzer_.get_stats().total_entries, 0u);
+}
+
+// =============================================================================
+// get_stats dirty flag caching
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, StatsCachingDirtyFlagClearedAfterGetStats) {
+    analyzer_.add_entry(make_entry(log_level::info, "entry1"));
+
+    // First call computes stats (stats_dirty_ = true -> false)
+    const auto& stats1 = analyzer_.get_stats();
+    EXPECT_EQ(stats1.total_entries, 1u);
+
+    // Second call should return cached result without recomputation
+    const auto& stats2 = analyzer_.get_stats();
+    EXPECT_EQ(stats2.total_entries, 1u);
+    // Both should reference the same cached object
+    EXPECT_EQ(&stats1, &stats2);
+}
+
+TEST_F(LogAnalyzerTest, StatsBecomesDirtyAfterAddEntry) {
+    analyzer_.add_entry(make_entry(log_level::info, "first"));
+    const auto& stats1 = analyzer_.get_stats();
+    EXPECT_EQ(stats1.total_entries, 1u);
+
+    // Adding another entry should invalidate the cache
+    analyzer_.add_entry(make_entry(log_level::warn, "second"));
+    const auto& stats2 = analyzer_.get_stats();
+    EXPECT_EQ(stats2.total_entries, 2u);
+}
+
+TEST_F(LogAnalyzerTest, StatsBecomesDirtyAfterClear) {
+    analyzer_.add_entry(make_entry(log_level::info, "entry"));
+    EXPECT_EQ(analyzer_.get_stats().total_entries, 1u);
+
+    analyzer_.clear();
+    EXPECT_EQ(analyzer_.get_stats().total_entries, 0u);
+}
+
+// =============================================================================
+// get_stats level counts
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, StatsLevelCounts) {
+    analyzer_.add_entry(make_entry(log_level::info, "i1"));
+    analyzer_.add_entry(make_entry(log_level::info, "i2"));
+    analyzer_.add_entry(make_entry(log_level::error, "e1"));
+    analyzer_.add_entry(make_entry(log_level::warn, "w1"));
+
+    const auto& stats = analyzer_.get_stats();
+    EXPECT_EQ(stats.level_counts.at(log_level::info), 2u);
+    EXPECT_EQ(stats.level_counts.at(log_level::error), 1u);
+    EXPECT_EQ(stats.level_counts.at(log_level::warn), 1u);
+}
+
+// =============================================================================
+// get_stats timestamps
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, StatsTracksEarliestAndLatestTimestamps) {
+    auto t1 = std::chrono::system_clock::now() - std::chrono::hours(2);
+    auto t2 = std::chrono::system_clock::now() - std::chrono::hours(1);
+    auto t3 = std::chrono::system_clock::now();
+
+    analyzer_.add_entry(make_entry(log_level::info, "mid", t2));
+    analyzer_.add_entry(make_entry(log_level::info, "earliest", t1));
+    analyzer_.add_entry(make_entry(log_level::info, "latest", t3));
+
+    const auto& stats = analyzer_.get_stats();
+    EXPECT_EQ(stats.earliest_timestamp, t1);
+    EXPECT_EQ(stats.latest_timestamp, t3);
+}
+
+TEST_F(LogAnalyzerTest, StatsEmptyEntriesHandledGracefully) {
+    const auto& stats = analyzer_.get_stats();
+    EXPECT_EQ(stats.total_entries, 0u);
+    EXPECT_TRUE(stats.level_counts.empty());
+}
+
+// =============================================================================
+// filter_by_level
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, FilterByLevelReturnsMatchingEntries) {
+    analyzer_.add_entry(make_entry(log_level::info, "info msg"));
+    analyzer_.add_entry(make_entry(log_level::error, "error msg"));
+    analyzer_.add_entry(make_entry(log_level::info, "another info"));
+
+    auto filtered = analyzer_.filter_by_level(log_level::info);
+    EXPECT_EQ(filtered.size(), 2u);
+    EXPECT_EQ(filtered[0].message, "info msg");
+    EXPECT_EQ(filtered[1].message, "another info");
+}
+
+TEST_F(LogAnalyzerTest, FilterByLevelReturnsEmptyWhenNoMatch) {
+    analyzer_.add_entry(make_entry(log_level::info, "info only"));
+
+    auto filtered = analyzer_.filter_by_level(log_level::fatal);
+    EXPECT_TRUE(filtered.empty());
+}
+
+// =============================================================================
+// filter_by_time_range
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, FilterByTimeRangeReturnsEntriesInRange) {
+    auto now = std::chrono::system_clock::now();
+    auto t1 = now - std::chrono::hours(3);
+    auto t2 = now - std::chrono::hours(2);
+    auto t3 = now - std::chrono::hours(1);
+
+    analyzer_.add_entry(make_entry(log_level::info, "old", t1));
+    analyzer_.add_entry(make_entry(log_level::info, "mid", t2));
+    analyzer_.add_entry(make_entry(log_level::info, "recent", t3));
+
+    // Filter: between 2.5 hours ago and 0.5 hours ago
+    auto start = now - std::chrono::minutes(150);
+    auto end = now - std::chrono::minutes(30);
+
+    auto filtered = analyzer_.filter_by_time_range(start, end);
+    EXPECT_EQ(filtered.size(), 2u);
+    EXPECT_EQ(filtered[0].message, "mid");
+    EXPECT_EQ(filtered[1].message, "recent");
+}
+
+TEST_F(LogAnalyzerTest, FilterByTimeRangeEmptyResult) {
+    auto now = std::chrono::system_clock::now();
+    analyzer_.add_entry(make_entry(log_level::info, "entry", now));
+
+    // Range entirely in the past
+    auto start = now - std::chrono::hours(10);
+    auto end = now - std::chrono::hours(5);
+
+    auto filtered = analyzer_.filter_by_time_range(start, end);
+    EXPECT_TRUE(filtered.empty());
+}
+
+// =============================================================================
+// search_messages
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, SearchMessagesFindsMatches) {
+    analyzer_.add_entry(make_entry(log_level::info, "database connection established"));
+    analyzer_.add_entry(make_entry(log_level::error, "database connection failed"));
+    analyzer_.add_entry(make_entry(log_level::info, "user logged in"));
+
+    auto results = analyzer_.search_messages("database");
+    EXPECT_EQ(results.size(), 2u);
+}
+
+TEST_F(LogAnalyzerTest, SearchMessagesPartialMatch) {
+    analyzer_.add_entry(make_entry(log_level::info, "processing request #123"));
+
+    auto results = analyzer_.search_messages("request");
+    EXPECT_EQ(results.size(), 1u);
+    EXPECT_EQ(results[0].message, "processing request #123");
+}
+
+TEST_F(LogAnalyzerTest, SearchMessagesNoMatch) {
+    analyzer_.add_entry(make_entry(log_level::info, "hello world"));
+
+    auto results = analyzer_.search_messages("nonexistent");
+    EXPECT_TRUE(results.empty());
+}
+
+// =============================================================================
+// get_error_rate
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, ErrorRateWithinWindow) {
+    auto now = std::chrono::system_clock::now();
+
+    // Add entries within the last 60 minutes
+    analyzer_.add_entry(make_entry(log_level::info, "ok", now - std::chrono::minutes(10)));
+    analyzer_.add_entry(make_entry(log_level::info, "ok", now - std::chrono::minutes(5)));
+    analyzer_.add_entry(make_entry(log_level::error, "err", now - std::chrono::minutes(3)));
+    analyzer_.add_entry(make_entry(log_level::fatal, "fatal", now - std::chrono::minutes(1)));
+
+    // 2 error/fatal out of 4 entries = 0.5
+    double rate = analyzer_.get_error_rate(std::chrono::minutes(60));
+    EXPECT_DOUBLE_EQ(rate, 0.5);
+}
+
+TEST_F(LogAnalyzerTest, ErrorRateZeroWhenNoErrors) {
+    auto now = std::chrono::system_clock::now();
+    analyzer_.add_entry(make_entry(log_level::info, "ok", now));
+
+    double rate = analyzer_.get_error_rate(std::chrono::minutes(60));
+    EXPECT_DOUBLE_EQ(rate, 0.0);
+}
+
+TEST_F(LogAnalyzerTest, ErrorRateZeroWhenNoEntriesInWindow) {
+    auto old = std::chrono::system_clock::now() - std::chrono::hours(24);
+    analyzer_.add_entry(make_entry(log_level::error, "old error", old));
+
+    // Window of 60 minutes should not include 24-hour-old entry
+    double rate = analyzer_.get_error_rate(std::chrono::minutes(60));
+    EXPECT_DOUBLE_EQ(rate, 0.0);
+}
+
+TEST_F(LogAnalyzerTest, ErrorRateEmptyAnalyzer) {
+    double rate = analyzer_.get_error_rate(std::chrono::minutes(60));
+    EXPECT_DOUBLE_EQ(rate, 0.0);
+}
+
+// =============================================================================
+// generate_summary_report
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, GenerateSummaryReportContainsExpectedSections) {
+    analyzer_.add_entry(make_entry(log_level::info, "msg1"));
+    analyzer_.add_entry(make_entry(log_level::error, "msg2"));
+
+    auto report = analyzer_.generate_summary_report();
+
+    EXPECT_NE(report.find("Log Analysis Summary"), std::string::npos);
+    EXPECT_NE(report.find("Total Entries: 2"), std::string::npos);
+    EXPECT_NE(report.find("Level Distribution"), std::string::npos);
+}
+
+TEST_F(LogAnalyzerTest, GenerateSummaryReportEmptyAnalyzer) {
+    auto report = analyzer_.generate_summary_report();
+
+    EXPECT_NE(report.find("Total Entries: 0"), std::string::npos);
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+TEST_F(LogAnalyzerTest, FactoryCreateBasic) {
+    auto analyzer = analyzer_factory::create_basic();
+
+    ASSERT_NE(analyzer, nullptr);
+    EXPECT_EQ(analyzer->get_stats().total_entries, 0u);
+}
+
+TEST_F(LogAnalyzerTest, FactoryCreatedAnalyzerIsFullyFunctional) {
+    auto analyzer = analyzer_factory::create_basic();
+
+    analyzer->add_entry(make_entry(log_level::warn, "test"));
+    EXPECT_EQ(analyzer->get_stats().total_entries, 1u);
+    EXPECT_EQ(analyzer->filter_by_level(log_level::warn).size(), 1u);
+}

--- a/tests/unit/server_test/log_server_test.cpp
+++ b/tests/unit/server_test/log_server_test.cpp
@@ -1,0 +1,220 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file log_server_test.cpp
+ * @brief Unit tests for log_server (construction, lifecycle, factory)
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/server/log_server.h>
+
+#include <thread>
+
+using namespace kcenon::logger::server;
+
+// =============================================================================
+// Test fixture
+// =============================================================================
+
+class LogServerTest : public ::testing::Test {
+protected:
+    void TearDown() override {
+        // Ensure any started servers are stopped
+    }
+};
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+TEST_F(LogServerTest, DefaultConstruction) {
+    log_server server;
+
+    EXPECT_FALSE(server.is_running());
+    EXPECT_EQ(server.get_config().host, "localhost");
+    EXPECT_EQ(server.get_config().port, 9999);
+    EXPECT_EQ(server.get_config().max_connections, 100u);
+    EXPECT_EQ(server.get_config().buffer_size, 8192u);
+    EXPECT_FALSE(server.get_config().enable_compression);
+    EXPECT_FALSE(server.get_config().enable_encryption);
+}
+
+TEST_F(LogServerTest, CustomConfigConstruction) {
+    server_config config;
+    config.host = "0.0.0.0";
+    config.port = 8080;
+    config.max_connections = 50;
+    config.buffer_size = 4096;
+    config.enable_compression = true;
+    config.enable_encryption = true;
+
+    log_server server(config);
+
+    EXPECT_EQ(server.get_config().host, "0.0.0.0");
+    EXPECT_EQ(server.get_config().port, 8080);
+    EXPECT_EQ(server.get_config().max_connections, 50u);
+    EXPECT_EQ(server.get_config().buffer_size, 4096u);
+    EXPECT_TRUE(server.get_config().enable_compression);
+    EXPECT_TRUE(server.get_config().enable_encryption);
+}
+
+// =============================================================================
+// Start / Stop lifecycle
+// =============================================================================
+
+TEST_F(LogServerTest, StartSetsRunningState) {
+    log_server server;
+
+    EXPECT_FALSE(server.is_running());
+    EXPECT_TRUE(server.start());
+    EXPECT_TRUE(server.is_running());
+
+    server.stop();
+    EXPECT_FALSE(server.is_running());
+}
+
+TEST_F(LogServerTest, DoubleStartReturnsFalse) {
+    log_server server;
+
+    EXPECT_TRUE(server.start());
+    EXPECT_FALSE(server.start());
+
+    server.stop();
+}
+
+TEST_F(LogServerTest, StopWhenNotRunningIsNoOp) {
+    log_server server;
+
+    // Calling stop on a non-running server should not crash
+    server.stop();
+    EXPECT_FALSE(server.is_running());
+}
+
+TEST_F(LogServerTest, StopThenRestartWorks) {
+    log_server server;
+
+    EXPECT_TRUE(server.start());
+    server.stop();
+    EXPECT_FALSE(server.is_running());
+
+    // Should be able to restart after stop
+    EXPECT_TRUE(server.start());
+    EXPECT_TRUE(server.is_running());
+
+    server.stop();
+}
+
+// =============================================================================
+// Destructor
+// =============================================================================
+
+TEST_F(LogServerTest, DestructorStopsRunningServer) {
+    {
+        log_server server;
+        server.start();
+        EXPECT_TRUE(server.is_running());
+        // Destructor should call stop() and join all threads
+    }
+    // If we reach here without hanging, the destructor worked correctly
+    SUCCEED();
+}
+
+// =============================================================================
+// Worker thread count
+// =============================================================================
+
+TEST_F(LogServerTest, WorkerThreadCountMatchesHardwareConcurrency) {
+    // This test verifies that start() creates the expected number of threads.
+    // We can't directly access worker_threads_ since it's private,
+    // but we verify that start() succeeds and the server operates correctly
+    // with multiple threads.
+    log_server server;
+    EXPECT_TRUE(server.start());
+    EXPECT_TRUE(server.is_running());
+
+    // Allow worker threads to begin their loops
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+    // Server should still be running after threads have started
+    EXPECT_TRUE(server.is_running());
+
+    server.stop();
+    EXPECT_FALSE(server.is_running());
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+TEST_F(LogServerTest, FactoryCreateBasicWithDefaultConfig) {
+    auto server = log_server_factory::create_basic();
+
+    ASSERT_NE(server, nullptr);
+    EXPECT_FALSE(server->is_running());
+    EXPECT_EQ(server->get_config().host, "localhost");
+    EXPECT_EQ(server->get_config().port, 9999);
+}
+
+TEST_F(LogServerTest, FactoryCreateBasicWithCustomConfig) {
+    server_config config;
+    config.host = "10.0.0.1";
+    config.port = 5555;
+
+    auto server = log_server_factory::create_basic(config);
+
+    ASSERT_NE(server, nullptr);
+    EXPECT_EQ(server->get_config().host, "10.0.0.1");
+    EXPECT_EQ(server->get_config().port, 5555);
+}
+
+TEST_F(LogServerTest, FactoryCreateDefault) {
+    auto server = log_server_factory::create_default();
+
+    ASSERT_NE(server, nullptr);
+    EXPECT_FALSE(server->is_running());
+    // create_default uses default server_config values
+    EXPECT_EQ(server->get_config().host, "localhost");
+    EXPECT_EQ(server->get_config().port, 9999);
+}
+
+TEST_F(LogServerTest, FactoryCreatedServerCanStartStop) {
+    auto server = log_server_factory::create_basic();
+
+    EXPECT_TRUE(server->start());
+    EXPECT_TRUE(server->is_running());
+
+    server->stop();
+    EXPECT_FALSE(server->is_running());
+}

--- a/tests/unit/writers_test/rotating_file_writer_test.cpp
+++ b/tests/unit/writers_test/rotating_file_writer_test.cpp
@@ -1,0 +1,286 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file rotating_file_writer_test.cpp
+ * @brief Unit tests for rotating_file_writer rotation logic
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/writers/rotating_file_writer.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::logger;
+using log_level = kcenon::common::interfaces::log_level;
+
+// =============================================================================
+// Test fixture with temporary directory management
+// =============================================================================
+
+class RotatingFileWriterTest : public ::testing::Test {
+protected:
+    std::filesystem::path temp_dir_;
+
+    void SetUp() override {
+        temp_dir_ = std::filesystem::temp_directory_path() / "rotating_writer_test";
+        std::filesystem::create_directories(temp_dir_);
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove_all(temp_dir_, ec);
+    }
+
+    std::string test_file(const std::string& name = "test.log") const {
+        return (temp_dir_ / name).string();
+    }
+
+    log_entry make_entry(const std::string& msg) const {
+        return log_entry(log_level::info, msg);
+    }
+
+    size_t count_files_in_dir() const {
+        size_t count = 0;
+        for (const auto& entry : std::filesystem::directory_iterator(temp_dir_)) {
+            if (entry.is_regular_file()) {
+                ++count;
+            }
+        }
+        return count;
+    }
+};
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, SizeBasedConstruction) {
+    rotating_file_writer writer(test_file(), 1024, 3);
+
+    EXPECT_EQ(writer.get_name(), "rotating_file");
+}
+
+TEST_F(RotatingFileWriterTest, TimeBasedConstructionDaily) {
+    rotating_file_writer writer(test_file(), rotation_type::daily, 3);
+
+    EXPECT_EQ(writer.get_name(), "rotating_file");
+}
+
+TEST_F(RotatingFileWriterTest, TimeBasedConstructionHourly) {
+    rotating_file_writer writer(test_file(), rotation_type::hourly, 5);
+
+    EXPECT_EQ(writer.get_name(), "rotating_file");
+}
+
+TEST_F(RotatingFileWriterTest, CombinedConstructionSizeAndTime) {
+    rotating_file_writer writer(
+        test_file(), rotation_type::size_and_time, 2048u, 3u, 100u);
+
+    EXPECT_EQ(writer.get_name(), "rotating_file");
+}
+
+TEST_F(RotatingFileWriterTest, CombinedConstructionThrowsForNonSizeAndTime) {
+    // Pass 5 args to unambiguously select the combined constructor
+    EXPECT_THROW(
+        rotating_file_writer(test_file(), rotation_type::daily, 1024u, 3u, 100u),
+        std::invalid_argument);
+}
+
+TEST_F(RotatingFileWriterTest, CombinedConstructionThrowsForSizeOnly) {
+    EXPECT_THROW(
+        rotating_file_writer(test_file(), rotation_type::size, 1024u, 3u, 100u),
+        std::invalid_argument);
+}
+
+TEST_F(RotatingFileWriterTest, DefaultExtensionWhenNoExtension) {
+    // File without extension should get .log appended internally
+    rotating_file_writer writer(
+        (temp_dir_ / "logfile").string(), 1024, 3);
+
+    EXPECT_EQ(writer.get_name(), "rotating_file");
+}
+
+// =============================================================================
+// Basic write
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, WriteCreatesFile) {
+    rotating_file_writer writer(test_file(), 1024, 3);
+
+    auto result = writer.write(make_entry("hello world"));
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(std::filesystem::exists(test_file()));
+}
+
+TEST_F(RotatingFileWriterTest, WriteMultipleEntries) {
+    rotating_file_writer writer(test_file(), 4096, 3);
+
+    for (int i = 0; i < 10; ++i) {
+        auto result = writer.write(make_entry("message " + std::to_string(i)));
+        EXPECT_TRUE(result.is_ok());
+    }
+}
+
+// =============================================================================
+// Size-based rotation
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, SizeBasedRotationCreatesBackupFile) {
+    // Small max_size and check_interval=1 to trigger rotation quickly
+    rotating_file_writer writer(test_file(), 50, 5, 1);
+
+    // Write enough data to exceed 50 bytes and trigger rotation
+    for (int i = 0; i < 20; ++i) {
+        writer.write(make_entry("This is a test message that is fairly long " + std::to_string(i)));
+    }
+
+    // Should have created backup files
+    EXPECT_GT(count_files_in_dir(), 1u);
+}
+
+// =============================================================================
+// Manual rotation
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, ManualRotateCreatesBackupFile) {
+    rotating_file_writer writer(test_file(), 1024 * 1024, 5);
+
+    // Write some data
+    writer.write(make_entry("before rotation"));
+
+    // Manually trigger rotation
+    writer.rotate();
+
+    // Write more data to the new file
+    writer.write(make_entry("after rotation"));
+
+    // Should have original + backup
+    EXPECT_GE(count_files_in_dir(), 2u);
+}
+
+TEST_F(RotatingFileWriterTest, ManualRotateMultipleTimes) {
+    rotating_file_writer writer(test_file(), 1024 * 1024, 10);
+
+    for (int i = 0; i < 3; ++i) {
+        writer.write(make_entry("message " + std::to_string(i)));
+        writer.rotate();
+    }
+
+    // Should have 3 backup files + 1 current file
+    EXPECT_GE(count_files_in_dir(), 3u);
+}
+
+// =============================================================================
+// Cleanup old files
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, MultipleRotationsCreateBackupFiles) {
+    rotating_file_writer writer(test_file(), 1024 * 1024, 5);
+
+    // Create 3 rotations with writes between them
+    for (int i = 0; i < 3; ++i) {
+        writer.write(make_entry("msg " + std::to_string(i)));
+        writer.rotate();
+    }
+
+    // Should have at least the current file + some backup files
+    EXPECT_GE(count_files_in_dir(), 2u);
+}
+
+// =============================================================================
+// Check interval optimization
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, CheckIntervalSkipsRotationCheck) {
+    // max_size = 50 bytes, check_interval = 100
+    // With check_interval=100, rotation check happens only every 100 writes
+    rotating_file_writer writer(test_file(), 50, 5, 100);
+
+    // Write 50 entries (below check_interval threshold)
+    for (int i = 0; i < 50; ++i) {
+        writer.write(make_entry("msg"));
+    }
+
+    // Despite exceeding max_size, rotation check hasn't triggered yet
+    // because writes_since_check < check_interval (50 < 100)
+    // Only the main file should exist (no rotation happened)
+    EXPECT_EQ(count_files_in_dir(), 1u);
+}
+
+TEST_F(RotatingFileWriterTest, CheckIntervalTriggersRotationAtThreshold) {
+    // max_size = 50 bytes, check_interval = 10
+    rotating_file_writer writer(test_file(), 50, 5, 10);
+
+    // Write enough entries to cross the check_interval threshold
+    // and have file size exceed max_size
+    for (int i = 0; i < 30; ++i) {
+        writer.write(make_entry("A longer test message for rotation testing " + std::to_string(i)));
+    }
+
+    // Rotation should have occurred after check_interval writes
+    EXPECT_GT(count_files_in_dir(), 1u);
+}
+
+// =============================================================================
+// get_name
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, GetNameReturnsCorrectValue) {
+    rotating_file_writer writer(test_file(), 1024, 3);
+    EXPECT_EQ(writer.get_name(), "rotating_file");
+}
+
+// =============================================================================
+// Write after rotation continues working
+// =============================================================================
+
+TEST_F(RotatingFileWriterTest, WriteAfterRotationSucceeds) {
+    rotating_file_writer writer(test_file(), 1024 * 1024, 5);
+
+    writer.write(make_entry("before"));
+    writer.rotate();
+
+    auto result = writer.write(make_entry("after rotation"));
+    EXPECT_TRUE(result.is_ok());
+
+    // Verify the main log file exists (content may be buffered)
+    EXPECT_TRUE(std::filesystem::exists(test_file()));
+}


### PR DESCRIPTION
Closes #441

## Summary
- Add 12 unit tests for `log_server`: construction, start/stop lifecycle, double-start idempotency, destructor auto-stop, worker thread verification, and factory methods
- Add 25 unit tests for `log_analyzer`: entry management, stats dirty-flag caching, level counts, timestamp tracking, filtering (by level, time range), message search, error rate computation, summary report generation, and factory
- Add 17 unit tests for `rotating_file_writer`: size/time/combined constructors, `invalid_argument` validation, basic write, size-based rotation trigger, manual `rotate()`, check_interval optimization, and write continuity after rotation
- Update `tests/CMakeLists.txt` with 3 new test targets and coverage registration

## Test Plan
- [x] All 54 new tests pass locally (12 + 25 + 17)
- [x] Full project build succeeds with all test targets
- [x] Tests use temporary directories cleaned up via TearDown
- [x] CI workflows pass