### PR TITLE
chore(ci): add SBOM generation and CVE scanning workflows

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   schedule:
+    # Run security scan daily at 2 AM UTC
     - cron: '0 2 * * *'
   workflow_dispatch:
 
@@ -13,6 +14,9 @@ permissions:
   contents: read
   security-events: write
 
+# Configurable severity threshold for CI blocking.
+# Set SECURITY_SEVERITY_CUTOFF in repository variables to override.
+# Valid values: CRITICAL, HIGH, MEDIUM, LOW
 env:
   SEVERITY_CUTOFF: ${{ vars.SECURITY_SEVERITY_CUTOFF || 'CRITICAL,HIGH' }}
 
@@ -27,6 +31,8 @@ jobs:
       with:
         submodules: true
 
+    # Trivy filesystem scan — detects vulnerabilities in source code,
+    # configuration files, and any lock files present.
     - name: Trivy filesystem scan
       uses: aquasecurity/trivy-action@master
       with:
@@ -51,12 +57,14 @@ jobs:
         import json
         import sys
 
+        # Compatible licenses with BSD-3-Clause
         COMPATIBLE_LICENSES = {
             'MIT', 'BSD-2-Clause', 'BSD-3-Clause', 'Apache-2.0',
             'ISC', 'Unlicense', 'BSL-1.0', 'Zlib', 'PostgreSQL',
             'Public Domain',
         }
 
+        # LGPL is compatible only with dynamic linking
         CONDITIONAL_LICENSES = {
             'LGPL-2.1': 'dynamic linking required',
             'LGPL-2.1-or-later': 'dynamic linking required',
@@ -78,6 +86,7 @@ jobs:
         print(f"License Compatibility Check: {project} ({project_license})")
         print("=" * 60)
 
+        # Known licenses for ecosystem SOUP components
         known_licenses = {
             'asio': 'BSL-1.0',
             'fmt': 'MIT',
@@ -109,14 +118,18 @@ jobs:
                     names.append(dep.get('name', 'unknown'))
             return names
 
+        # Core dependencies
         dep_names = collect_deps(manifest.get('dependencies', []))
 
+        # Feature dependencies
         for feat_data in manifest.get('features', {}).values():
             dep_names.extend(collect_deps(feat_data.get('dependencies', [])))
 
+        # Deduplicate
         dep_names = sorted(set(dep_names))
 
         for dep_name in dep_names:
+            # Skip ecosystem packages
             if dep_name.startswith('kcenon-'):
                 print(f"  {dep_name:25} {'BSD-3-Clause':15} ECOSYSTEM")
                 continue

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -43,59 +43,73 @@ jobs:
         output-file: sbom-spdx.json
         artifact-name: sbom-spdx
 
+    - name: Scan SBOM for CVEs with Grype
+      uses: anchore/scan-action@v6
+      id: grype-scan
+      with:
+        sbom: sbom-cyclonedx.json
+        severity-cutoff: high
+        fail-build: ${{ github.event_name == 'pull_request' }}
+        output-format: sarif
+
+    - name: Upload Grype SARIF to GitHub Security
+      uses: github/codeql-action/upload-sarif@v3
+      if: always() && steps.grype-scan.outputs.sarif != ''
+      continue-on-error: true
+      with:
+        sarif_file: ${{ steps.grype-scan.outputs.sarif }}
+
     - name: Parse vcpkg dependencies
       run: |
         if [ -f "vcpkg.json" ]; then
-          echo "# vcpkg Dependencies" > vcpkg-dependencies.md
-          echo "" >> vcpkg-dependencies.md
-          echo "**Generated**: $(date -u)" >> vcpkg-dependencies.md
-          echo "" >> vcpkg-dependencies.md
-          echo "## Direct Dependencies" >> vcpkg-dependencies.md
-          echo "" >> vcpkg-dependencies.md
-
-          python3 << 'EOF'
+          python3 << 'PYEOF' > vcpkg-dependencies.md
         import json
 
         with open('vcpkg.json', 'r') as f:
             manifest = json.load(f)
 
+        print("# vcpkg Dependencies")
+        print()
         print(f"**Project**: {manifest.get('name', 'N/A')}")
         print(f"**Version**: {manifest.get('version', 'N/A')}")
         print()
-        print("| Package | Features |")
-        print("|---------|----------|")
+        print("## Direct Dependencies")
+        print()
+        print("| Package | Version Constraint | Features |")
+        print("|---------|-------------------|----------|")
 
         deps = manifest.get('dependencies', [])
         for dep in deps:
             if isinstance(dep, str):
-                print(f"| {dep} | - |")
+                print(f"| {dep} | - | - |")
             elif isinstance(dep, dict):
                 name = dep.get('name', 'unknown')
+                version = dep.get('version>=', '-')
                 features = ', '.join(dep.get('features', [])) or '-'
-                print(f"| {name} | {features} |")
-        EOF
+                print(f"| {name} | {version} | {features} |")
 
-          python3 << 'EOF' >> vcpkg-dependencies.md
-        import json
-
-        with open('vcpkg.json', 'r') as f:
-            manifest = json.load(f)
-
-        print(f"**Project**: {manifest.get('name', 'N/A')}")
-        print(f"**Version**: {manifest.get('version', 'N/A')}")
-        print()
-        print("| Package | Features |")
-        print("|---------|----------|")
-
-        deps = manifest.get('dependencies', [])
-        for dep in deps:
-            if isinstance(dep, str):
-                print(f"| {dep} | - |")
-            elif isinstance(dep, dict):
-                name = dep.get('name', 'unknown')
-                features = ', '.join(dep.get('features', [])) or '-'
-                print(f"| {name} | {features} |")
-        EOF
+        features = manifest.get('features', {})
+        if features:
+            print()
+            print("## Feature Dependencies")
+            print()
+            for feat_name, feat_data in features.items():
+                feat_deps = feat_data.get('dependencies', [])
+                if feat_deps:
+                    print(f"### {feat_name}")
+                    print()
+                    print("| Package | Version Constraint | Features |")
+                    print("|---------|-------------------|----------|")
+                    for dep in feat_deps:
+                        if isinstance(dep, str):
+                            print(f"| {dep} | - | - |")
+                        elif isinstance(dep, dict):
+                            name = dep.get('name', 'unknown')
+                            version = dep.get('version>=', '-')
+                            dep_features = ', '.join(dep.get('features', [])) or '-'
+                            print(f"| {name} | {version} | {dep_features} |")
+                    print()
+        PYEOF
         else
           echo "No vcpkg.json found" > vcpkg-dependencies.md
         fi
@@ -117,7 +131,7 @@ jobs:
         cat vcpkg-dependencies.md >> SBOM_REPORT.md
 
     - name: Upload SBOM artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sbom-${{ github.sha }}
         path: |
@@ -139,7 +153,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Submit SBOM to Dependency Graph
-      uses: advanced-security/spdx-dependency-submission-action@v0.1.1
+      uses: advanced-security/spdx-dependency-submission-action@v0.2.0
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       continue-on-error: true
       with:


### PR DESCRIPTION
## What
Update SBOM generation and CVE scanning CI workflows to align with the shared ecosystem template from common_system.

## Why
The existing workflows were outdated compared to the common_system baseline:
- **sbom.yml**: Missing Grype CVE scan step, missing SARIF upload to GitHub Security, outdated vcpkg dependency parser (no version constraint or feature dependency support), older action versions (upload-artifact v4 to v7, spdx-dependency-submission v0.1.1 to v0.2.0)
- **cve-scan.yml**: Missing inline comments for configurable severity threshold and Trivy scan description

Synchronizing these workflows ensures consistent security scanning and supply chain transparency across all ecosystem repositories.

## Who
- Maintainer: @kcenon

## Where
- .github/workflows/sbom.yml
- .github/workflows/cve-scan.yml

## How
Copied the canonical workflow files from common_system repository verbatim, replacing the existing outdated versions.

### Key improvements in sbom.yml
- Added Grype CVE scan against generated SBOM with SARIF upload to GitHub Security tab
- Enhanced vcpkg dependency parser with version constraint and feature dependency sections
- Upgraded actions/upload-artifact from v4 to v7
- Upgraded spdx-dependency-submission-action from v0.1.1 to v0.2.0

### Key improvements in cve-scan.yml
- Added descriptive comments for severity threshold configuration and Trivy scan purpose

Closes #466