### PR TITLE
fix(cmake): use lowercase thread_system as find_package name in UnifiedDependencies

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -116,7 +116,7 @@ set(_UNIFIED_FETCH_NAME_network_system "NetworkSystem")
 
 # find_package names
 set(_UNIFIED_PACKAGE_NAME_common_system "common_system")
-set(_UNIFIED_PACKAGE_NAME_thread_system "ThreadSystem")
+set(_UNIFIED_PACKAGE_NAME_thread_system "thread_system")
 set(_UNIFIED_PACKAGE_NAME_logger_system "LoggerSystem")
 set(_UNIFIED_PACKAGE_NAME_monitoring_system "MonitoringSystem")
 set(_UNIFIED_PACKAGE_NAME_container_system "ContainerSystem")


### PR DESCRIPTION
## What

### Summary
Aligns `_UNIFIED_PACKAGE_NAME_thread_system` with the installed vcpkg package name by changing from PascalCase `ThreadSystem` to lowercase `thread_system`.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `cmake/UnifiedDependencies.cmake` — find_package name mapping

## Why

### Problem Solved
The vcpkg overlay port installs thread_system with the lowercase package name `thread_system`, creating `thread_system-config.cmake`. However, `UnifiedDependencies.cmake` was calling `find_package(ThreadSystem)`, which looks for `ThreadSystemConfig.cmake` or `ThreadSystem-config.cmake` — a case mismatch that prevents package discovery in vcpkg builds.

This causes an unnecessary FetchContent fallback, which then fails in the vcpkg sandbox (no network access) and with CMake 4.x (CMP0170 deprecates `FetchContent_Populate`).

### Related Issues
- Closes #482
- Follows the same fix pattern as #481 (common_system PascalCase → lowercase)
- Related: kcenon/database_system#432 (similar target name mismatch)

## Where

### Files Changed
| File | Change |
|------|--------|
| `cmake/UnifiedDependencies.cmake` | 1 line: `ThreadSystem` → `thread_system` |

## How

### Implementation Details
Single-line change to the `_UNIFIED_PACKAGE_NAME_thread_system` variable, matching the pattern established in #481 for `common_system`.

### Testing
- Verified diff is minimal and matches the #481 fix pattern
- CI will validate the build

### Breaking Changes
None — this fixes a broken path; existing direct `find_package(ThreadSystem)` calls by consumers (if any) are unaffected since this only changes the UnifiedDependencies internal lookup.