### PR TITLE
docs: fix Doxyfile portability and improve comment coverage

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -7,13 +7,13 @@ OUTPUT_DIRECTORY       = documents
 GENERATE_HTML          = YES
 GENERATE_LATEX         = NO
 EXTRACT_ALL            = YES
-EXTRACT_PRIVATE        = NO
+EXTRACT_PRIVATE        = YES
 EXTRACT_STATIC         = YES
 QUIET                  = NO
 RECURSIVE              = YES
 CASE_SENSE_NAMES       = YES
 FULL_PATH_NAMES        = YES
-STRIP_FROM_PATH        = /Users/dongcheolshin/Sources/logger_system/
+STRIP_FROM_PATH        =
 JAVADOC_AUTOBRIEF      = YES
 TAB_SIZE               = 4
 OPTIMIZE_OUTPUT_FOR_C  = NO
@@ -22,14 +22,17 @@ OPTIMIZE_FOR_FORTRAN   = NO
 OPTIMIZE_OUTPUT_VHDL   = NO
 MARKDOWN_SUPPORT       = YES
 USE_MDFILE_AS_MAINPAGE = README.md
-INLINE_SOURCES         = NO
+INLINE_SOURCES         = YES
+CREATE_SUBDIRS         = YES
 SOURCE_BROWSER         = YES
 GENERATE_TREEVIEW      = YES
 HAVE_DOT               = YES
 DOT_IMAGE_FORMAT       = svg
 CLASS_DIAGRAMS         = YES
-CALL_GRAPH             = NO
-CALLER_GRAPH           = NO
+COLLABORATION_GRAPH    = YES
+UML_LOOK               = YES
+CALL_GRAPH             = YES
+CALLER_GRAPH           = YES
 
 # Enhanced documentation settings
 ALWAYS_DETAILED_SEC    = YES
@@ -74,9 +77,10 @@ INPUT                  = README.md ARCHITECTURE.md SECURITY.md \
                          include/kcenon/logger \
                          src \
                          docs
-FILE_PATTERNS          = *.h *.hpp *.cpp *.md
-EXCLUDE_PATTERNS       = */tests/* */unittest/* */benchmarks/*
+FILE_PATTERNS          = *.h *.hpp *.cpp *.cppm *.tpp *.md
+EXCLUDE_PATTERNS       = */tests/* */unittest/* */benchmarks/* \
+                         */build/* */build_*/* */vcpkg/* */.git/*
 HTML_OUTPUT            = html
-HTML_COLORSTYLE_HUE    = 200
+HTML_COLORSTYLE_HUE    = 220
 HTML_TIMESTAMP         = YES
 

--- a/include/kcenon/logger/core/logger.h
+++ b/include/kcenon/logger/core/logger.h
@@ -118,11 +118,14 @@ using overflow_policy = logger_system::overflow_policy;
 using logger_metrics = metrics::logger_performance_stats;
 using performance_metrics = metrics::logger_performance_stats; // Alias for examples
 
-// Metric type enum
+/**
+ * @enum metric_type
+ * @brief Types of metrics that can be recorded by the logger.
+ */
 enum class metric_type {
-    gauge,
-    counter,
-    histogram
+    gauge,      ///< A metric that can go up or down (e.g., queue depth).
+    counter,    ///< A monotonically increasing metric (e.g., total messages).
+    histogram   ///< A distribution of values (e.g., processing latency).
 };
 
 // Forward declarations

--- a/include/kcenon/logger/core/logger_config.h
+++ b/include/kcenon/logger/core/logger_config.h
@@ -29,51 +29,68 @@ using log_level = common::interfaces::log_level;
  * and provides validation to ensure configuration correctness.
  */
 struct logger_config {
-    // Basic settings
-    bool async = true;
-    std::size_t buffer_size = 8192;
-    log_level min_level = log_level::info;
-    
-    // Performance settings
-    std::size_t batch_size = 100;
-    std::chrono::milliseconds flush_interval{1000};
-    bool use_lock_free = false;
-    std::size_t max_writers = 10;
-    bool enable_batch_writing = false;
-    
-    // Feature flags
-    bool enable_metrics = false;
-    bool enable_crash_handler = false;
-    bool enable_structured_logging = false;
-    bool enable_color_output = true;
-    bool enable_timestamp = true;
-    bool enable_source_location = false;
-    
-    // Queue settings
-    std::size_t max_queue_size = 10000;
+    /// @name Basic settings
+    /// @{
+    bool async = true;                              ///< Enable asynchronous logging.
+    std::size_t buffer_size = 8192;                 ///< Internal buffer size in bytes.
+    log_level min_level = log_level::info;           ///< Minimum log level to process.
+    /// @}
+
+    /// @name Performance settings
+    /// @{
+    std::size_t batch_size = 100;                   ///< Number of messages per batch write.
+    std::chrono::milliseconds flush_interval{1000}; ///< Interval between automatic flushes.
+    bool use_lock_free = false;                     ///< Use lock-free queue implementation.
+    std::size_t max_writers = 10;                   ///< Maximum number of concurrent writers.
+    bool enable_batch_writing = false;              ///< Enable batch writing mode.
+    /// @}
+
+    /// @name Feature flags
+    /// @{
+    bool enable_metrics = false;                    ///< Enable performance metrics collection.
+    bool enable_crash_handler = false;              ///< Enable crash signal handler.
+    bool enable_structured_logging = false;         ///< Enable structured (JSON) log output.
+    bool enable_color_output = true;                ///< Enable ANSI color output.
+    bool enable_timestamp = true;                   ///< Include timestamp in log entries.
+    bool enable_source_location = false;            ///< Include source file/line in log entries.
+    /// @}
+
+    /// @name Queue settings
+    /// @{
+    std::size_t max_queue_size = 10000;             ///< Maximum number of queued messages.
+    /**
+     * @enum overflow_policy
+     * @brief Policy for handling queue overflow when max_queue_size is reached.
+     */
     enum class overflow_policy {
-        drop_oldest,    // Drop oldest messages when queue is full
-        drop_newest,    // Drop new messages when queue is full (default)
-        block,          // Block until space is available
-        grow            // Dynamically grow the queue (use with caution)
+        drop_oldest,    ///< Drop oldest messages when queue is full.
+        drop_newest,    ///< Drop new messages when queue is full (default).
+        block,          ///< Block until space is available.
+        grow            ///< Dynamically grow the queue (use with caution).
     };
-    overflow_policy queue_overflow_policy = overflow_policy::drop_newest;
-    
-    // File output settings
-    std::size_t max_file_size = 100 * 1024 * 1024;  // 100MB default
-    std::size_t max_file_count = 5;                  // For rotating files
-    std::string log_directory = "./logs";
-    std::string log_file_prefix = "app";
-    
-    // Network settings
-    std::string remote_host = "";
-    uint16_t remote_port = 0;
-    std::chrono::milliseconds network_timeout{5000};
-    std::size_t network_retry_count = 3;
-    
-    // Performance tuning
-    std::size_t writer_thread_count = 1;
-    bool enable_compression = false;
+    overflow_policy queue_overflow_policy = overflow_policy::drop_newest; ///< Active overflow policy.
+    /// @}
+
+    /// @name File output settings
+    /// @{
+    std::size_t max_file_size = 100 * 1024 * 1024;  ///< Maximum file size in bytes (default: 100MB).
+    std::size_t max_file_count = 5;                  ///< Maximum number of rotating log files.
+    std::string log_directory = "./logs";             ///< Directory for log file output.
+    std::string log_file_prefix = "app";             ///< Prefix for log file names.
+    /// @}
+
+    /// @name Network settings
+    /// @{
+    std::string remote_host = "";                    ///< Remote log collector hostname.
+    uint16_t remote_port = 0;                        ///< Remote log collector port.
+    std::chrono::milliseconds network_timeout{5000}; ///< Network operation timeout.
+    std::size_t network_retry_count = 3;             ///< Number of network retry attempts.
+    /// @}
+
+    /// @name Performance tuning
+    /// @{
+    std::size_t writer_thread_count = 1;             ///< Number of dedicated writer threads.
+    bool enable_compression = false;                 ///< Enable log compression.
     
     /**
      * @brief Validate the configuration


### PR DESCRIPTION
## Summary
- Remove hardcoded `STRIP_FROM_PATH` with another developer's home directory
- Enable call/caller graphs, collaboration diagrams, and UML-style output
- Add C++20 module support (`*.cppm`, `*.tpp`) and build directory exclusions
- Document `metric_type` enum with per-enumerator descriptions
- Convert all `logger_config` member comments from `//` to `///` for Doxygen visibility
- Add `@name` groups for logical member organization in `logger_config`

## Test plan
- [ ] Run `doxygen Doxyfile` and verify no new warnings
- [ ] Verify `metric_type` and `overflow_policy` enums appear in documentation
- [ ] Verify `logger_config` members have descriptions in generated docs
- [ ] Verify call graphs appear in HTML output

Closes #483