### PR TITLE
chore(ci): adopt setup-vcpkg composite action for vcpkg setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,72 +93,30 @@ jobs:
           echo "VCPKG_FORCE_SYSTEM_BINARIES=arm" >> $GITHUB_ENV
         fi
 
-    - name: Cache vcpkg
-      uses: actions/cache@v5
-      id: vcpkg-cache
+    - name: Setup vcpkg
+      uses: kcenon/common_system/.github/actions/setup-vcpkg@main
       with:
-        path: |
-          ${{ github.workspace }}/vcpkg
-          !${{ github.workspace }}/vcpkg/buildtrees
-          !${{ github.workspace }}/vcpkg/packages
-          !${{ github.workspace }}/vcpkg/downloads
-        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-${{ hashFiles('vcpkg.json') }}
-
-    - name: Set up vcpkg (Unix)
-      if: runner.os != 'Windows'
-      run: |
-        if [ ! -d "vcpkg" ]; then
-          git clone https://github.com/Microsoft/vcpkg.git
-        fi
-        cd vcpkg
-        git pull
-        ./bootstrap-vcpkg.sh
-        cd ..
-
-    - name: Set up vcpkg (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        if (!(Test-Path "vcpkg")) {
-          git clone https://github.com/Microsoft/vcpkg.git
-        }
-        cd vcpkg
-        git pull
-        .\bootstrap-vcpkg.bat
-        cd ..
-
-    - name: Determine vcpkg commit (Unix)
-      if: runner.os != 'Windows'
-      id: vcpkg-commit-unix
-      run: echo "commit=$(git -C vcpkg rev-parse HEAD)" >> $GITHUB_OUTPUT
-
-    - name: Determine vcpkg commit (Windows)
-      if: runner.os == 'Windows'
-      id: vcpkg-commit-windows
-      shell: pwsh
-      run: |
-        $commit = git -C vcpkg rev-parse HEAD
-        "commit=$commit" >> $env:GITHUB_OUTPUT
+        extra-cache-key: 'logger-system'
 
     - name: Cache vcpkg installed
       uses: actions/cache@v5
       id: vcpkg-installed
       with:
         path: ${{ github.workspace }}/vcpkg_installed
-        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}-${{ steps.vcpkg-commit-unix.outputs.commit || steps.vcpkg-commit-windows.outputs.commit }}
+        key: ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.compiler }}-vcpkg-installed-${{ matrix.triplet }}-
 
     - name: Install dependencies with vcpkg (Unix)
       if: runner.os != 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
       run: |
-        ./vcpkg/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
+        ${{ env.VCPKG_ROOT }}/vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}/vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Install dependencies with vcpkg (Windows)
       if: runner.os == 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
       shell: pwsh
       run: |
-        .\vcpkg\vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}\vcpkg_installed --triplet ${{ matrix.triplet }}
+        ${{ env.VCPKG_ROOT }}\vcpkg install --x-manifest-root=. --x-install-root=${{ github.workspace }}\vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Prepare build directory
       if: runner.os != 'Windows'
@@ -202,7 +160,7 @@ jobs:
           -DLOGGER_USE_THREAD_SYSTEM=ON \
           -DLOGGER_BUILD_INTEGRATION_TESTS=OFF \
           -DUNIFIED_USE_LOCAL=ON \
-          -DCMAKE_TOOLCHAIN_FILE="${GITHUB_WORKSPACE}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.CMAKE_TOOLCHAIN_FILE }}" \
           -DCMAKE_C_COMPILER=$C_COMPILER \
           -DCMAKE_CXX_COMPILER=$CXX_COMPILER
 
@@ -228,7 +186,7 @@ jobs:
           -DLOGGER_USE_THREAD_SYSTEM=ON `
           -DLOGGER_BUILD_INTEGRATION_TESTS=OFF `
           -DUNIFIED_USE_LOCAL=ON `
-          -DCMAKE_TOOLCHAIN_FILE="$env:GITHUB_WORKSPACE\vcpkg\scripts\buildsystems\vcpkg.cmake" `
+          -DCMAKE_TOOLCHAIN_FILE="${{ env.CMAKE_TOOLCHAIN_FILE }}" `
           -DCMAKE_CXX_FLAGS="/std:c++20 /permissive- /Zc:__cplusplus /EHsc" `
           -DCMAKE_TRY_COMPILE_TARGET_TYPE="STATIC_LIBRARY"
 


### PR DESCRIPTION
## What
Replace inline vcpkg setup logic in CI workflow with the ecosystem's reusable composite action from `kcenon/common_system/.github/actions/setup-vcpkg@main`.

## Why
- Eliminates ~50 lines of duplicated vcpkg setup code
- Pins vcpkg to ecosystem baseline commit (prevents HEAD drift)
- Standardizes cache key strategy across ecosystem
- Pilot for ecosystem-wide CI migration (kcenon/common_system#512)

## Where
- `.github/workflows/ci.yml` — vcpkg setup steps replaced

## How
Replaced manual vcpkg clone, bootstrap, and cache configuration with a single composite action call. The action handles pinned checkout, cross-platform bootstrap, environment variable setup, and intelligent caching.

Additional changes:
- Updated `vcpkg install` steps to use `VCPKG_ROOT` env var from the action
- Updated cmake `-DCMAKE_TOOLCHAIN_FILE` to use `CMAKE_TOOLCHAIN_FILE` env var from the action
- Simplified vcpkg_installed cache key (vcpkg commit is now pinned by the action)

Relates to kcenon/common_system#512