### PR TITLE
chore(deps): update embedded common_system to ecosystem baseline

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -110,7 +110,7 @@ set(_UNIFIED_REPO_network_system "network_system")
 
 # Default GIT_TAG per dependency (used when no explicit GIT_TAG is passed)
 # Keep in sync with ecosystem release versions
-set(_UNIFIED_DEFAULT_TAG_common_system "93b1d0f64c6fb69529f0ff84bed2601de07ebba5")
+set(_UNIFIED_DEFAULT_TAG_common_system "78080b2d85bf73472abf971946bf1537d3f128f2")
 set(_UNIFIED_DEFAULT_TAG_thread_system "v0.3.1")
 set(_UNIFIED_DEFAULT_TAG_logger_system "v0.1.3")
 set(_UNIFIED_DEFAULT_TAG_monitoring_system "v0.1.0")


### PR DESCRIPTION
## What

Update the pinned `common_system` FetchContent commit hash in `UnifiedDependencies.cmake` to the latest `main` branch commit (`78080b2`), which includes the ecosystem-standard vcpkg baseline and dependency overrides.

### Change Type
- [x] Chore (dependency update)

### Affected Components
- `cmake/UnifiedDependencies.cmake` — FetchContent default tag for common_system

## Why

### Problem Solved
The FetchContent fallback tag for `common_system` was pinned to an older commit (`93b1d0f`) that uses the outdated vcpkg builtin baseline (`c4af3593`). This diverges from the ecosystem standard baseline (`d90a9b15`) established in Phase 1.

| Item | Before | After |
|------|--------|-------|
| common_system commit | `93b1d0f` | `78080b2` |
| vcpkg builtin baseline | `c4af3593` (old) | `d90a9b15` (ecosystem standard) |
| gtest override | none | 1.17.0 |
| benchmark override | none | 1.9.5 |

### Related Issues
- Closes #544
- Part of kcenon/common_system#515

## Where

| File | Change |
|------|--------|
| `cmake/UnifiedDependencies.cmake` | Updated `_UNIFIED_DEFAULT_TAG_common_system` hash |

## How

### Implementation Details
Updated the `_UNIFIED_DEFAULT_TAG_common_system` variable from `93b1d0f64c6fb69529f0ff84bed2601de07ebba5` to `78080b2d85bf73472abf971946bf1537d3f128f2`.

Note: The CI workflow already checks out `common_system` at `ref: main`, so normal CI builds already use the latest version. This change ensures the FetchContent fallback path (used when local checkout is missing and find_package fails) also resolves the correct version.

### Testing
- CI will validate that the build succeeds with the updated common_system on all platforms (Ubuntu, macOS, Windows)