### PR TITLE
docs(doxyfile): Add ecosystem-standard ALIASES

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -55,6 +55,8 @@ EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = sources
 PREDEFINED             = USE_THREAD_SYSTEM
+ALIASES                = "thread_safety=@par Thread Safety:^^" \
+                         "performance=@par Performance:^^"
 
 # Warning settings
 WARNINGS               = YES


### PR DESCRIPTION
## What

### Summary
Add `@thread_safety` and `@performance` custom ALIASES to Doxyfile, aligning with the ecosystem standard established by monitoring_system.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#472

### Motivation
Custom ALIASES enable consistent cross-referencing of thread safety guarantees and performance characteristics in API documentation across all 8 ecosystem libraries.

## How

### Implementation Details
Added two ALIASES entries matching monitoring_system's existing configuration.

### Test Plan
- [ ] Doxygen build succeeds (`build-Doxygen.yaml` workflow)