### PR TITLE
fix(vcpkg): sync vcpkg.json version to 0.1.3

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-logger-system",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "port-version": 0,
   "description": "High-performance C++20 async logging library with file rotation and console output",
   "homepage": "https://github.com/kcenon/logger_system",


### PR DESCRIPTION
## Summary
- Sync vcpkg.json version from 0.1.2 to 0.1.3
- Aligns with CMakeLists.txt project version and vcpkg registry baseline

## Test plan
- [ ] Verify vcpkg.json version matches CMakeLists.txt
- [ ] Verify vcpkg.json version matches registry baseline

Closes #505