### PR TITLE
feat(cmake): add vcpkg CMake preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -89,6 +89,23 @@
                 "BUILD_SAMPLES": "OFF",
                 "LOGGER_BUILD_INTEGRATION_TESTS": "ON"
             }
+        },
+        {
+            "name": "vcpkg",
+            "displayName": "vcpkg Release",
+            "description": "Release build using vcpkg for dependency management",
+            "binaryDir": "${sourceDir}/build/vcpkg",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": {
+                    "type": "FILEPATH",
+                    "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                },
+                "CMAKE_BUILD_TYPE": "Release",
+                "BUILD_TESTS": "OFF",
+                "BUILD_BENCHMARKS": "OFF",
+                "BUILD_SAMPLES": "OFF",
+                "FETCHCONTENT_FULLY_DISCONNECTED": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -119,6 +136,10 @@
         {
             "name": "ci",
             "configurePreset": "ci"
+        },
+        {
+            "name": "vcpkg",
+            "configurePreset": "vcpkg"
         }
     ],
     "testPresets": [


### PR DESCRIPTION
## Summary
- Add dedicated `vcpkg` configure preset and build preset to CMakePresets.json
- Follows the pattern established in database_system and pacs_system

## Test plan
- [ ] `cmake --preset vcpkg` configures successfully with VCPKG_ROOT set
- [ ] `cmake --build --preset vcpkg` builds successfully
- [ ] JSON validates without errors

Closes #560