### PR TITLE
refactor(deps): update common_system dependency to latest version

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Checkout thread_system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
         token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -337,6 +338,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
         token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -429,6 +431,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Install dependencies (Ubuntu)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Configure CMake with coverage

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Checkout thread_system (required dependency)
@@ -137,6 +138,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Checkout thread_system (required dependency)
@@ -211,6 +213,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Checkout thread_system (required dependency)
@@ -299,6 +302,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Checkout thread_system (required dependency)
@@ -471,6 +475,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Checkout thread_system (required dependency)

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -32,6 +32,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Install dependencies
@@ -114,6 +115,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/common_system
+        ref: main
         path: common_system
 
     - name: Install cppcheck

--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -110,7 +110,7 @@ set(_UNIFIED_REPO_network_system "network_system")
 
 # Default GIT_TAG per dependency (used when no explicit GIT_TAG is passed)
 # Keep in sync with ecosystem release versions
-set(_UNIFIED_DEFAULT_TAG_common_system "v0.2.0")
+set(_UNIFIED_DEFAULT_TAG_common_system "e5adfa990418c917a846986bbd19d7b4d12ee515")
 set(_UNIFIED_DEFAULT_TAG_thread_system "v0.3.1")
 set(_UNIFIED_DEFAULT_TAG_logger_system "v0.1.3")
 set(_UNIFIED_DEFAULT_TAG_monitoring_system "v0.1.0")


### PR DESCRIPTION
## What

### Summary
Updates common_system dependency management to use the latest version (commit e5adfa9) which includes the ObjectPool zero-overhead deleter fix from Phase 1. Pins all CI workflow common_system checkouts with explicit `ref: main`.

### Change Type
- [x] Refactor (no functional changes)
- [x] Chore

### Affected Components
- `cmake/UnifiedDependencies.cmake` — FetchContent default tag updated
- `.github/workflows/*.yml` — 13 common_system checkout steps pinned with `ref: main`

## Why

### Problem Solved
The common_system FetchContent default tag was pinned to `v0.2.0`, which does not include the ObjectPool zero-overhead deleter fix (kcenon/common_system#488). CI workflows checked out common_system without an explicit `ref`, relying on implicit default behavior.

### Related Issues
- Relates to #527 (replace vendored common_system copy with proper CMake dependency)

### Context
Investigation revealed that `common_system/` in logger_system is NOT a vendored copy committed to git — it's a locally-cloned nested git repository (gitignored on line 82 of `.gitignore`). The `UnifiedDependencies.cmake` module already provides proper CMake dependency resolution via:
1. **LOCAL mode**: workspace-relative `common_system/` directory (used by CI and local dev)
2. **FetchContent fallback**: fetches from GitHub when local directory is absent

The ODR risk from #527 is primarily about **version divergence** between locally-cloned copies, not literal code duplication. This PR addresses that by updating the FetchContent tag to the latest version.

### container_system Note
`container_system` uses the same pattern: a locally-cloned `common_system/` (nested git repo, not a submodule) pinned at an even older commit (`89ca18e` — feat(interfaces): implement health monitoring API #274). It should receive the same update.

## How

### Implementation Details
1. **`cmake/UnifiedDependencies.cmake`**: Changed `_UNIFIED_DEFAULT_TAG_common_system` from `v0.2.0` to commit hash `e5adfa990418c917a846986bbd19d7b4d12ee515` (latest main, includes ObjectPool fix)
2. **CI workflows**: Added explicit `ref: main` to all 13 `actions/checkout` steps for common_system across 6 workflow files

### Testing Done
- [x] CMake configure succeeds
- [x] Full build succeeds (100% targets)
- [x] 33/34 tests pass (1 pre-existing failure in `logger_encrypted_writer_test` — OpenSSL-related, unrelated to this change)

### Breaking Changes
None — the dependency resolution mechanism is unchanged; only the pinned version is updated.