### PR TITLE
chore(deps): add kcenon git registry and align vcpkg baseline

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,6 +2,16 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d"
-  }
+    "baseline": "dd306f32e07d87fdb16837af64f33b6b415c770a"
+  },
+  "registries": [
+    {
+      "kind": "git",
+      "repository": "https://github.com/kcenon/vcpkg-registry.git",
+      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "packages": [
+        "kcenon-*"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## What

Add \`kcenon/vcpkg-registry.git\` registry reference to \`vcpkg-configuration.json\`
and align the builtin registry baseline with the rest of the kcenon ecosystem.

**Before:** no registry entry; \`vcpkg install kcenon-*\` failed without \`--overlay-ports\`
**After:** \`kcenon-*\` packages resolve automatically via the remote registry

## Why

Without the registry reference, resolving \`kcenon-*\` package dependencies
requires manually passing \`--overlay-ports\` to every cmake/vcpkg invocation,
which is error-prone and undocumented.  This change enables standard
\`vcpkg install\` to work without flags.

The builtin baseline is updated from \`c4af3593\` to \`dd306f32\` to align with
\`monitoring_system\` (the canonical vcpkg configuration in the kcenon ecosystem).

Part of kcenon/monitoring_system#531

## Where

- \`vcpkg-configuration.json\`

## How

### Changes
- Added \`registries\` section with \`kcenon/vcpkg-registry.git\` (baseline: \`77cc46d5\`)
- Updated \`default-registry.baseline\` from \`c4af3593\` to \`dd306f32\`

### Test Plan
\`\`\`bash
vcpkg install kcenon-logger-system
# Should resolve without --overlay-ports
\`\`\`