### PR TITLE
chore(deps): replace GIT_TAG main default with v0.1.0 and add deprecation warning

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -223,9 +223,21 @@ endmacro()
 macro(unified_find_dependency DEP_NAME)
     cmake_parse_arguments(_UFD "REQUIRED;OPTIONAL" "VERSION;GIT_TAG" "" ${ARGN})
 
-    # Default to main branch if no tag specified
+    # Default to the latest release tag if no tag specified.
+    # Using "main" is a moving target and breaks build reproducibility
+    # and SOUP version traceability (IEC 62304 §8.1.2).
+    # See: https://github.com/kcenon/common_system/issues/402
     if(NOT _UFD_GIT_TAG)
-        set(_UFD_GIT_TAG "main")
+        set(_UFD_GIT_TAG "v0.1.0")
+    endif()
+
+    if("${_UFD_GIT_TAG}" STREQUAL "main")
+        message(WARNING
+            "[UnifiedDependencies] GIT_TAG 'main' used for ${DEP_NAME}.\n"
+            "This breaks build reproducibility and SOUP version traceability (IEC 62304 §8.1.2).\n"
+            "Pass a specific release tag to unified_find_dependency(), e.g.:\n"
+            "  unified_find_dependency(${DEP_NAME} GIT_TAG v0.1.0)"
+        )
     endif()
 
     # Check if already loaded


### PR DESCRIPTION
Part of kcenon/common_system#402

## Summary

- Change `unified_find_dependency()` default `GIT_TAG` from `"main"` to `"v0.1.0"`
- Add CMake `WARNING` when `"main"` is passed explicitly, identifying the caller dependency name
- Add reference to tracking issue in the comment block

## Why

Using `main` as a `GIT_TAG` breaks:
1. **Build reproducibility** — a push to `main` can silently change what gets compiled
2. **SOUP version traceability** — IEC 62304 §8.1.2 requires exact version identification for SOUP components

## Files Modified

- `cmake/UnifiedDependencies.cmake`

## Test Plan

- [x] CMake configure with no `GIT_TAG` argument uses `v0.1.0` as default
- [x] Calling `unified_find_dependency(common_system GIT_TAG main)` emits a CMake WARNING
- [x] FetchContent fallback still works when tag exists in remote