### PR TITLE
fix(vcpkg): sync local portfile CONFIG_PATH with v0.1.3 release tag

### DIFF
--- a/vcpkg-ports/kcenon-logger-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-logger-system/portfile.cmake
@@ -32,8 +32,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME logger_system
-    CONFIG_PATH lib/cmake/logger_system
+    PACKAGE_NAME LoggerSystem
+    CONFIG_PATH lib/cmake/LoggerSystem
 )
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")

--- a/vcpkg-ports/kcenon-logger-system/usage
+++ b/vcpkg-ports/kcenon-logger-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-logger-system provides CMake targets:
+
+    find_package(logger_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE logger_system::LoggerSystem)
+
+Available features: encryption, otlp

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-logger-system",
   "version-semver": "0.1.3",
-  "port-version": 0,
+  "port-version": 4,
   "description": "High-performance C++20 async logging library with file rotation and console output",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Fix `vcpkg_cmake_config_fixup` PACKAGE_NAME and CONFIG_PATH to match v0.1.3 release tag (PascalCase)
- Sync root `vcpkg.json` port-version from 0 to 4
- Add missing `usage` file to local port directory

## Related
- Closes #562
- Related: kcenon/vcpkg-registry#48

## Test plan
- [ ] Verify portfile PACKAGE_NAME matches release tag install path
- [ ] Verify root vcpkg.json port-version matches port definition