### PR TITLE
fix(build): add DLL export macros, fix CMake install/export and include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,22 +267,7 @@ if(LOGGER_USE_THREAD_SYSTEM)
         set(THREAD_SYSTEM_FOUND TRUE)
         message(STATUS "Logger System: thread_system integration enabled")
         message(STATUS "  Direction: logger_system → thread_system (using thread_pool for async I/O)")
-
-        # Define LOGGER_HAS_THREAD_SYSTEM for conditional compilation
-        # This macro is used in:
-        # - include/kcenon/logger/integration/thread_system_integration.h
-        # - src/integration/thread_system_integration.cpp
-        add_compile_definitions(LOGGER_HAS_THREAD_SYSTEM)
-
-        # Create a unified thread_system target if needed (header-only).
-        # Do NOT link internal sub-targets (thread_base, interfaces, utilities)
-        # as they are not in LoggerSystem's export set and cause install(EXPORT) failures.
-        if(NOT TARGET thread_system AND NOT TARGET ThreadSystem)
-            add_library(thread_system INTERFACE)
-            target_include_directories(thread_system INTERFACE
-                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../thread_system/include>
-            )
-        endif()
+        # LOGGER_HAS_THREAD_SYSTEM is set per-target below (in thread_system linking section)
     else()
         message(STATUS "Logger System: thread_system not found, using standalone mode")
         set(THREAD_SYSTEM_FOUND FALSE)
@@ -358,11 +343,19 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
     if(SOURCE_COUNT GREATER 5)
         # Create library with new structure
         add_library(LoggerSystem ${LOGGER_SOURCES} ${LOGGER_HEADERS})
+        set_target_properties(LoggerSystem PROPERTIES EXPORT_NAME logger)
         target_include_directories(LoggerSystem
             PUBLIC
                 $<BUILD_INTERFACE:${LOGGER_INCLUDE_DIR}>
                 $<INSTALL_INTERFACE:include>
         )
+
+        # DLL export support
+        if(BUILD_SHARED_LIBS)
+            target_compile_definitions(LoggerSystem PRIVATE LOGGER_SYSTEM_BUILDING)
+        else()
+            target_compile_definitions(LoggerSystem PUBLIC LOGGER_SYSTEM_STATIC)
+        endif()
 
         # Optional module compile definitions (Issue #357: SRP)
         if(LOGGER_WITH_SERVER)
@@ -415,26 +408,42 @@ if(EXISTS ${LOGGER_INCLUDE_DIR}/kcenon/logger AND EXISTS ${LOGGER_SOURCE_DIR})
         # thread_system integration (optional, for advanced features)
         if(THREAD_SYSTEM_FOUND)
             message(STATUS "Logger System: thread_system found, optional backend available")
-            if(TARGET ThreadSystem)
+
+            # Use the resolved target from UnifiedDependencies
+            if(thread_system_TARGET AND TARGET ${thread_system_TARGET})
+                get_target_property(_ts_imported ${thread_system_TARGET} IMPORTED)
+                if(_ts_imported)
+                    # IMPORTED target (vcpkg / find_package): safe to export
+                    target_link_libraries(LoggerSystem PUBLIC ${thread_system_TARGET})
+                    target_compile_definitions(LoggerSystem PUBLIC LOGGER_HAS_THREAD_SYSTEM)
+                else()
+                    # Local (submodule) target: cannot be in our export set
+                    target_link_libraries(LoggerSystem PRIVATE ${thread_system_TARGET})
+                    target_compile_definitions(LoggerSystem PRIVATE LOGGER_HAS_THREAD_SYSTEM)
+                    set(_LOGGER_HAS_LOCAL_THREAD_SYSTEM TRUE)
+                endif()
+            elseif(TARGET ThreadSystem)
                 get_target_property(_ts_imported ThreadSystem IMPORTED)
-                target_link_libraries(LoggerSystem PRIVATE ThreadSystem)
+                target_link_libraries(LoggerSystem PUBLIC ThreadSystem)
+                target_compile_definitions(LoggerSystem PUBLIC LOGGER_HAS_THREAD_SYSTEM)
                 if(NOT _ts_imported)
                     set(_LOGGER_HAS_LOCAL_THREAD_SYSTEM TRUE)
                 endif()
             elseif(TARGET thread_system)
                 get_target_property(_ts_imported thread_system IMPORTED)
-                target_link_libraries(LoggerSystem PRIVATE thread_system)
+                target_link_libraries(LoggerSystem PUBLIC thread_system)
+                target_compile_definitions(LoggerSystem PUBLIC LOGGER_HAS_THREAD_SYSTEM)
                 if(NOT _ts_imported)
                     set(_LOGGER_HAS_LOCAL_THREAD_SYSTEM TRUE)
                 endif()
             else()
                 # Fallback: header-only access when aggregate targets are unavailable.
-                # Do NOT link internal sub-targets (thread_base, interfaces, utilities)
-                # as they are not part of LoggerSystem's export set.
                 target_include_directories(LoggerSystem
                     PUBLIC
                         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../thread_system/include>
                 )
+                target_compile_definitions(LoggerSystem PRIVATE LOGGER_HAS_THREAD_SYSTEM)
+                set(_LOGGER_HAS_LOCAL_THREAD_SYSTEM TRUE)
             endif()
         else()
             message(STATUS "Logger System: Using standalone async implementation (no thread_system)")
@@ -627,8 +636,8 @@ if(INSTALL_TARGETS)
     endif()
 endif()
 
-install(DIRECTORY include/kcenon/logger/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/logger_system
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp"
 )
 

--- a/cmake/LoggerSystemConfig.cmake.in
+++ b/cmake/LoggerSystemConfig.cmake.in
@@ -20,14 +20,20 @@ endif()
 # thread_system is optional (Issue #222: standalone std::jthread implementation)
 set(LoggerSystem_USE_THREAD_SYSTEM @LOGGER_USE_THREAD_SYSTEM@)
 if(LoggerSystem_USE_THREAD_SYSTEM)
-    find_dependency(ThreadSystem QUIET)
-    if(NOT ThreadSystem_FOUND)
+    find_dependency(thread_system QUIET)
+    if(NOT thread_system_FOUND)
+        # Fallback: try CamelCase package name
+        find_dependency(ThreadSystem QUIET)
+    endif()
+    if(NOT thread_system_FOUND AND NOT ThreadSystem_FOUND)
         message(STATUS "LoggerSystem: thread_system not found, using standalone mode")
     endif()
 endif()
 
-# Include the exported targets
-include("${CMAKE_CURRENT_LIST_DIR}/LoggerSystemTargets.cmake")
+# Include the exported targets (may not exist when local thread_system skipped export)
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/LoggerSystemTargets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/LoggerSystemTargets.cmake")
+endif()
 
 # Provide the features that were enabled during build
 set(LoggerSystem_USE_DI @LOGGER_USE_DI@)

--- a/include/kcenon/logger/builders/writer_builder.h
+++ b/include/kcenon/logger/builders/writer_builder.h
@@ -74,6 +74,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../interfaces/log_writer_interface.h"
 #include "../interfaces/log_filter_interface.h"
 #include "../interfaces/log_formatter_interface.h"
+#include <kcenon/logger/logger_export.h>
 
 #include <chrono>
 #include <cstddef>
@@ -114,7 +115,7 @@ class secure_key;
  *
  * @since 4.1.0
  */
-class writer_builder {
+class LOGGER_SYSTEM_API writer_builder {
 public:
     /**
      * @brief Default constructor

--- a/include/kcenon/logger/core/log_collector.h
+++ b/include/kcenon/logger/core/log_collector.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <kcenon/common/interfaces/logger_interface.h>
 #include <kcenon/logger/interfaces/log_writer_interface.h>
+#include <kcenon/logger/logger_export.h>
 
 #include <atomic>
 #include <chrono>
@@ -58,7 +59,7 @@ namespace kcenon::logger {
  * Collects log entries in a queue (mutex/condition-variable backed)
  * and processes them in a background thread to minimize logging overhead.
  */
-class log_collector {
+class LOGGER_SYSTEM_API log_collector {
 public:
     /**
      * @brief Constructor

--- a/include/kcenon/logger/core/log_context_scope.h
+++ b/include/kcenon/logger/core/log_context_scope.h
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/logger/logger_export.h>
 
 #include <algorithm>
 #include <optional>
@@ -275,7 +276,7 @@ private:
  *
  * @since 3.2.0
  */
-class log_context_scope {
+class LOGGER_SYSTEM_API log_context_scope {
 public:
     /**
      * @brief Construct scope with initial fields

--- a/include/kcenon/logger/core/logger.h
+++ b/include/kcenon/logger/core/logger.h
@@ -49,9 +49,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/logger/interfaces/logger_types.h>
 #include <kcenon/logger/interfaces/log_entry.h>
 #include <kcenon/logger/interfaces/log_writer_interface.h>
-#include <kcenon/logger/security/signal_manager.h>
+#include <kcenon/logger/logger_export.h>
 #include <kcenon/logger/otlp/otel_context.h>
 #include <kcenon/logger/sampling/sampling_config.h>
+#include <kcenon/logger/security/signal_manager.h>
 #include "structured_log_builder.h"
 #include "unified_log_context.h"
 
@@ -180,8 +181,8 @@ using routing::router_builder;
  *
  * @note For integration with common_system monitoring interfaces, use logger_monitoring_adapter
  */
-class logger : public security::critical_logger_interface,
-               public common::interfaces::ILogger {
+class LOGGER_SYSTEM_API logger : public security::critical_logger_interface,
+                                public common::interfaces::ILogger {
 public:
     /**
      * @brief Constructor with optional configuration

--- a/include/kcenon/logger/core/logger_context.h
+++ b/include/kcenon/logger/core/logger_context.h
@@ -8,9 +8,10 @@ All rights reserved.
 *****************************************************************************/
 
 #include <memory>
-#include <kcenon/logger/security/signal_manager_interface.h>
-#include <kcenon/logger/core/signal_manager_context.h>
 #include <kcenon/logger/core/logger_registry.h>
+#include <kcenon/logger/core/signal_manager_context.h>
+#include <kcenon/logger/logger_export.h>
+#include <kcenon/logger/security/signal_manager_interface.h>
 
 /**
  * @file logger_context.h
@@ -75,7 +76,7 @@ namespace core {
  * Thread Safety: All methods are thread-safe. Each component provides its own
  * thread safety guarantees.
  */
-class logger_context {
+class LOGGER_SYSTEM_API logger_context {
 public:
     /**
      * @brief Default constructor - creates default implementations

--- a/include/kcenon/logger/core/logger_registry.h
+++ b/include/kcenon/logger/core/logger_registry.h
@@ -10,6 +10,8 @@ All rights reserved.
 #include <vector>
 #include <shared_mutex>
 
+#include <kcenon/logger/logger_export.h>
+
 // Forward declaration to avoid circular dependencies
 namespace kcenon::logger::security {
     class critical_logger_interface;
@@ -37,7 +39,7 @@ namespace kcenon::logger::core {
  * Thread Safety: All methods are thread-safe. Uses shared_mutex for reader-writer lock
  * optimization (multiple readers, single writer).
  */
-class logger_registry {
+class LOGGER_SYSTEM_API logger_registry {
 public:
     /**
      * @brief Default constructor

--- a/include/kcenon/logger/core/metrics/logger_metrics.h
+++ b/include/kcenon/logger/core/metrics/logger_metrics.h
@@ -40,6 +40,8 @@
 #include <map>
 #include <string>
 
+#include <kcenon/logger/logger_export.h>
+
 namespace kcenon::logger::metrics {
 
 /**
@@ -174,7 +176,7 @@ struct logger_performance_stats {
 /**
  * @brief Global logger metrics instance
  */
-extern logger_performance_stats g_logger_stats;
+extern LOGGER_SYSTEM_API logger_performance_stats g_logger_stats;
 
 /**
  * @brief Record a logged message

--- a/include/kcenon/logger/core/scoped_context_guard.h
+++ b/include/kcenon/logger/core/scoped_context_guard.h
@@ -59,6 +59,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "unified_log_context.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <optional>
 #include <string>
 #include <string_view>
@@ -124,7 +126,7 @@ class logger;
  *
  * @since 3.3.0
  */
-class scoped_context_guard {
+class LOGGER_SYSTEM_API scoped_context_guard {
 public:
     /**
      * @brief Construct guard and save current context

--- a/include/kcenon/logger/core/signal_manager_context.h
+++ b/include/kcenon/logger/core/signal_manager_context.h
@@ -9,6 +9,7 @@ All rights reserved.
 
 #include <memory>
 #include <mutex>
+#include <kcenon/logger/logger_export.h>
 #include <kcenon/logger/security/signal_manager_interface.h>
 
 /**
@@ -32,7 +33,7 @@ namespace kcenon::logger::core {
  *
  * Thread Safety: All methods are thread-safe.
  */
-class signal_manager_context {
+class LOGGER_SYSTEM_API signal_manager_context {
 public:
     /**
      * @brief Default constructor - creates null signal manager

--- a/include/kcenon/logger/core/unified_log_context.h
+++ b/include/kcenon/logger/core/unified_log_context.h
@@ -62,6 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/logger/logger_export.h>
 #include <kcenon/logger/otlp/otel_context.h>
 
 #include <optional>
@@ -141,7 +142,7 @@ enum class context_category : uint8_t {
  *
  * @since 3.3.0
  */
-class unified_log_context {
+class LOGGER_SYSTEM_API unified_log_context {
 public:
     /**
      * @brief Default constructor

--- a/include/kcenon/logger/integration/executor_integration.h
+++ b/include/kcenon/logger/integration/executor_integration.h
@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <kcenon/logger/core/thread_integration_detector.h>
 #include <kcenon/logger/integration/standalone_executor.h>
+#include <kcenon/logger/logger_export.h>
 
 #if LOGGER_HAS_IEXECUTOR
 
@@ -139,7 +140,7 @@ enum class executor_type {
  *
  * @since 1.5.0
  */
-class executor_integration {
+class LOGGER_SYSTEM_API executor_integration {
 public:
     /**
      * @brief Enable async processing with optional executor

--- a/include/kcenon/logger/integration/standalone_executor.h
+++ b/include/kcenon/logger/integration/standalone_executor.h
@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <kcenon/logger/core/thread_integration_detector.h>
+#include <kcenon/logger/logger_export.h>
 
 #if LOGGER_HAS_IEXECUTOR
 
@@ -142,7 +143,7 @@ private:
  *
  * @since 1.5.0
  */
-class standalone_executor : public common::interfaces::IExecutor {
+class LOGGER_SYSTEM_API standalone_executor : public common::interfaces::IExecutor {
 public:
     /**
      * @brief Constructor with configurable queue size
@@ -272,7 +273,7 @@ private:
 /**
  * @brief Factory for creating standalone executor instances
  */
-class standalone_executor_factory {
+class LOGGER_SYSTEM_API standalone_executor_factory {
 public:
     /**
      * @brief Create a new standalone executor

--- a/include/kcenon/logger/integration/thread_system_integration.h
+++ b/include/kcenon/logger/integration/thread_system_integration.h
@@ -62,6 +62,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include <kcenon/logger/logger_export.h>
+
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -148,7 +150,7 @@ enum class async_backend_type {
  * @note Only available when LOGGER_HAS_THREAD_SYSTEM is defined
  * @since 1.4.0
  */
-class thread_system_integration {
+class LOGGER_SYSTEM_API thread_system_integration {
 public:
     /**
      * @brief Enable thread_pool backend with optional custom pool

--- a/include/kcenon/logger/logger_export.h
+++ b/include/kcenon/logger/logger_export.h
@@ -1,0 +1,31 @@
+#pragma once
+
+/**
+ * @file logger_export.h
+ * @brief DLL export/import macros for logger_system shared library support
+ *
+ * @details Provides the LOGGER_SYSTEM_API macro for controlling symbol visibility.
+ *
+ * - Static builds: Define LOGGER_SYSTEM_STATIC (done automatically by CMake
+ *   when BUILD_SHARED_LIBS=OFF). All symbols have default visibility.
+ * - Shared library builds: LOGGER_SYSTEM_BUILDING is defined when compiling
+ *   the library itself (exports symbols). Consumers import symbols.
+ *
+ * @since 0.2.0
+ */
+
+#ifdef LOGGER_SYSTEM_STATIC
+#define LOGGER_SYSTEM_API
+#elif defined(LOGGER_SYSTEM_BUILDING)
+#ifdef _WIN32
+#define LOGGER_SYSTEM_API __declspec(dllexport)
+#else
+#define LOGGER_SYSTEM_API __attribute__((visibility("default")))
+#endif
+#else
+#ifdef _WIN32
+#define LOGGER_SYSTEM_API __declspec(dllimport)
+#else
+#define LOGGER_SYSTEM_API
+#endif
+#endif

--- a/include/kcenon/logger/sampling/log_sampler.h
+++ b/include/kcenon/logger/sampling/log_sampler.h
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "sampling_config.h"
 #include <kcenon/logger/interfaces/log_entry.h>
+#include <kcenon/logger/logger_export.h>
 #include <kcenon/common/interfaces/logger_interface.h>
 
 #include <atomic>
@@ -95,7 +96,7 @@ using log_level = common::interfaces::log_level;
  *
  * @since 3.3.0
  */
-class log_sampler {
+class LOGGER_SYSTEM_API log_sampler {
 public:
     /**
      * @brief Construct a sampler with the given configuration
@@ -318,7 +319,7 @@ private:
  *
  * @since 3.3.0
  */
-class sampler_factory {
+class LOGGER_SYSTEM_API sampler_factory {
 public:
     /**
      * @brief Create a disabled sampler (pass-through)

--- a/include/kcenon/logger/security/signal_manager.h
+++ b/include/kcenon/logger/security/signal_manager.h
@@ -8,6 +8,7 @@ All rights reserved.
 *****************************************************************************/
 
 #include "signal_manager_interface.h"
+#include <kcenon/logger/logger_export.h>
 #include <csignal>
 #include <set>
 #include <mutex>
@@ -76,7 +77,7 @@ inline int safe_fsync(int fd) {
  *
  * @since 2.0.0 - Converted from singleton to DI pattern
  */
-class signal_manager : public signal_manager_interface {
+class LOGGER_SYSTEM_API signal_manager : public signal_manager_interface {
 public:
     /**
      * @brief Default constructor

--- a/include/kcenon/logger/writers/base_writer.h
+++ b/include/kcenon/logger/writers/base_writer.h
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/common/interfaces/logger_interface.h>
 #include <kcenon/common/patterns/result.h>
 #include <kcenon/logger/core/error_codes.h>
+#include <kcenon/logger/logger_export.h>
 #include "../interfaces/log_writer_interface.h"
 #include "../interfaces/log_entry.h"
 #include "../interfaces/log_formatter_interface.h"
@@ -119,7 +120,7 @@ namespace kcenon::logger {
  *
  * @since 1.0.0
  */
-class base_writer : public log_writer_interface {
+class LOGGER_SYSTEM_API base_writer : public log_writer_interface {
 public:
     /**
      * @brief Constructor with optional formatter

--- a/include/kcenon/logger/writers/batch_writer.h
+++ b/include/kcenon/logger/writers/batch_writer.h
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "queued_writer_base.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <vector>
 #include <chrono>
 
@@ -58,7 +61,7 @@ namespace kcenon::logger {
  * @since 1.4.0 Added async_writer_tag and decorator_writer_tag for classification
  * @since 4.0.0 Refactored to use queued_writer_base
  */
-class batch_writer : public queued_writer_base<std::vector<log_entry>> {
+class LOGGER_SYSTEM_API batch_writer : public queued_writer_base<std::vector<log_entry>> {
     using base_type = queued_writer_base<std::vector<log_entry>>;
 
 public:

--- a/include/kcenon/logger/writers/buffered_writer.h
+++ b/include/kcenon/logger/writers/buffered_writer.h
@@ -68,6 +68,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "decorator_writer_base.h"
 #include "../interfaces/log_entry.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -104,7 +106,7 @@ namespace kcenon::logger {
  *
  * @since 4.0.0
  */
-class buffered_writer : public decorator_writer_base {
+class LOGGER_SYSTEM_API buffered_writer : public decorator_writer_base {
 public:
     /**
      * @brief Default buffer size (number of entries)

--- a/include/kcenon/logger/writers/console_writer.h
+++ b/include/kcenon/logger/writers/console_writer.h
@@ -35,6 +35,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../interfaces/log_writer_interface.h"
 #include "../interfaces/log_formatter_interface.h"
 #include "../interfaces/writer_category.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <atomic>
 #include <mutex>
 #include <memory>
@@ -61,7 +64,7 @@ namespace kcenon::logger {
  * @since 4.0.0 Refactored for Decorator pattern with simplified inheritance
  * @since 4.1.0 Directly implements log_writer_interface as core writer
  */
-class console_writer : public log_writer_interface, public sync_writer_tag {
+class LOGGER_SYSTEM_API console_writer : public log_writer_interface, public sync_writer_tag {
 public:
     /**
      * @brief Constructor

--- a/include/kcenon/logger/writers/critical_writer.h
+++ b/include/kcenon/logger/writers/critical_writer.h
@@ -47,6 +47,9 @@ All rights reserved.
 
 #include "base_writer.h"
 #include "../interfaces/writer_category.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -104,7 +107,7 @@ struct critical_writer_config {
  *
  * @since 1.4.0 Added decorator_writer_tag for category classification
  */
-class critical_writer : public base_writer, public decorator_writer_tag {
+class LOGGER_SYSTEM_API critical_writer : public base_writer, public decorator_writer_tag {
 public:
     /**
      * @brief Constructor

--- a/include/kcenon/logger/writers/decorator_writer_base.h
+++ b/include/kcenon/logger/writers/decorator_writer_base.h
@@ -65,6 +65,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../interfaces/log_writer_interface.h"
 #include "../interfaces/writer_category.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <memory>
 #include <string>
 #include <string_view>
@@ -94,7 +96,7 @@ namespace kcenon::logger {
  *
  * @since 4.0.0
  */
-class decorator_writer_base : public log_writer_interface, public decorator_writer_tag {
+class LOGGER_SYSTEM_API decorator_writer_base : public log_writer_interface, public decorator_writer_tag {
 public:
     /**
      * @brief Construct a decorator writer base

--- a/include/kcenon/logger/writers/encrypted_writer.h
+++ b/include/kcenon/logger/writers/encrypted_writer.h
@@ -71,6 +71,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../security/secure_key_storage.h"
 #include "../core/error_codes.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <array>
 #include <memory>
 #include <mutex>
@@ -211,7 +213,7 @@ struct encrypted_log_header {
  * @since 1.4.0 Added decorator_writer_tag for category classification
  * @since 4.0.0 Refactored to use decorator_writer_base
  */
-class encrypted_writer : public decorator_writer_base {
+class LOGGER_SYSTEM_API encrypted_writer : public decorator_writer_base {
 public:
     /**
      * @brief Construct encrypted writer with wrapped writer

--- a/include/kcenon/logger/writers/file_writer.h
+++ b/include/kcenon/logger/writers/file_writer.h
@@ -10,6 +10,9 @@ All rights reserved.
 #include "../interfaces/log_writer_interface.h"
 #include "../interfaces/log_formatter_interface.h"
 #include "../interfaces/writer_category.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <fstream>
 #include <atomic>
 #include <memory>
@@ -34,7 +37,7 @@ namespace kcenon::logger {
  * @since 4.0.0 Refactored for Decorator pattern with simplified inheritance
  * @since 4.1.0 Directly implements log_writer_interface as core writer
  */
-class file_writer : public log_writer_interface, public sync_writer_tag {
+class LOGGER_SYSTEM_API file_writer : public log_writer_interface, public sync_writer_tag {
 public:
     /**
      * @brief Constructor

--- a/include/kcenon/logger/writers/filtered_writer.h
+++ b/include/kcenon/logger/writers/filtered_writer.h
@@ -66,6 +66,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "decorator_writer_base.h"
 #include "../interfaces/log_filter_interface.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <memory>
 
 namespace kcenon::logger {
@@ -93,7 +95,7 @@ namespace kcenon::logger {
  * @since 4.0.0
  * @since 4.1.0 Migrated to use decorator_writer_base for code reuse
  */
-class filtered_writer : public decorator_writer_base {
+class LOGGER_SYSTEM_API filtered_writer : public decorator_writer_base {
 public:
     /**
      * @brief Construct a filtered writer

--- a/include/kcenon/logger/writers/formatted_writer.h
+++ b/include/kcenon/logger/writers/formatted_writer.h
@@ -67,6 +67,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "decorator_writer_base.h"
 #include "../interfaces/log_formatter_interface.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <memory>
 
 namespace kcenon::logger {
@@ -94,7 +96,7 @@ namespace kcenon::logger {
  * @since 4.0.0
  * @since 4.1.0 Migrated to use decorator_writer_base for code reuse
  */
-class formatted_writer : public decorator_writer_base {
+class LOGGER_SYSTEM_API formatted_writer : public decorator_writer_base {
 public:
     /**
      * @brief Construct a formatted writer

--- a/include/kcenon/logger/writers/network_writer.h
+++ b/include/kcenon/logger/writers/network_writer.h
@@ -10,6 +10,9 @@ All rights reserved.
 #include "base_writer.h"
 #include "../interfaces/log_entry.h"
 #include "../interfaces/writer_category.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <queue>
 #include <condition_variable>
 #include <atomic>
@@ -31,7 +34,7 @@ class network_reconnect_jthread_worker;
  *
  * @since 1.4.0 Added async_writer_tag for category classification
  */
-class network_writer : public base_writer, public async_writer_tag {
+class LOGGER_SYSTEM_API network_writer : public base_writer, public async_writer_tag {
 public:
     enum class protocol_type {
         tcp,

--- a/include/kcenon/logger/writers/otlp_writer.h
+++ b/include/kcenon/logger/writers/otlp_writer.h
@@ -62,6 +62,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../interfaces/writer_category.h"
 #include "../otlp/otel_context.h"
 
+#include <kcenon/logger/logger_export.h>
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -97,7 +99,7 @@ namespace kcenon::logger {
  * @since 3.0.0
  * @since 1.4.0 Added async_writer_tag for category classification
  */
-class otlp_writer : public base_writer, public async_writer_tag {
+class LOGGER_SYSTEM_API otlp_writer : public base_writer, public async_writer_tag {
 public:
     /**
      * @enum protocol_type

--- a/include/kcenon/logger/writers/rotating_file_writer.h
+++ b/include/kcenon/logger/writers/rotating_file_writer.h
@@ -9,6 +9,9 @@ All rights reserved.
 
 #include "file_writer.h"
 #include "../interfaces/writer_category.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <chrono>
 #include <vector>
 #include <sstream>
@@ -50,7 +53,7 @@ enum class rotation_type {
  * @since 1.3.0 Refactored to use thread_safe_writer via file_writer
  * @since 1.4.0 Inherits sync_writer_tag from file_writer
  */
-class rotating_file_writer : public file_writer {
+class LOGGER_SYSTEM_API rotating_file_writer : public file_writer {
 public:
     /**
      * @brief Construct with size-based rotation

--- a/include/kcenon/logger/writers/thread_safe_writer.h
+++ b/include/kcenon/logger/writers/thread_safe_writer.h
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "base_writer.h"
+
+#include <kcenon/logger/logger_export.h>
+
 #include <mutex>
 
 /**
@@ -103,7 +106,7 @@ namespace kcenon::logger {
  *
  * @since 1.3.0
  */
-class thread_safe_writer : public base_writer {
+class LOGGER_SYSTEM_API thread_safe_writer : public base_writer {
 public:
     /**
      * @brief Constructor with optional formatter


### PR DESCRIPTION
Closes #485

## Summary

- Add `LOGGER_SYSTEM_API` DLL export macro to 30 public class declarations across 29 header files, enabling Windows shared library builds
- Create `logger_export.h` with platform-aware `__declspec(dllexport/dllimport)` / `__attribute__((visibility))` definitions
- Fix `install(DIRECTORY)` to preserve `kcenon/logger/` include prefix — eliminates vcpkg portfile `sed` header path fixup
- Set `EXPORT_NAME logger` on LoggerSystem target so exported CMake target is `LoggerSystem::logger`
- Replace global `add_compile_definitions(LOGGER_HAS_THREAD_SYSTEM)` with target-scoped `target_compile_definitions` (PUBLIC for IMPORTED, PRIVATE for local)
- Resolve thread_system via `${thread_system_TARGET}` from UnifiedDependencies instead of hardcoded target names
- Update `LoggerSystemConfig.cmake.in`: try both lowercase and CamelCase thread_system package names, guard `LoggerSystemTargets.cmake` include with existence check

## vcpkg Port Workarounds Addressed

| Workaround | Status |
|------------|--------|
| Manual `LoggerSystemTargets.cmake` generation | Fixed: `install(EXPORT)` now produces correct targets |
| Header path `sed` replacement (`kcenon/logger/` -> `logger_system/`) | Fixed: headers install to `kcenon/logger/` prefix |
| No `__declspec(dllexport)` annotations | Fixed: `LOGGER_SYSTEM_API` on all public classes |
| `LOGGER_USE_THREAD_SYSTEM=OFF` forced | Fixed: target-scoped definitions, proper target resolution |
| Unified deps target name patch | Fixed: uses `${thread_system_TARGET}` variable |

## Test Plan

- [x] Local build verification (macOS arm64, CMake, static library): all 29 source files compile successfully
- [ ] CI: Ubuntu GCC build
- [ ] CI: Ubuntu Clang build
- [ ] CI: Windows MSVC build
- [ ] CI: macOS build
- [ ] Verify `find_package(LoggerSystem CONFIG REQUIRED)` + `target_link_libraries(myapp LoggerSystem::logger)` works in consumer project