### PR TITLE
Add vcpkg version overrides for IEC 62304 compliance

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,6 +13,16 @@
       "version>=": "10.0.0"
     }
   ],
+  "overrides": [
+    { "name": "fmt", "version": "10.2.1" },
+    { "name": "openssl", "version": "3.3.0" },
+    { "name": "spdlog", "version": "1.13.0" },
+    { "name": "opentelemetry-cpp", "version": "1.14.2" },
+    { "name": "protobuf", "version": "3.21.12" },
+    { "name": "grpc", "version": "1.51.1" },
+    { "name": "gtest", "version": "1.14.0" },
+    { "name": "benchmark", "version": "1.8.3" }
+  ],
   "features": {
     "encryption": {
       "description": "Enable encrypted log writer with AES-256-GCM",


### PR DESCRIPTION
## Summary
Add vcpkg version overrides to pin exact SOUP versions for IEC 62304 Clause 8.1.2 compliance (configuration items shall be uniquely identified).

Versions are pinned from vcpkg baseline c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d.

## Motivation
- Closes the gap between web/server SOUP version pinning (npm ci, pip --require-hashes) and C++ ecosystem
- Ensures reproducible builds even if vcpkg baseline is updated
- Refs kcenon/flonics_project#245

## Test plan
- [x] Verify vcpkg.json is valid JSON
- [x] Verify overrides match baseline versions
- [x] Verify CI build succeeds with pinned versions