### PR TITLE
chore(cmake): Standardize namespace to snake_case (LoggerSystem:: → logger_system::)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -651,7 +651,7 @@ if(INSTALL_TARGETS)
     else()
         install(EXPORT logger_system-targets
             FILE logger_system-targets.cmake
-            NAMESPACE LoggerSystem::
+            NAMESPACE logger_system::
             DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/logger_system
         )
     endif()

--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -61,6 +61,8 @@ set(_UNIFIED_TARGET_MAP_thread_system
 
 set(_UNIFIED_TARGET_MAP_logger_system
     "logger"
+    "logger_system::LoggerSystem"
+    "LoggerSystem::LoggerSystem"
     "LoggerSystem::logger"
     "LoggerSystem"
     "logger_system"
@@ -128,7 +130,7 @@ set(_UNIFIED_FETCH_NAME_network_system "NetworkSystem")
 # find_package names
 set(_UNIFIED_PACKAGE_NAME_common_system "common_system")
 set(_UNIFIED_PACKAGE_NAME_thread_system "thread_system")
-set(_UNIFIED_PACKAGE_NAME_logger_system "LoggerSystem")
+set(_UNIFIED_PACKAGE_NAME_logger_system "logger_system")
 set(_UNIFIED_PACKAGE_NAME_monitoring_system "MonitoringSystem")
 set(_UNIFIED_PACKAGE_NAME_container_system "ContainerSystem")
 set(_UNIFIED_PACKAGE_NAME_database_system "DatabaseSystem")

--- a/cmake/logger_system-config.cmake.in
+++ b/cmake/logger_system-config.cmake.in
@@ -31,6 +31,26 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/logger_system-targets.cmake")
     include("${CMAKE_CURRENT_LIST_DIR}/logger_system-targets.cmake")
 endif()
 
+# Backward compatibility aliases for LoggerSystem:: namespace consumers
+# The canonical namespace is now logger_system::, but existing consumers
+# may still use LoggerSystem::LoggerSystem or LoggerSystem::logger.
+if(TARGET logger_system::LoggerSystem AND NOT TARGET LoggerSystem::LoggerSystem)
+    add_library(LoggerSystem::LoggerSystem INTERFACE IMPORTED)
+    set_target_properties(LoggerSystem::LoggerSystem PROPERTIES
+        INTERFACE_LINK_LIBRARIES logger_system::LoggerSystem
+    )
+endif()
+
+# Set variables for compatibility
+set(logger_system_FOUND TRUE)
+set(logger_system_LIBRARIES logger_system::LoggerSystem)
+
+# Legacy variables for backward compatibility
+set(LoggerSystem_FOUND TRUE)
+set(LOGGERSYSTEM_FOUND TRUE)
+set(LoggerSystem_LIBRARIES ${logger_system_LIBRARIES})
+set(LOGGERSYSTEM_LIBRARIES ${logger_system_LIBRARIES})
+
 # Provide the features that were enabled during build
 set(LoggerSystem_USE_DI @LOGGER_USE_DI@)
 set(LoggerSystem_USE_MONITORING @LOGGER_USE_MONITORING@)


### PR DESCRIPTION
## What

Standardize the CMake export namespace from `LoggerSystem::` to `logger_system::`, aligning with the ecosystem convention of `<package_name>::` snake_case namespaces.

## Why

- Closes #511
- Part of kcenon/common_system#456
- Ecosystem consistency: `common_system::`, `thread_system::`, `network_system::` all use snake_case namespaces. `LoggerSystem::` was the outlier.
- Follows the precedent set by `network_system` namespace migration.

## Where

| File | Change |
|------|--------|
| `CMakeLists.txt` | `NAMESPACE LoggerSystem::` → `logger_system::` in `install(EXPORT)` |
| `cmake/logger_system-config.cmake.in` | Add backward compatibility IMPORTED target alias (`LoggerSystem::LoggerSystem` → `logger_system::LoggerSystem`) and legacy `_FOUND` / `_LIBRARIES` variables |
| `cmake/UnifiedDependencies.cmake` | Add `logger_system::LoggerSystem` to target map; fix `_UNIFIED_PACKAGE_NAME` to `logger_system` |

## How

### Namespace change
- Primary exported namespace changed from `LoggerSystem::` to `logger_system::` in `install(EXPORT)`.
- Exported target: `logger_system::LoggerSystem` (was `LoggerSystem::LoggerSystem`).

### Backward compatibility
- **Target alias**: `LoggerSystem::LoggerSystem` is created as an `INTERFACE IMPORTED` target forwarding to `logger_system::LoggerSystem`, so existing `target_link_libraries(... LoggerSystem::LoggerSystem)` calls continue to work.
- **Variables**: `LoggerSystem_FOUND`, `LOGGERSYSTEM_FOUND`, `LoggerSystem_LIBRARIES`, `LOGGERSYSTEM_LIBRARIES` are all set for consumers checking these.
- **UnifiedDependencies**: Target map updated to search `logger_system::LoggerSystem` first, then fall back to legacy names. Package name corrected from `LoggerSystem` to `logger_system`.

### Migration for consumers
- No immediate changes required; `LoggerSystem::LoggerSystem` still resolves.
- New code should use `logger_system::LoggerSystem`.

## Test plan
- [ ] CI builds pass (the namespace change only affects `install(EXPORT)`, not the build itself)
- [ ] Verify `find_package(logger_system)` provides both `logger_system::LoggerSystem` and `LoggerSystem::LoggerSystem` targets