### PR TITLE
docs(legal): align dependency inventory with manifest

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -158,6 +158,10 @@ jobs:
             sys.exit(1)
         EOF
 
+    - name: Dependency documentation consistency check
+      if: always()
+      run: python3 scripts/ci/check_dependency_docs.py
+
     - name: Generate security report
       if: always()
       run: |

--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -3,78 +3,97 @@
 This file documents third-party dependencies and their license compatibility
 with the project's BSD-3-Clause license.
 
-## fmt
+## Default Build
 
-| Item               | Value                                          |
-|--------------------|--------------------------------------------- --|
-| Component          | {fmt} formatting library                       |
-| License            | MIT                                            |
-| Minimum Version    | 10.0.0                                         |
-| Usage              | String formatting                              |
-| BSD-3 Compatible   | Yes                                            |
+The default build has no required third-party production dependencies.
+Optional functionality is enabled through explicit vcpkg features.
 
-## OpenSSL (Optional — encryption feature)
+## Optional Feature Dependencies
+
+## OpenSSL (`encryption` feature)
 
 | Item               | Value                                          |
 |--------------------|--------------------------------------------- --|
 | Component          | OpenSSL                                        |
 | License            | Apache-2.0                                     |
+| Pinned Version     | 3.3.0                                          |
 | Usage              | AES-256-GCM encrypted log writer               |
 | Linking            | Dynamic (shared library)                       |
 | BSD-3 Compatible   | Yes                                            |
 
-## spdlog (Optional — benchmarks feature)
-
-| Item               | Value                                          |
-|--------------------|--------------------------------------------- --|
-| Component          | spdlog                                         |
-| License            | MIT                                            |
-| Minimum Version    | 1.13.0                                         |
-| Usage              | Benchmark comparison logging library           |
-| BSD-3 Compatible   | Yes                                            |
-
-## OpenTelemetry C++ SDK (Optional — otlp feature)
+## OpenTelemetry C++ SDK (`otlp` feature)
 
 | Item               | Value                                          |
 |--------------------|--------------------------------------------- --|
 | Component          | OpenTelemetry C++ SDK                          |
 | License            | Apache-2.0                                     |
-| Minimum Version    | 1.14.0                                         |
+| Pinned Version     | 1.14.2                                         |
 | Usage              | Distributed tracing and metrics via OTLP       |
 | Linking            | Dynamic                                        |
 | BSD-3 Compatible   | Yes                                            |
 
-## protobuf (Optional — otlp feature)
+## Protocol Buffers (`otlp` feature)
 
 | Item               | Value                                          |
 |--------------------|--------------------------------------------- --|
 | Component          | Protocol Buffers                               |
 | License            | BSD-3-Clause                                   |
-| Minimum Version    | 3.21.0                                         |
+| Pinned Version     | 3.21.12                                        |
 | Usage              | Serialization for gRPC/OTLP                    |
 | Linking            | Dynamic                                        |
 | BSD-3 Compatible   | Yes                                            |
 
-## gRPC (Optional — otlp feature)
+## gRPC (`otlp` feature)
 
 | Item               | Value                                          |
 |--------------------|--------------------------------------------- --|
 | Component          | gRPC C++                                       |
 | License            | Apache-2.0                                     |
-| Minimum Version    | 1.51.1                                         |
+| Pinned Version     | 1.51.1                                         |
 | Usage              | OTLP gRPC transport                            |
 | Linking            | Dynamic                                        |
 | BSD-3 Compatible   | Yes                                            |
 
-## All Dependencies (License Summary)
+## spdlog (`benchmarks` feature)
+
+| Item               | Value                                          |
+|--------------------|--------------------------------------------- --|
+| Component          | spdlog                                         |
+| License            | MIT                                            |
+| Pinned Version     | 1.13.0                                         |
+| Usage              | Benchmark comparison logging library           |
+| BSD-3 Compatible   | Yes                                            |
+
+## Development and Test Dependencies
+
+## Google Test (`testing` feature)
+
+| Item               | Value                                          |
+|--------------------|--------------------------------------------- --|
+| Component          | Google Test                                    |
+| License            | BSD-3-Clause                                   |
+| Pinned Version     | 1.14.0                                         |
+| Usage              | Unit tests and mocks                           |
+| BSD-3 Compatible   | Yes                                            |
+
+## Google Benchmark (`benchmarks` feature)
+
+| Item               | Value                                          |
+|--------------------|--------------------------------------------- --|
+| Component          | Google Benchmark                               |
+| License            | Apache-2.0                                     |
+| Pinned Version     | 1.8.3                                          |
+| Usage              | Performance benchmark framework                |
+| BSD-3 Compatible   | Yes                                            |
+
+## Dependency Summary
 
 | Dependency          | License        | Type     | BSD-3 Compatible |
 |---------------------|----------------|----------|------------------|
-| fmt                 | MIT            | Core     | Yes              |
 | OpenSSL             | Apache-2.0     | Optional | Yes              |
-| spdlog              | MIT            | Optional | Yes              |
 | opentelemetry-cpp   | Apache-2.0     | Optional | Yes              |
 | protobuf            | BSD-3-Clause   | Optional | Yes              |
 | gRPC                | Apache-2.0     | Optional | Yes              |
+| spdlog              | MIT            | Optional | Yes              |
 | GTest               | BSD-3-Clause   | Testing  | Yes              |
 | Google Benchmark    | Apache-2.0     | Testing  | Yes              |

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ For comprehensive examples including all decorators, performance patterns, and r
 
 **Using vcpkg**:
 ```bash
-# Install with default features (fmt only)
+# Install with the default feature set (no optional third-party dependencies)
 vcpkg install kcenon-logger-system
 
 # Install with benchmarks (includes spdlog for comparison)
@@ -221,10 +221,25 @@ target_link_libraries(your_app PRIVATE LoggerSystem::logger)
 | CMake | 3.20+ | Yes | Build system |
 | [common_system](https://github.com/kcenon/common_system) | latest | Yes | Common interfaces (ILogger, Result<T>) |
 | [thread_system](https://github.com/kcenon/thread_system) | latest | Optional | Async logging with thread pool support |
-| [fmt](https://github.com/fmtlib/fmt) | 10.0+ | Yes | Modern formatting library |
+| Third-party production packages | None in the default vcpkg manifest | No | Optional features add OpenSSL, OTLP, or benchmark-comparison dependencies only when enabled |
 | vcpkg | latest | Optional | Package management |
 
-> **Note**: spdlog is **not** used internally by logger_system. It is only included as an optional dependency for benchmark comparisons. See [Benchmarks](docs/BENCHMARKS.md) for performance comparisons.
+> **Note**: The default vcpkg package has no required third-party production dependencies. Optional features add OpenSSL (`encryption`), OpenTelemetry/gRPC/Protocol Buffers (`otlp`), or spdlog (`benchmarks`) only when explicitly enabled. See [docs/SOUP.md](docs/SOUP.md) and [LICENSE-THIRD-PARTY](LICENSE-THIRD-PARTY) for the authoritative dependency inventory.
+
+#### Optional Feature Dependencies
+
+| Feature | Third-Party Dependencies | Purpose |
+|---------|--------------------------|---------|
+| `encryption` | OpenSSL | AES-256-GCM encrypted log writer |
+| `otlp` | OpenTelemetry C++ SDK, gRPC, Protocol Buffers | OTLP telemetry export |
+| `benchmarks` | spdlog | Benchmark comparison against another logging library |
+
+#### Development and Benchmark Dependencies
+
+| Category | Dependencies | Purpose |
+|----------|--------------|---------|
+| Test-only | Google Test | Unit tests and mocks |
+| Benchmark-only | Google Benchmark | Performance benchmarks |
 
 #### Dependency Flow
 
@@ -567,7 +582,7 @@ cmake -DLOGGER_WARNINGS_AS_ERRORS=ON  # Treat warnings as errors
 **Minimum Requirements**:
 - C++20 compiler
 - CMake 3.20+
-- fmt library
+- No required third-party production packages in the default build
 
 [🖥️ Platform Details →](docs/PRODUCTION_QUALITY.md#platform-support)
 

--- a/scripts/ci/check_dependency_docs.py
+++ b/scripts/ci/check_dependency_docs.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate dependency category documentation against the vcpkg manifest."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "vcpkg.json"
+SOUP_PATH = REPO_ROOT / "docs" / "SOUP.md"
+LICENSE_PATH = REPO_ROOT / "LICENSE-THIRD-PARTY"
+README_PATH = REPO_ROOT / "README.md"
+
+DISPLAY_NAMES = {
+    "openssl": ("OpenSSL", "openssl"),
+    "opentelemetry-cpp": ("OpenTelemetry C++ SDK", "opentelemetry-cpp"),
+    "protobuf": ("Protocol Buffers", "protobuf"),
+    "grpc": ("gRPC", "grpc"),
+    "spdlog": ("spdlog",),
+    "gtest": ("Google Test", "GTest", "gtest"),
+    "benchmark": ("Google Benchmark", "benchmark"),
+}
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def collect_dependency_categories(manifest: dict) -> tuple[set[str], set[str], set[str]]:
+    default_build = set()
+    optional = set()
+    test_only = set()
+
+    for dep in manifest.get("dependencies", []):
+        if isinstance(dep, str):
+            default_build.add(dep)
+        else:
+            default_build.add(dep["name"])
+
+    for feature_name, feature_data in manifest.get("features", {}).items():
+        for dep in feature_data.get("dependencies", []):
+            dep_name = dep if isinstance(dep, str) else dep["name"]
+            if feature_name == "testing":
+                test_only.add(dep_name)
+            elif feature_name == "benchmarks" and dep_name == "benchmark":
+                test_only.add(dep_name)
+            else:
+                optional.add(dep_name)
+
+    return default_build, optional, test_only
+
+
+def section_between(text: str, start: str, end: str | None) -> str:
+    try:
+        start_index = text.index(start) + len(start)
+    except ValueError as exc:
+        raise AssertionError(f"Missing section header: {start}") from exc
+
+    if end is None:
+        return text[start_index:]
+
+    try:
+        end_index = text.index(end, start_index)
+    except ValueError as exc:
+        raise AssertionError(f"Missing section header: {end}") from exc
+
+    return text[start_index:end_index]
+
+
+def has_any_display_name(section: str, dependency_name: str) -> bool:
+    aliases = DISPLAY_NAMES.get(dependency_name, (dependency_name,))
+    return any(alias in section for alias in aliases)
+
+
+def assert_contains_all(section: str, expected: set[str], context: str) -> None:
+    missing = sorted(name for name in expected if not has_any_display_name(section, name))
+    if missing:
+        raise AssertionError(f"{context} is missing: {', '.join(missing)}")
+
+
+def assert_contains_none(section: str, unexpected: set[str], context: str) -> None:
+    present = sorted(name for name in unexpected if has_any_display_name(section, name))
+    if present:
+        raise AssertionError(f"{context} should not contain: {', '.join(present)}")
+
+
+def check_soup(default_build: set[str], optional: set[str], test_only: set[str]) -> None:
+    soup = SOUP_PATH.read_text(encoding="utf-8")
+    production = section_between(soup, "## Production SOUP", "## Optional SOUP")
+    optional_section = section_between(soup, "## Optional SOUP", "## Development/Test SOUP (Not Deployed)")
+    test_section = section_between(soup, "## Development/Test SOUP (Not Deployed)", "## Safety Classification Key")
+
+    if default_build:
+        assert_contains_all(production, default_build, "docs/SOUP.md production section")
+    elif "*(none in default build)*" not in production:
+        raise AssertionError("docs/SOUP.md production section must state that the default build has no SOUP")
+
+    assert_contains_all(optional_section, optional, "docs/SOUP.md optional section")
+    assert_contains_all(test_section, test_only, "docs/SOUP.md development/test section")
+    assert_contains_none(production, optional | test_only, "docs/SOUP.md production section")
+
+
+def check_license_inventory(default_build: set[str], optional: set[str], test_only: set[str]) -> None:
+    license_doc = LICENSE_PATH.read_text(encoding="utf-8")
+    default_section = section_between(license_doc, "## Default Build", "## Optional Feature Dependencies")
+    optional_section = section_between(license_doc, "## Optional Feature Dependencies", "## Development and Test Dependencies")
+    test_section = section_between(license_doc, "## Development and Test Dependencies", "## Dependency Summary")
+    summary_section = section_between(license_doc, "## Dependency Summary", None)
+
+    if default_build:
+        assert_contains_all(default_section, default_build, "LICENSE-THIRD-PARTY default section")
+    elif "no required third-party production dependencies" not in default_section:
+        raise AssertionError("LICENSE-THIRD-PARTY default section must state that the default build has no third-party dependencies")
+
+    assert_contains_all(optional_section, optional, "LICENSE-THIRD-PARTY optional section")
+    assert_contains_all(test_section, test_only, "LICENSE-THIRD-PARTY test section")
+    assert_contains_none(default_section, optional | test_only, "LICENSE-THIRD-PARTY default section")
+    assert_contains_none(summary_section, {"fmt"}, "LICENSE-THIRD-PARTY summary")
+
+
+def check_readme(default_build: set[str], optional: set[str], test_only: set[str]) -> None:
+    readme = README_PATH.read_text(encoding="utf-8")
+    optional_section = section_between(readme, "#### Optional Feature Dependencies", "#### Development and Benchmark Dependencies")
+    benchmark_section = section_between(readme, "#### Development and Benchmark Dependencies", "#### Dependency Flow")
+
+    if default_build:
+        assert_contains_all(readme, default_build, "README.md default-build description")
+    elif "no required third-party production dependencies" not in readme:
+        raise AssertionError("README.md must describe the default build as having no required third-party production dependencies")
+
+    assert_contains_all(optional_section, optional, "README.md optional dependency section")
+    assert_contains_all(benchmark_section, test_only, "README.md development and benchmark dependency section")
+
+
+def main() -> int:
+    manifest = load_manifest()
+    default_build, optional, test_only = collect_dependency_categories(manifest)
+
+    check_soup(default_build, optional, test_only)
+    check_license_inventory(default_build, optional, test_only)
+    check_readme(default_build, optional, test_only)
+
+    print("Dependency documentation is consistent with vcpkg.json")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as error:
+        print(f"Dependency documentation check failed: {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Background

`logger_system` documents the default build as having no required production SOUP, but `LICENSE-THIRD-PARTY` still described `fmt` as a core dependency. That drift made the legal inventory inconsistent with `vcpkg.json`, `docs/SOUP.md`, and the current optional-feature model.

## Problem

The repository mixed default-build, optional-feature, and development-only dependencies in a way that no longer matched the manifest. That weakens the reliability of the license inventory and any downstream SBOM or compliance review.

## Approach

Align the legal inventory and top-level dependency documentation with the current manifest, then add a lightweight CI check so future manifest or documentation changes do not drift apart silently.

## Main Changes

- Reworked `LICENSE-THIRD-PARTY` to remove the stale `fmt` entry and split dependencies into default-build, optional-feature, and development/test categories.
- Updated `README.md` installation and requirements guidance to state that the default vcpkg package has no required third-party production dependencies, and documented which dependencies are introduced by each optional feature.
- Added `scripts/ci/check_dependency_docs.py` to validate `vcpkg.json`, `docs/SOUP.md`, `LICENSE-THIRD-PARTY`, and `README.md` stay aligned.
- Wired the new consistency check into `.github/workflows/cve-scan.yml`.

## Verification

- `python3 scripts/ci/check_dependency_docs.py`
- `python3 -m py_compile scripts/ci/check_dependency_docs.py`

## Remaining Risks / Follow-up

- `README.kr.md` still contains older dependency wording and was left untouched in this change because the issue scope focused on the primary README and legal/compliance docs.
- If the dependency model evolves again, the new CI check should fail until the manifest and documentation are updated together.

Closes #478