### PR TITLE
refactor(deps): remove unused fmt dependency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,14 +7,8 @@
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",
   "supports": "!(uwp | xbox)",
-  "dependencies": [
-    {
-      "name": "fmt",
-      "version>=": "10.0.0"
-    }
-  ],
+  "dependencies": [],
   "overrides": [
-    { "name": "fmt", "version": "10.2.1" },
     { "name": "openssl", "version": "3.3.0" },
     { "name": "spdlog", "version": "1.13.0" },
     { "name": "opentelemetry-cpp", "version": "1.14.2" },


### PR DESCRIPTION
## Summary

- Remove fmt from vcpkg.json dependencies and overrides
- Source code already migrated to std::format (2025-12-03 per CHANGELOG)
- No C++ source files use fmt::format or #include <fmt/...>

## Test plan

- [x] vcpkg.json is valid JSON
- [x] CI build passes without fmt dependency
- [x] No source files reference fmt headers or functions
- [x] All unit and integration tests pass

Closes #457