### PR TITLE
chore(cleanup): remove legacy sources/ directory

### DIFF
--- a/.cppcheck
+++ b/.cppcheck
@@ -13,7 +13,6 @@
     <paths>
         <dir name="include/"/>
         <dir name="src/"/>
-        <dir name="sources/"/>
     </paths>
 
     <!-- Excluded paths -->

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ docs/latex/
 # Temporary files
 *.tmp
 *.temp
+*.bak
 .cache/
 
 # Benchmark results

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,19 +535,10 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
         endif()
 
     else()
-        message(STATUS "Logger System: New structure incomplete, using legacy sources")
-        set(USE_LEGACY_SOURCES TRUE)
+        message(FATAL_ERROR "Logger System: New structure incomplete (src/ has fewer than 6 .cpp files)")
     endif()
 else()
-    message(STATUS "Logger System: Using legacy directory structure")
-    set(USE_LEGACY_SOURCES TRUE)
-endif()
-
-# Use legacy sources if needed
-if(USE_LEGACY_SOURCES)
-    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/sources)
-        add_subdirectory(sources)
-    endif()
+    message(FATAL_ERROR "Logger System: Required directories missing: include/kcenon/logger and src/")
 endif()
 
 if (BUILD_SAMPLES)
@@ -636,7 +627,7 @@ if(INSTALL_TARGETS)
     endif()
 endif()
 
-install(DIRECTORY sources/
+install(DIRECTORY include/kcenon/logger/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/logger_system
     FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )

--- a/Doxyfile
+++ b/Doxyfile
@@ -71,10 +71,8 @@ ALPHABETICAL_INDEX     = YES
 COLS_IN_ALPHA_INDEX    = 5
 
 INPUT                  = README.md ARCHITECTURE.md SECURITY.md \
-                         sources/logger \
-                         sources/logger/config \
-                         sources/logger/interfaces \
-                         sources/logger/writers \
+                         include/kcenon/logger \
+                         src \
                          docs
 FILE_PATTERNS          = *.h *.hpp *.cpp *.md
 EXCLUDE_PATTERNS       = */tests/* */unittest/* */benchmarks/*

--- a/cmake/LoggerCoverage.cmake
+++ b/cmake/LoggerCoverage.cmake
@@ -110,7 +110,7 @@ function(logger_setup_coverage_target)
             COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/coverage
             COMMAND ${GCOVR_EXECUTABLE}
                 --root ${CMAKE_SOURCE_DIR}
-                --filter ${CMAKE_SOURCE_DIR}/sources/
+                --filter ${CMAKE_SOURCE_DIR}/src/
                 --exclude ${CMAKE_SOURCE_DIR}/unittest/
                 --exclude ${CMAKE_SOURCE_DIR}/tests/
                 --html --html-details

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Use clang-format with the provided `.clang-format` file:
 
 ```bash
 # Format a file
-clang-format -i sources/logger/logger.cpp
+clang-format -i src/core/logger.cpp
 
 # Format all files
 find . -name "*.cpp" -o -name "*.h" | xargs clang-format -i

--- a/examples/crash_protection/CMakeLists.txt
+++ b/examples/crash_protection/CMakeLists.txt
@@ -21,10 +21,7 @@ set_target_properties(${SAMPLE_NAME} PROPERTIES
 
 # Include directories
 target_include_directories(${SAMPLE_NAME} PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../sources
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../sources/interfaces
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../sources/logger
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../sources/logger/writers
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../include
 )
 
 # Link libraries

--- a/sources/CMakeLists.txt
+++ b/sources/CMakeLists.txt
@@ -1,7 +1,0 @@
-# Legacy sources directory - placeholder for compatibility
-# The actual sources are in the new directory structure:
-# - include/kcenon/logger/
-# - src/
-
-# For now, this is an empty CMakeLists.txt to satisfy the build system
-# until the logger_system is fully migrated to the new structure

--- a/tests/unit/flow_test/CMakeLists.txt
+++ b/tests/unit/flow_test/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(overflow_policy_test
 
 target_include_directories(overflow_policy_test
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/sources
+        ${CMAKE_SOURCE_DIR}/include
 )
 
 # Add test

--- a/tests/unit/flow_test/overflow_policy_test.cpp
+++ b/tests/unit/flow_test/overflow_policy_test.cpp
@@ -5,7 +5,8 @@ Copyright (c) 2025, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include "../../sources/logger/flow/overflow_policy.h"
+// TODO: overflow_policy.h not yet migrated to new structure
+// #include <kcenon/logger/flow/overflow_policy.h>
 
 #include <gtest/gtest.h>
 #include <kcenon/common/interfaces/logger_interface.h>

--- a/tests/unit/health_test/health_check_test.cpp
+++ b/tests/unit/health_test/health_check_test.cpp
@@ -6,9 +6,10 @@ All rights reserved.
 *****************************************************************************/
 
 #include <gtest/gtest.h>
-#include "../../sources/logger/health/health_check_system.h"
-#include "../../sources/logger/writers/base_writer.h"
-#include "../../sources/logger/core/log_collector.h"
+// TODO: health_check_system.h not yet migrated to new structure
+// #include <kcenon/logger/health/health_check_system.h>
+#include <kcenon/logger/writers/base_writer.h>
+#include <kcenon/logger/core/log_collector.h>
 #include <kcenon/common/interfaces/logger_interface.h>
 #include <thread>
 #include <chrono>

--- a/tests/unit/mocks/mock_monitor.hpp
+++ b/tests/unit/mocks/mock_monitor.hpp
@@ -10,8 +10,9 @@
 
 #pragma once
 
-#include "../../sources/logger/monitoring/monitoring_interface.h"
-#include "../../sources/logger/error_codes.h"
+// TODO: monitoring_interface.h not yet migrated to new structure
+// #include <kcenon/logger/monitoring/monitoring_interface.h>
+#include <kcenon/logger/core/error_codes.h>
 #include <atomic>
 #include <map>
 #include <mutex>

--- a/tests/unit/mocks/mock_writer.hpp
+++ b/tests/unit/mocks/mock_writer.hpp
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "../../sources/logger/writers/base_writer.h"
-#include "../../sources/logger/interfaces/log_entry.h"
-#include "../../sources/logger/error_codes.h"
+#include <kcenon/logger/writers/base_writer.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/logger/core/error_codes.h>
 #include <kcenon/common/interfaces/logger_interface.h>
 #include <atomic>
 #include <vector>

--- a/tests/unit/monitoring_test/CMakeLists.txt
+++ b/tests/unit/monitoring_test/CMakeLists.txt
@@ -9,8 +9,7 @@ add_executable(monitoring_test
 
 # Include directories
 target_include_directories(monitoring_test PRIVATE
-    ${CMAKE_SOURCE_DIR}/sources
-    ${CMAKE_SOURCE_DIR}/sources/logger
+    ${CMAKE_SOURCE_DIR}/include
 )
 
 # Link with required libraries

--- a/tests/unit/safety_test/crash_safety_test.cpp
+++ b/tests/unit/safety_test/crash_safety_test.cpp
@@ -12,7 +12,9 @@ All rights reserved.
 #include <fstream>
 #include <thread>
 
-#include "../../sources/interfaces/logger_crash_safety.h"
+// TODO: logger_crash_safety.h not yet migrated to new structure
+// See include/kcenon/logger/safety/crash_safe_logger.h for replacement
+#include <kcenon/logger/safety/crash_safe_logger.h>
 
 using namespace logger_module;
 

--- a/tests/unit/stress_test/CMakeLists.txt
+++ b/tests/unit/stress_test/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(stress_test
 # Include directories
 target_include_directories(stress_test
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/sources
+        ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/unittest
 )
 

--- a/tests/unit/stress_test/stress_test.cpp
+++ b/tests/unit/stress_test/stress_test.cpp
@@ -18,11 +18,11 @@
 #include <thread>
 #include <vector>
 
-#include "../../sources/logger/config/logger_builder.h"
-#include "../../sources/logger/logger.h"
-#include "../../sources/logger/writers/async_writer.h"
-#include "../../sources/logger/writers/console_writer.h"
-#include "../../sources/logger/writers/file_writer.h"
+#include <kcenon/logger/core/logger_builder.h>
+#include <kcenon/logger/core/logger.h>
+#include <kcenon/logger/writers/async_writer.h>
+#include <kcenon/logger/writers/console_writer.h>
+#include <kcenon/logger/writers/file_writer.h>
 #include "../mocks/mock_writer.hpp"
 #include <kcenon/common/interfaces/logger_interface.h>
 


### PR DESCRIPTION
## Summary

- Remove the legacy `sources/` directory which contained only a residual CMakeLists.txt placeholder from the structural migration to `src/` + `include/`
- Update all references across 16 files (CMakeLists.txt, test includes, Doxyfile, .cppcheck, coverage config) to point to the new `include/kcenon/logger/` and `src/` structure
- Add `*.bak` to `.gitignore`

## Details

The `sources/` directory was left behind during the migration to the new directory structure (`src/` for implementation, `include/kcenon/logger/` for headers). It contained only a 288-byte placeholder CMakeLists.txt. However, multiple files still referenced it:

| File | Change |
|------|--------|
| `CMakeLists.txt` | Remove legacy fallback `add_subdirectory(sources)` block; fix `install(DIRECTORY)` to use `include/kcenon/logger/` |
| `cmake/LoggerCoverage.cmake` | Update gcovr filter from `sources/` to `src/` |
| `Doxyfile` | Update INPUT paths to new structure |
| `.cppcheck` | Remove `sources/` from checked paths |
| `examples/crash_protection/CMakeLists.txt` | Update include directories |
| `tests/unit/*/CMakeLists.txt` | Update include directories (monitoring_test, stress_test, flow_test) |
| `tests/unit/*/*.cpp` | Update `#include` paths to new structure |
| `tests/unit/mocks/*.hpp` | Update `#include` paths to new structure |
| `docs/contributing/CONTRIBUTING.md` | Fix example path |
| `.gitignore` | Add `*.bak` pattern |

Some test files referenced headers that have no exact equivalent in the new structure (e.g., `health_check_system.h`, `overflow_policy.h`, `monitoring_interface.h`). These have been marked with TODO comments as they were already broken before this change.

Part of kcenon/common_system#393

## Test plan

- [x] Verify CMake configuration succeeds without the `sources/` directory
- [x] Verify existing passing tests still pass
- [x] Verify `install(DIRECTORY ...)` correctly installs headers from new location