### PR TITLE
fix(cmake): use configured GIT_TAG in find_package FetchContent fallback

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -553,7 +553,7 @@ macro(_unified_resolve_find_package DEP_NAME VERSION IS_REQUIRED)
     elseif(UNIFIED_ALLOW_FETCHCONTENT_FALLBACK)
         # Fallback to FetchContent
         message(STATUS "[UnifiedDependencies] ${DEP_NAME}: Not found, trying FetchContent fallback...")
-        _unified_resolve_fetchcontent(${DEP_NAME} "main")
+        _unified_resolve_fetchcontent(${DEP_NAME} ${_UFD_GIT_TAG})
     else()
         set(${DEP_NAME}_FOUND FALSE)
     endif()


### PR DESCRIPTION
Closes #490

## Summary

- Replace hardcoded `"main"` in `_unified_resolve_find_package()` FetchContent fallback (line 556) with the configured `_UFD_GIT_TAG` variable
- Aligns the `FIND_PACKAGE` fallback path with the `FETCHCONTENT` resolution mode, which already uses `${_UFD_GIT_TAG}` correctly (line 284)
- Ensures build reproducibility and SOUP version traceability (IEC 62304)

## Changes

| File | Change |
|------|--------|
| `cmake/UnifiedDependencies.cmake:556` | `"main"` → `${_UFD_GIT_TAG}` |

## Test Plan

- [x] CMake configure succeeds without errors
- [x] Full build completes successfully
- [ ] CI pipeline passes