### PR TITLE
chore(cmake): adopt snake_case package name for CMake install/export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,7 +627,7 @@ if(INSTALL_TARGETS)
         )
     else()
         install(TARGETS ${INSTALL_TARGETS}
-            EXPORT LoggerSystemTargets
+            EXPORT logger_system-targets
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -649,22 +649,22 @@ if(INSTALL_TARGETS)
         # already have both logger_system and thread_system available.
         message(STATUS "Logger System: Skipping install(EXPORT) — local thread_system linked (not IMPORTED)")
     else()
-        install(EXPORT LoggerSystemTargets
-            FILE LoggerSystemTargets.cmake
+        install(EXPORT logger_system-targets
+            FILE logger_system-targets.cmake
             NAMESPACE LoggerSystem::
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LoggerSystem
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/logger_system
         )
     endif()
 endif()
 
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LoggerSystemConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/LoggerSystemConfig.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LoggerSystem
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/logger_system-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/logger_system
 )
 
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/LoggerSystemConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config-version.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
 )
@@ -679,7 +679,7 @@ if(BUILD_WITH_COMMON_SYSTEM)
 endif()
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/LoggerSystemConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/LoggerSystemConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/LoggerSystem
+    ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/logger_system
 )

--- a/cmake/logger_system-config.cmake.in
+++ b/cmake/logger_system-config.cmake.in
@@ -31,8 +31,8 @@ if(LoggerSystem_USE_THREAD_SYSTEM)
 endif()
 
 # Include the exported targets (may not exist when local thread_system skipped export)
-if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/LoggerSystemTargets.cmake")
-    include("${CMAKE_CURRENT_LIST_DIR}/LoggerSystemTargets.cmake")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/logger_system-targets.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/logger_system-targets.cmake")
 endif()
 
 # Provide the features that were enabled during build


### PR DESCRIPTION
## What

Rename CMake `install(EXPORT)` and config file naming from `LoggerSystem` (PascalCase) to `logger_system` (snake_case).

After this change, consumers can use `find_package(logger_system CONFIG REQUIRED)` natively without wrapper config files.

## Why

### Related Issues
- Closes #500

### Motivation
The kcenon ecosystem has standardized on snake_case `PACKAGE_NAME` for all vcpkg overlay ports. Previously, the `monitoring_system` overlay required a thin wrapper config to bridge `find_package(logger_system)` to the upstream `LoggerSystemConfig.cmake`. This PR eliminates that wrapper requirement.

## Where

### Files Changed
| File | Change |
|------|--------|
| `cmake/LoggerSystemConfig.cmake.in` → `cmake/logger_system-config.cmake.in` | Renamed and updated targets reference |
| `CMakeLists.txt` | Updated all install/export paths to snake_case |

### CMake Changes
| Before | After |
|--------|-------|
| `EXPORT LoggerSystemTargets` | `EXPORT logger_system-targets` |
| `FILE LoggerSystemTargets.cmake` | `FILE logger_system-targets.cmake` |
| `cmake/LoggerSystem/` | `cmake/logger_system/` |
| `LoggerSystemConfig.cmake` | `logger_system-config.cmake` |
| `LoggerSystemConfigVersion.cmake` | `logger_system-config-version.cmake` |

## How

### Implementation Details
- Target namespace `LoggerSystem::` is **preserved** for backward compatibility
- All install paths use the snake_case `logger_system` directory
- The targets file reference in the config template is updated to match

### Testing Done
- [x] CMake configure succeeds with new file names
- [x] Generated `logger_system-config.cmake` references `logger_system-targets.cmake` correctly
- [x] Generated `logger_system-config-version.cmake` produced correctly

### Breaking Changes
Consumers using `find_package(LoggerSystem)` (PascalCase) will need to update to `find_package(logger_system)`. The installed target names (`LoggerSystem::LoggerSystem`) remain unchanged.