### PR TITLE
refactor(arch): resolve thread_system bidirectional dependency risk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,47 +206,42 @@ endif()
 option(LOGGER_USE_THREAD_SYSTEM "Enable optional thread_system integration" OFF)
 
 ##################################################
-# Bidirectional Dependency Check (Issue #252)
+# Bidirectional Dependency Guard (Issue #252 — Resolved)
 ##################################################
-# WARNING: Circular dependency risk exists between logger_system and thread_system
+# The bidirectional dependency risk between logger_system and thread_system has been
+# resolved. thread_system's BUILD_WITH_LOGGER_SYSTEM is deprecated (thread_system#336)
+# and scheduled for removal in v0.5.0.0.
 #
-# Possible configurations:
-# - logger_system → thread_system (LOGGER_USE_THREAD_SYSTEM=ON): Uses thread_pool for async I/O
-# - thread_system → logger_system (BUILD_WITH_LOGGER_SYSTEM=ON): Uses logger for debug output
+# This guard remains as a safety check during the transition period.
+# Direction: logger_system → thread_system (optional, unidirectional)
+# Removed:  thread_system → logger_system (deprecated, uses ILogger DI instead)
 #
-# RECOMMENDATION: Enable only ONE direction in production:
-# - Preferred: logger_system → thread_system (for async performance)
-# - Avoid: Bidirectional dependency (may cause build order issues)
-#
-# See: docs/integration/THREAD_SYSTEM.md for recommended configurations
+# See: docs/DEPENDENCY_ARCHITECTURE.md for the resolved dependency graph
+# See: docs/integration/THREAD_SYSTEM.md for integration options
 
-function(check_bidirectional_dependency_risk)
+function(check_bidirectional_dependency_guard)
     # Check if we're enabling logger → thread direction
     if(LOGGER_USE_THREAD_SYSTEM)
-        # Check if thread_system has reverse dependency (thread → logger)
+        # Check if thread_system still has deprecated reverse dependency (thread → logger)
         if(DEFINED BUILD_WITH_LOGGER_SYSTEM AND BUILD_WITH_LOGGER_SYSTEM)
             message(WARNING
                 "=================================================================\n"
-                "BIDIRECTIONAL DEPENDENCY RISK DETECTED (Issue #252)\n"
+                "DEPRECATED CONFIGURATION DETECTED (Issue #252)\n"
                 "=================================================================\n"
                 "  logger_system → thread_system (LOGGER_USE_THREAD_SYSTEM=ON)\n"
                 "  thread_system → logger_system (BUILD_WITH_LOGGER_SYSTEM=ON)\n"
                 "\n"
-                "This configuration may cause:\n"
-                "  - Build order issues in unified builds\n"
-                "  - Circular header include problems\n"
-                "  - Initialization order complications\n"
+                "BUILD_WITH_LOGGER_SYSTEM is deprecated in thread_system (see\n"
+                "thread_system#336) and scheduled for removal in v0.5.0.0.\n"
+                "thread_system now uses ILogger dependency injection instead.\n"
                 "\n"
-                "RECOMMENDATION:\n"
-                "  Enable only ONE direction. Preferred configuration:\n"
-                "    LOGGER_USE_THREAD_SYSTEM=ON (for async I/O performance)\n"
-                "    BUILD_WITH_LOGGER_SYSTEM=OFF (disable reverse dependency)\n"
-                "\n"
-                "See: docs/integration/THREAD_SYSTEM.md#dependency-configuration\n"
+                "ACTION:\n"
+                "  Set BUILD_WITH_LOGGER_SYSTEM=OFF and use ILogger DI approach.\n"
+                "  See: docs/DEPENDENCY_ARCHITECTURE.md\n"
                 "=================================================================")
         endif()
 
-        # Additional check: Inspect thread_system target for reverse dependency
+        # Additional check: Inspect thread_system target for deprecated reverse dependency
         if(TARGET thread_system::thread_system)
             get_target_property(THREAD_DEFS thread_system::thread_system
                                INTERFACE_COMPILE_DEFINITIONS)
@@ -254,17 +249,17 @@ function(check_bidirectional_dependency_risk)
                 string(FIND "${THREAD_DEFS}" "BUILD_WITH_LOGGER_SYSTEM" _bidep_pos)
                 if(NOT _bidep_pos EQUAL -1)
                     message(WARNING
-                        "Bidirectional dependency detected: thread_system target has "
+                        "Deprecated configuration detected: thread_system target has "
                         "BUILD_WITH_LOGGER_SYSTEM in compile definitions. "
-                        "Consider disabling one direction.")
+                        "This is deprecated (thread_system#336) and will be removed in v0.5.0.0.")
                 endif()
             endif()
         endif()
     endif()
 endfunction()
 
-# Perform dependency check
-check_bidirectional_dependency_risk()
+# Perform dependency guard check
+check_bidirectional_dependency_guard()
 
 if(LOGGER_USE_THREAD_SYSTEM)
     unified_find_dependency(thread_system QUIET)

--- a/docs/DEPENDENCY_ARCHITECTURE.md
+++ b/docs/DEPENDENCY_ARCHITECTURE.md
@@ -1,0 +1,97 @@
+# Dependency Architecture
+
+## Overview
+
+logger_system follows a strict unidirectional dependency model using a tiered architecture. The bidirectional dependency risk identified in Issue #252 has been resolved.
+
+## Dependency Tiers
+
+```
+Tier 0: common_system (ILogger, IExecutor, Result<T>)
+           ^            ^
+           |            |
+Tier 1: thread_system   |
+           ^            |
+           |            |
+Tier 2: logger_system --+
+           (optional: LOGGER_USE_THREAD_SYSTEM)
+```
+
+- **Tier 0 (common_system)**: Provides shared interfaces (`ILogger`, `IExecutor`) and types (`Result<T>`). No dependencies on higher tiers.
+- **Tier 1 (thread_system)**: Depends only on common_system. Uses `ILogger` for logging via dependency injection.
+- **Tier 2 (logger_system)**: Depends on common_system (required) and thread_system (optional, `LOGGER_USE_THREAD_SYSTEM=OFF` by default).
+
+## Abstraction Interfaces
+
+| Interface | Defined In | Purpose |
+|-----------|-----------|---------|
+| `ILogger` | common_system | Allows thread_system to log without depending on logger_system |
+| `IExecutor` | common_system | Allows logger_system to use thread pools without tight coupling |
+| `Result<T>` | common_system | Shared error handling type across all tiers |
+
+## Resolved: Bidirectional Dependency (Issue #252)
+
+### Previous State
+
+Both systems could optionally depend on each other:
+- `logger_system -> thread_system` via `LOGGER_USE_THREAD_SYSTEM=ON`
+- `thread_system -> logger_system` via `BUILD_WITH_LOGGER_SYSTEM=ON`
+
+### Current State (Resolved)
+
+- **`logger_system -> thread_system`**: Optional, off by default. Clean unidirectional dependency.
+- **`thread_system -> logger_system`**: **Deprecated** via thread_system#336. `BUILD_WITH_LOGGER_SYSTEM` is off by default and scheduled for removal in **v0.5.0.0**. thread_system now uses `ILogger` dependency injection from common_system instead.
+
+### CMake Guard
+
+A transitional guard in `CMakeLists.txt` warns if both flags are enabled simultaneously. This guard will be removed once thread_system#336 is complete and `BUILD_WITH_LOGGER_SYSTEM` is removed.
+
+## Configuration
+
+### Recommended (Default)
+
+```bash
+cmake -B build   # Both integrations OFF, standalone mode
+```
+
+### With thread_pool Backend
+
+```bash
+cmake -B build -DLOGGER_USE_THREAD_SYSTEM=ON
+```
+
+### Deprecated (Avoid)
+
+```bash
+# BUILD_WITH_LOGGER_SYSTEM is deprecated in thread_system
+cmake -B build -DLOGGER_USE_THREAD_SYSTEM=ON -DBUILD_WITH_LOGGER_SYSTEM=ON
+```
+
+## Migration Guide
+
+If you are using `BUILD_WITH_LOGGER_SYSTEM=ON` in thread_system:
+
+1. Set `BUILD_WITH_LOGGER_SYSTEM=OFF`
+2. Inject an `ILogger` implementation at runtime instead:
+   ```cpp
+   #include <kcenon/logger/adapters/common_logger_adapter.h>
+   auto logger = std::make_shared<kcenon::logger::adapters::common_logger_adapter>();
+   thread_pool.set_logger(logger);  // ILogger dependency injection
+   ```
+3. This approach has no compile-time dependency on logger_system
+
+## Timeline
+
+| Milestone | Status | Description |
+|-----------|--------|-------------|
+| Issue #252 | Resolved | Bidirectional risk identified and analyzed |
+| Issue #336 | In Progress | thread_system deprecates BUILD_WITH_LOGGER_SYSTEM |
+| v0.5.0.0 | Planned | BUILD_WITH_LOGGER_SYSTEM removed from thread_system |
+| Post-v0.5.0.0 | Planned | CMake bidirectional guard can be removed from logger_system |
+
+## Related
+
+- [Integration Guide](integration/THREAD_SYSTEM.md) - Detailed integration options
+- [Issue #252](https://github.com/kcenon/logger_system/issues/252) - Original bidirectional dependency issue
+- [Issue #458](https://github.com/kcenon/logger_system/issues/458) - Resolution tracking
+- [thread_system#336](https://github.com/kcenon/thread_system/issues/336) - Deprecation of BUILD_WITH_LOGGER_SYSTEM

--- a/docs/integration/THREAD_SYSTEM.md
+++ b/docs/integration/THREAD_SYSTEM.md
@@ -102,9 +102,15 @@ When enabled, CMake will:
 
 ## Dependency Configuration
 
-### Bidirectional Dependency Risk (Issue #252)
+### Bidirectional Dependency Risk (Issue #252 — Resolved)
 
-Both `logger_system` and `thread_system` can optionally depend on each other:
+> **Resolved**: The bidirectional dependency risk has been resolved. thread_system's
+> `BUILD_WITH_LOGGER_SYSTEM` is deprecated (thread_system#336) and scheduled for removal
+> in v0.5.0.0. thread_system now uses `ILogger` dependency injection from common_system
+> instead. See [docs/DEPENDENCY_ARCHITECTURE.md](../DEPENDENCY_ARCHITECTURE.md) for the
+> resolved dependency graph.
+
+Previously, both `logger_system` and `thread_system` could optionally depend on each other:
 
 ```
            ┌──────────────────────┐


### PR DESCRIPTION
## Summary
- Update CMakeLists.txt bidirectional dependency check to reflect resolved state
- Create docs/DEPENDENCY_ARCHITECTURE.md documenting clean unidirectional dependency flow
- Update integration documentation to mark Issue #252 as resolved

## Test plan
- [x] CMakeLists.txt bidirectional check updated with resolved status
- [x] docs/DEPENDENCY_ARCHITECTURE.md created with dependency graph
- [x] Integration docs updated to reflect resolved state
- [x] No functional changes to build system behavior
- [x] CI builds pass (no cmake logic changes, only comments and docs)

Closes #458