### PR TITLE
chore(deps): pin OTLP dependency versions

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -41,11 +41,18 @@
       "dependencies": [
         {
           "name": "opentelemetry-cpp",
+          "version>=": "1.14.0",
           "default-features": false,
           "features": ["otlp-http", "otlp-grpc"]
         },
-        "protobuf",
-        "grpc"
+        {
+          "name": "protobuf",
+          "version>=": "3.21.0"
+        },
+        {
+          "name": "grpc",
+          "version>=": "1.51.1"
+        }
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Pin `opentelemetry-cpp` to `>= 1.14.0` (stable OTLP exporters)
- Pin `protobuf` to `>= 3.21.0` (proto3 optional field support)
- Pin `grpc` to `>= 1.51.1` (security fixes)

Ensures SOUP traceability per IEC 62304.

## Test Plan

- [x] `vcpkg.json` passes JSON validation
- [x] CI build succeeds

Closes #451