### PR TITLE
fix(cmake): use lowercase common_system as find_package name in UnifiedDependencies

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -115,7 +115,7 @@ set(_UNIFIED_FETCH_NAME_database_system "DatabaseSystem")
 set(_UNIFIED_FETCH_NAME_network_system "NetworkSystem")
 
 # find_package names
-set(_UNIFIED_PACKAGE_NAME_common_system "CommonSystem")
+set(_UNIFIED_PACKAGE_NAME_common_system "common_system")
 set(_UNIFIED_PACKAGE_NAME_thread_system "ThreadSystem")
 set(_UNIFIED_PACKAGE_NAME_logger_system "LoggerSystem")
 set(_UNIFIED_PACKAGE_NAME_monitoring_system "MonitoringSystem")


### PR DESCRIPTION
## Summary

- Fix `_UNIFIED_PACKAGE_NAME_common_system` in `UnifiedDependencies.cmake` from `"CommonSystem"` to `"common_system"`

## Root Cause

The vcpkg overlay port (`kcenon-common-system`) installs `common_system` with the cmake package name `common_system` (lowercase, matching `common_systemConfig.cmake`). However, `UnifiedDependencies.cmake` was calling `find_package(CommonSystem)` (PascalCase), which cannot find the installed package config file.

This caused `find_package` to fail silently, triggering the FetchContent fallback, which then fails under vcpkg's `FETCHCONTENT_FULLY_DISCONNECTED=ON` restriction.

## Test Plan

- [ ] `vcpkg install kcenon-logger-system --overlay-ports=./monitoring_system/vcpkg-ports` succeeds
- [ ] `find_package(LoggerSystem CONFIG REQUIRED)` works in a test consumer

## Related

- Closes #480
- Part of monitoring_system#283 (vcpkg overlay port for logger_system)