### PR TITLE
chore(deps): update grpc, protobuf, openssl, and other dependencies

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "dd306f32e07d87fdb16837af64f33b6b415c770a"
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
   },
   "registries": [
     {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,13 +11,13 @@
     "kcenon-common-system"
   ],
   "overrides": [
-    { "name": "openssl", "version": "3.3.0" },
-    { "name": "spdlog", "version": "1.13.0" },
-    { "name": "opentelemetry-cpp", "version": "1.14.2" },
-    { "name": "protobuf", "version": "3.21.12" },
-    { "name": "grpc", "version": "1.51.1" },
-    { "name": "gtest", "version": "1.14.0" },
-    { "name": "benchmark", "version": "1.8.3" }
+    { "name": "openssl", "version": "3.4.1" },
+    { "name": "spdlog", "version": "1.15.3" },
+    { "name": "opentelemetry-cpp", "version": "1.18.0" },
+    { "name": "protobuf", "version": "4.25.1" },
+    { "name": "grpc", "version": "1.60.0" },
+    { "name": "gtest", "version": "1.17.0" },
+    { "name": "benchmark", "version": "1.9.5" }
   ],
   "features": {
     "encryption": {


### PR DESCRIPTION
## Summary
- Update dependency overrides for ecosystem consistency (part of kcenon/common_system#486)
- grpc: 1.51.1 -> 1.60.0
- protobuf: 3.21.12 -> 4.25.1
- openssl: 3.3.0 -> 3.4.1
- opentelemetry-cpp: 1.14.2 -> 1.18.0
- spdlog: 1.13.0 -> 1.15.3
- gtest: 1.14.0 -> 1.17.0
- benchmark: 1.8.3 -> 1.9.5
- vcpkg builtin-baseline updated to latest

## Why
- grpc 1.51.1 is from 2022, missing security fixes and performance improvements
- protobuf 4.25.1 maintains v3 API compatibility while getting latest bug fixes
- openssl 3.4.1 includes security patches over 3.3.0

## Test plan
- [ ] CI builds pass on all platforms
- [ ] OTLP integration with grpc feature works
- [ ] Existing tests pass