### PR TITLE
docs: replace GIT_TAG main with tagged versions in FetchContent examples

### DIFF
--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -395,7 +395,7 @@ include(FetchContent)
 FetchContent_Declare(
     logger_system
     GIT_REPOSITORY https://github.com/kcenon/logger_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(logger_system)
 ```

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -35,7 +35,7 @@ include(FetchContent)
 FetchContent_Declare(
     LoggerSystem
     GIT_REPOSITORY https://github.com/kcenon/logger_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 FetchContent_MakeAvailable(LoggerSystem)
 

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -140,13 +140,13 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_Declare(
     logger_system
     GIT_REPOSITORY https://github.com/kcenon/logger_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(common_system logger_system)

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -140,13 +140,13 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.2.0  # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_Declare(
     logger_system
     GIT_REPOSITORY https://github.com/kcenon/logger_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(common_system logger_system)


### PR DESCRIPTION
## Summary

- Pin all FetchContent documentation examples to tagged releases instead of the `main` branch
- Prevents users from copy-pasting non-reproducible build configurations

Part of kcenon/common_system#448

## Changed Files

| File | Change |
|------|--------|
| `docs/guides/QUICK_START.md` | `common_system` GIT_TAG main -> v0.2.0, `logger_system` GIT_TAG main -> v0.1.0 |
| `docs/guides/QUICK_START.kr.md` | `common_system` GIT_TAG main -> v0.2.0, `logger_system` GIT_TAG main -> v0.1.0 |
| `docs/guides/GETTING_STARTED.md` | `LoggerSystem` GIT_TAG main -> v0.1.0 |
| `docs/advanced/MIGRATION.md` | `logger_system` GIT_TAG main -> v0.1.0 |

## Notes

- `cmake/UnifiedDependencies.cmake` is **not** modified here; it has a separate tracking issue (logger_system#490)
- Each pinned version includes the comment: `# Pin to a specific release tag; do NOT use main`

## Test plan

- [ ] Verify documentation renders correctly on GitHub
- [ ] Confirm no remaining `GIT_TAG main` references in documentation files