### PR TITLE
fix(vcpkg): enable thread_system linking in vcpkg port build

### DIFF
--- a/vcpkg-ports/kcenon-logger-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-logger-system/portfile.cmake
@@ -12,13 +12,11 @@ vcpkg_from_github(
 # Feature-based options
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        encryption LOGGER_USE_ENCRYPTION
-        otlp       LOGGER_ENABLE_OTLP
+        encryption    LOGGER_USE_ENCRYPTION
+        otlp          LOGGER_ENABLE_OTLP
+        thread-system LOGGER_USE_THREAD_SYSTEM
 )
 
-# Disable thread_system integration: upstream CMake does not link thread_system
-# library properly in vcpkg mode (unresolved externals for thread_pool symbols).
-# The logger falls back to its standalone executor which works correctly.
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
@@ -27,7 +25,6 @@ vcpkg_cmake_configure(
         -DBUILD_SAMPLES=OFF
         -DLOGGER_BUILD_INTEGRATION_TESTS=OFF
         -DLOGGER_ENABLE_COVERAGE=OFF
-        -DLOGGER_USE_THREAD_SYSTEM=OFF
         -DFETCHCONTENT_FULLY_DISCONNECTED=ON
         ${FEATURE_OPTIONS}
 )

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-logger-system",
   "version": "0.1.3",
-  "port-version": 3,
+  "port-version": 4,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",
@@ -46,6 +46,12 @@
           "name": "grpc",
           "version>=": "1.51.1"
         }
+      ]
+    },
+    "thread-system": {
+      "description": "Enable thread_system integration for async executor",
+      "dependencies": [
+        "kcenon-thread-system"
       ]
     }
   }


### PR DESCRIPTION
## What

Enable `thread_system` integration as an opt-in feature in the vcpkg port, replacing the hardcoded `-DLOGGER_USE_THREAD_SYSTEM=OFF` workaround.

### Change Type
- [x] Bugfix (restores disabled functionality)

### Affected Components
- `vcpkg-ports/kcenon-logger-system/vcpkg.json` — new `thread-system` feature
- `vcpkg-ports/kcenon-logger-system/portfile.cmake` — feature mapping via `vcpkg_check_features`

## Why

### Problem Solved
The vcpkg port previously hardcoded `-DLOGGER_USE_THREAD_SYSTEM=OFF` due to unresolved external symbols during vcpkg builds. This meant vcpkg consumers could not use the async executor powered by thread_system, falling back to a basic single-threaded executor.

The root cause was that `kcenon-thread-system` was not listed as a dependency, so `find_package(thread_system)` failed in the `FETCHCONTENT_FULLY_DISCONNECTED=ON` build. With the feature properly declared, vcpkg installs `kcenon-thread-system` first, making the CMake find path work correctly.

### Related Issues
- Closes #545
- Part of kcenon/common_system#515

## Where

| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-logger-system/vcpkg.json` | Added `thread-system` feature with `kcenon-thread-system` dependency; bumped port-version 3 -> 4 |
| `vcpkg-ports/kcenon-logger-system/portfile.cmake` | Added `thread-system` to `vcpkg_check_features`; removed hardcoded `-DLOGGER_USE_THREAD_SYSTEM=OFF` |

## How

### Implementation Details

1. **Port manifest** (`vcpkg.json`): Added `thread-system` feature that pulls in `kcenon-thread-system` as a dependency
2. **Portfile** (`portfile.cmake`): Mapped `thread-system` feature to `LOGGER_USE_THREAD_SYSTEM` CMake option via `vcpkg_check_features`
3. **Removed workaround**: Deleted the hardcoded `-DLOGGER_USE_THREAD_SYSTEM=OFF` and its explanatory comment

### How It Works
- `vcpkg install kcenon-logger-system[thread-system]` installs `kcenon-thread-system` first, then configures logger_system with `-DLOGGER_USE_THREAD_SYSTEM=ON`
- `vcpkg install kcenon-logger-system` (default) configures with `-DLOGGER_USE_THREAD_SYSTEM=OFF` (standalone mode)
- In both cases, `FETCHCONTENT_FULLY_DISCONNECTED=ON` is set, so all dependencies must come from vcpkg

### Testing
- CI will validate that the default port build (without thread-system feature) still works
- Full validation of the thread-system feature requires the validate-vcpkg-port workflow with feature flags