### PR TITLE
fix(cmake): Enable thread_system integration in vcpkg mode

### DIFF
--- a/cmake/logger_system-config.cmake.in
+++ b/cmake/logger_system-config.cmake.in
@@ -18,19 +18,15 @@ if(LoggerSystem_BUILD_WITH_COMMON_SYSTEM)
 endif()
 
 # thread_system is optional (Issue #222: standalone std::jthread implementation)
+# When built with thread_system support, consumers MUST have it available
+# so that INTERFACE_LINK_LIBRARIES references resolve correctly.
 set(LoggerSystem_USE_THREAD_SYSTEM @LOGGER_USE_THREAD_SYSTEM@)
 if(LoggerSystem_USE_THREAD_SYSTEM)
-    find_dependency(thread_system QUIET)
-    if(NOT thread_system_FOUND)
-        # Fallback: try CamelCase package name
-        find_dependency(ThreadSystem QUIET)
-    endif()
-    if(NOT thread_system_FOUND AND NOT ThreadSystem_FOUND)
-        message(STATUS "LoggerSystem: thread_system not found, using standalone mode")
-    endif()
+    find_dependency(thread_system CONFIG REQUIRED)
 endif()
 
-# Include the exported targets (may not exist when local thread_system skipped export)
+# Include the exported targets — must come after all find_dependency() calls
+# so that IMPORTED target references (e.g., thread_system::ThreadSystem) resolve.
 if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/logger_system-targets.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/logger_system-targets.cmake")
 endif()


### PR DESCRIPTION
## Summary

- Fix `logger_system-config.cmake.in` to use `find_dependency(thread_system CONFIG REQUIRED)` instead of `QUIET`
- Remove obsolete CamelCase fallback (upstream thread_system now uses snake_case natively)
- Ensure targets file is included after all dependency resolution

## Why

The vcpkg portfile currently forces `LOGGER_USE_THREAD_SYSTEM=OFF` because consumers
hit unresolved externals for thread_pool symbols. The root cause: the installed config
used `QUIET` mode which silently skipped loading thread_system targets, leaving
`INTERFACE_LINK_LIBRARIES` references unresolved.

With `CONFIG REQUIRED`, the config file will:
1. Fail fast with a diagnostic message if thread_system is missing
2. Properly load thread_system IMPORTED targets before including logger_system targets
3. Enable the vcpkg portfile to build with thread_system support

## Test plan

- [ ] `cmake --build` succeeds with `LOGGER_USE_THREAD_SYSTEM=ON`
- [ ] `cmake --build` succeeds with `LOGGER_USE_THREAD_SYSTEM=OFF` (standalone mode)
- [ ] Consumer project: `find_package(logger_system)` resolves all targets
- [ ] CI passes on all platforms (Ubuntu, macOS, Windows)

Relates to #507