### PR TITLE
chore: add local vcpkg portfile for registry synchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ CTestTestfile.cmake
 _deps/
 *.cmake
 !cmake/*.cmake
+!vcpkg-ports/**/*.cmake
 
 # Testing
 Testing/

--- a/vcpkg-ports/kcenon-logger-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-logger-system/portfile.cmake
@@ -1,0 +1,45 @@
+# kcenon-logger-system portfile
+# High-performance C++20 async logging library with 4.34M msg/sec throughput
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/logger_system
+    REF "v${VERSION}"
+    SHA512 90884ec4210e6ebeb534aed2eb9928cfc2a80d0ab7220f9ed9be63d32bcfc6154e6bd2960c7d11cb196c3dcb345650c6e182f8edc44867b4bcf0efeb1dfed0f2
+    HEAD_REF main
+)
+
+# Feature-based options
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        encryption LOGGER_USE_ENCRYPTION
+        otlp       LOGGER_ENABLE_OTLP
+)
+
+# Disable thread_system integration: upstream CMake does not link thread_system
+# library properly in vcpkg mode (unresolved externals for thread_pool symbols).
+# The logger falls back to its standalone executor which works correctly.
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DBUILD_BENCHMARKS=OFF
+        -DBUILD_SAMPLES=OFF
+        -DLOGGER_BUILD_INTEGRATION_TESTS=OFF
+        -DLOGGER_ENABLE_COVERAGE=OFF
+        -DLOGGER_USE_THREAD_SYSTEM=OFF
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME logger_system
+    CONFIG_PATH lib/cmake/logger_system
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -1,0 +1,52 @@
+{
+  "name": "kcenon-logger-system",
+  "version": "0.1.3",
+  "port-version": 3,
+  "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
+  "homepage": "https://github.com/kcenon/logger_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "encryption": {
+      "description": "Enable encrypted log writer with AES-256-GCM",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.3.0"
+        }
+      ]
+    },
+    "otlp": {
+      "description": "Enable OpenTelemetry (OTLP) integration",
+      "dependencies": [
+        {
+          "name": "opentelemetry-cpp",
+          "default-features": false,
+          "features": [
+            "otlp-http",
+            "otlp-grpc"
+          ]
+        },
+        {
+          "name": "protobuf",
+          "version>=": "3.21.12"
+        },
+        {
+          "name": "grpc",
+          "version>=": "1.51.1"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `vcpkg-ports/kcenon-logger-system/` with `portfile.cmake` and `vcpkg.json` mirroring the canonical vcpkg-registry
- Update `.gitignore` to allow cmake files in `vcpkg-ports/`

## Rationale

Standardize portfile management (Strategy B: local + registry sync) across the ecosystem, following the pattern already established by `monitoring_system`. Local portfiles enable atomic source+port changes and CI validation.

## Test plan

- [ ] Verify portfile matches the canonical registry version
- [ ] Verify `.gitignore` correctly allows `vcpkg-ports/**/*.cmake`
- [ ] CI builds pass without regression

Ref: kcenon/vcpkg-registry#36