### PR TITLE
test(coverage): improve test coverage from 65% to 80%+

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,18 +11,18 @@ coverage:
   status:
     project:
       default:
-        target: 55%  # Phase 1: Establish baseline
+        target: 65%  # Phase 2: Improved baseline with expanded test suite
         threshold: 2%
         if_ci_failed: error
     patch:
       default:
-        target: 60%
+        target: 70%
         threshold: 5%
         if_ci_failed: error
 
 # Gradual improvement plan:
-# - Phase 1 (Current): 55% project, 60% patch
-# - Phase 2: 65% project, 70% patch
+# - Phase 1: 55% project, 60% patch
+# - Phase 2 (Current): 65% project, 70% patch
 # - Phase 3: 75% project, 80% patch
 
 parsers:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -936,6 +936,230 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/di_test/di_container_test.cpp")
     message(STATUS "DI container integration tests: Added")
 endif()
 
+# Path validator tests (Issue #566 - security path validation coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/security_test/path_validator_test.cpp")
+    add_executable(logger_path_validator_test
+        unit/security_test/path_validator_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_path_validator_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_path_validator_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_path_validator_test
+        COMMAND logger_path_validator_test
+    )
+    set_target_properties(logger_path_validator_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Path validator tests: Added")
+endif()
+
+# Error codes tests (Issue #566 - error code helpers coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/core_test/error_codes_test.cpp")
+    add_executable(logger_error_codes_test
+        unit/core_test/error_codes_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_error_codes_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_error_codes_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_error_codes_test
+        COMMAND logger_error_codes_test
+    )
+    set_target_properties(logger_error_codes_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Error codes tests: Added")
+endif()
+
+# Writer category tests (Issue #566 - writer category type traits coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/writers_test/writer_category_test.cpp")
+    add_executable(logger_writer_category_test
+        unit/writers_test/writer_category_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_writer_category_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_writer_category_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_writer_category_test
+        COMMAND logger_writer_category_test
+    )
+    set_target_properties(logger_writer_category_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Writer category tests: Added")
+endif()
+
+# String utils tests (Issue #566 - utility function coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/utils_test/string_utils_test.cpp")
+    add_executable(logger_string_utils_test
+        unit/utils_test/string_utils_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_string_utils_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_string_utils_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_string_utils_test
+        COMMAND logger_string_utils_test
+    )
+    set_target_properties(logger_string_utils_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "String utils tests: Added")
+endif()
+
+# Time utils tests (Issue #566 - utility function coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/utils_test/time_utils_test.cpp")
+    add_executable(logger_time_utils_test
+        unit/utils_test/time_utils_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_time_utils_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_time_utils_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_time_utils_test
+        COMMAND logger_time_utils_test
+    )
+    set_target_properties(logger_time_utils_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Time utils tests: Added")
+endif()
+
+# File utils tests (Issue #566 - utility function coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/utils_test/file_utils_test.cpp")
+    add_executable(logger_file_utils_test
+        unit/utils_test/file_utils_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_file_utils_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_file_utils_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_file_utils_test
+        COMMAND logger_file_utils_test
+    )
+    set_target_properties(logger_file_utils_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "File utils tests: Added")
+endif()
+
+# Formatter tests (Issue #566 - formatter coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/formatters_test/formatters_test.cpp")
+    add_executable(logger_formatters_test
+        unit/formatters_test/formatters_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_formatters_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_formatters_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_formatters_test
+        COMMAND logger_formatters_test
+    )
+    set_target_properties(logger_formatters_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Formatter tests: Added")
+endif()
+
+# Filter tests (Issue #566 - filter chain coverage)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/unit/filters_test/filters_test.cpp")
+    add_executable(logger_filters_test
+        unit/filters_test/filters_test.cpp
+    )
+
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(logger_filters_test
+            PRIVATE LoggerSystem GTest::gtest_main
+        )
+    else()
+        target_link_libraries(logger_filters_test
+            PRIVATE LoggerSystem gtest_main
+        )
+    endif()
+
+    add_test(NAME logger_filters_test
+        COMMAND logger_filters_test
+    )
+    set_target_properties(logger_filters_test PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+
+    message(STATUS "Filter tests: Added")
+endif()
+
+# Coverage registration for Issue #566 test targets
+foreach(_test_target IN ITEMS
+    logger_path_validator_test
+    logger_error_codes_test
+    logger_writer_category_test
+    logger_string_utils_test
+    logger_time_utils_test
+    logger_file_utils_test
+    logger_formatters_test
+    logger_filters_test
+)
+    if(TARGET ${_test_target} AND COMMAND logger_register_coverage_target)
+        logger_register_coverage_target(${_test_target})
+    endif()
+endforeach()
+
 # Cleanup
 unset(_LOGGER_TEST_TARGETS)
 unset(_test_target)

--- a/tests/unit/core_test/error_codes_test.cpp
+++ b/tests/unit/core_test/error_codes_test.cpp
@@ -1,0 +1,242 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file error_codes_test.cpp
+ * @brief Unit tests for logger error codes and helper functions
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/core/error_codes.h>
+
+#include <string>
+
+using namespace kcenon::logger;
+namespace common = kcenon::common;
+
+// =============================================================================
+// logger_error_to_string
+// =============================================================================
+
+TEST(ErrorCodesTest, SuccessToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::success), "Success");
+}
+
+TEST(ErrorCodesTest, GeneralErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::unknown_error), "Unknown error");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::not_implemented), "Not implemented");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::invalid_argument), "Invalid argument");
+}
+
+TEST(ErrorCodesTest, WriterErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_not_found), "Writer not found");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_initialization_failed), "Writer initialization failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_already_exists), "Writer already exists");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_not_healthy), "Writer not healthy");
+}
+
+TEST(ErrorCodesTest, FileErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::file_open_failed), "Failed to open file");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::file_write_failed), "Failed to write to file");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::file_rotation_failed), "File rotation failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::file_permission_denied), "File permission denied");
+}
+
+TEST(ErrorCodesTest, NetworkErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::network_connection_failed), "Network connection failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::network_send_failed), "Network send failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::network_timeout), "Network timeout");
+}
+
+TEST(ErrorCodesTest, BufferErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::buffer_overflow), "Buffer overflow");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::queue_full), "Queue is full");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::queue_stopped), "Queue is stopped");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::queue_overflow_dropped), "Queue overflow: messages dropped");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::queue_overflow_blocked), "Queue overflow: operation blocked");
+}
+
+TEST(ErrorCodesTest, ConfigurationErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::invalid_configuration), "Invalid configuration");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::configuration_missing), "Configuration missing");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::configuration_conflict), "Configuration conflict");
+}
+
+TEST(ErrorCodesTest, MetricsErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::metrics_collection_failed), "Metrics collection failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::metrics_not_available), "Metrics not available");
+}
+
+TEST(ErrorCodesTest, ProcessingErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::flush_timeout), "Flush timeout");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::processing_failed), "Processing failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::filter_error), "Filter error");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::formatter_error), "Formatter error");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::batch_processing_timeout), "Batch processing timeout");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::batch_processing_failed), "Batch processing failed");
+}
+
+TEST(ErrorCodesTest, SecurityErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::encryption_failed), "Encryption failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::decryption_failed), "Decryption failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::authentication_failed), "Authentication failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::sanitization_failed), "Sanitization failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::path_traversal_detected), "Path traversal attack detected");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::invalid_key_size), "Invalid encryption key size");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::invalid_filename), "Invalid filename");
+}
+
+TEST(ErrorCodesTest, DIContainerErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::di_not_available), "DI container not available");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::component_not_found), "Component not found in DI container");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::registration_failed), "Failed to register component in DI container");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::creation_failed), "Failed to create component from factory");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::operation_failed), "DI container operation failed");
+}
+
+TEST(ErrorCodesTest, WriterExtendedErrorCodesToString) {
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_not_available), "Writer not available");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_configuration_error), "Writer configuration error");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::writer_operation_failed), "Writer operation failed");
+    EXPECT_EQ(logger_error_to_string(logger_error_code::destructor_cleanup_failed), "Destructor cleanup failed");
+}
+
+// =============================================================================
+// make_logger_void_result
+// =============================================================================
+
+TEST(ErrorCodesTest, MakeLoggerVoidResultError) {
+    auto result = make_logger_void_result(logger_error_code::file_open_failed, "test.log");
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().code, static_cast<int>(logger_error_code::file_open_failed));
+    EXPECT_EQ(result.error().message, "test.log");
+}
+
+TEST(ErrorCodesTest, MakeLoggerVoidResultDefaultMessage) {
+    auto result = make_logger_void_result(logger_error_code::queue_full);
+    EXPECT_TRUE(result.is_err());
+    EXPECT_EQ(result.error().message, "Queue is full");
+}
+
+// =============================================================================
+// make_logger_void_success
+// =============================================================================
+
+TEST(ErrorCodesTest, MakeLoggerVoidSuccess) {
+    auto result = make_logger_void_success();
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_FALSE(result.is_err());
+}
+
+// =============================================================================
+// get_logger_error_code
+// =============================================================================
+
+TEST(ErrorCodesTest, GetLoggerErrorCodeFromError) {
+    auto result = make_logger_void_result(logger_error_code::network_timeout);
+    auto code = get_logger_error_code(result);
+    EXPECT_EQ(code, logger_error_code::network_timeout);
+}
+
+TEST(ErrorCodesTest, GetLoggerErrorCodeFromSuccess) {
+    auto result = make_logger_void_success();
+    auto code = get_logger_error_code(result);
+    EXPECT_EQ(code, logger_error_code::success);
+}
+
+// =============================================================================
+// has_logger_error
+// =============================================================================
+
+TEST(ErrorCodesTest, HasLoggerErrorTrue) {
+    auto result = make_logger_void_result(logger_error_code::buffer_overflow);
+    EXPECT_TRUE(has_logger_error(result));
+}
+
+TEST(ErrorCodesTest, HasLoggerErrorFalse) {
+    auto result = make_logger_void_success();
+    EXPECT_FALSE(has_logger_error(result));
+}
+
+// =============================================================================
+// get_logger_error_message
+// =============================================================================
+
+TEST(ErrorCodesTest, GetLoggerErrorMessageFromError) {
+    auto result = make_logger_void_result(logger_error_code::encryption_failed, "AES error");
+    auto msg = get_logger_error_message(result);
+    EXPECT_EQ(msg, "AES error");
+}
+
+TEST(ErrorCodesTest, GetLoggerErrorMessageFromSuccess) {
+    auto result = make_logger_void_success();
+    auto msg = get_logger_error_message(result);
+    EXPECT_EQ(msg, "");
+}
+
+// =============================================================================
+// result<T> wrapper
+// =============================================================================
+
+TEST(ErrorCodesTest, ResultWithValue) {
+    result<int> res(42);
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value(), 42);
+}
+
+TEST(ErrorCodesTest, ResultWithError) {
+    result<int> res(logger_error_code::invalid_argument, "bad input");
+    EXPECT_FALSE(res.has_value());
+    EXPECT_EQ(res.error_code(), logger_error_code::invalid_argument);
+    EXPECT_EQ(res.error_message(), "bad input");
+}
+
+TEST(ErrorCodesTest, ResultBoolConversion) {
+    result<int> ok_res(42);
+    result<int> err_res(logger_error_code::unknown_error);
+
+    EXPECT_TRUE(static_cast<bool>(ok_res));
+    EXPECT_FALSE(static_cast<bool>(err_res));
+}
+
+TEST(ErrorCodesTest, ResultDefaultErrorMessage) {
+    result<std::string> res(logger_error_code::file_open_failed);
+    EXPECT_EQ(res.error_message(), "Failed to open file");
+}
+
+TEST(ErrorCodesTest, ResultStringValue) {
+    result<std::string> res(std::string("hello"));
+    EXPECT_TRUE(res.has_value());
+    EXPECT_EQ(res.value(), "hello");
+}

--- a/tests/unit/filters_test/CMakeLists.txt
+++ b/tests/unit/filters_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Log filter unit tests (level, regex, composite, function, field, category filters)
+add_executable(logger_filters_test filters_test.cpp)
+
+if(TARGET GTest::gtest_main)
+    target_link_libraries(logger_filters_test PRIVATE LoggerSystem GTest::gtest_main)
+else()
+    target_link_libraries(logger_filters_test PRIVATE LoggerSystem gtest_main)
+endif()
+
+add_test(NAME logger_filters_test COMMAND logger_filters_test)
+set_target_properties(logger_filters_test PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)

--- a/tests/unit/filters_test/filters_test.cpp
+++ b/tests/unit/filters_test/filters_test.cpp
@@ -1,0 +1,537 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file filters_test.cpp
+ * @brief Unit tests for all log filter implementations
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/filters/log_filter.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <memory>
+#include <string>
+
+using namespace kcenon::logger;
+using namespace kcenon::logger::filters;
+using log_level = kcenon::common::interfaces::log_level;
+
+// =============================================================================
+// level_filter
+// =============================================================================
+
+TEST(LevelFilterTest, PassesAtOrAboveMinLevel) {
+    level_filter filter(log_level::warning);
+
+    log_entry critical_entry(log_level::critical, "critical");
+    log_entry error_entry(log_level::error, "error");
+    log_entry warning_entry(log_level::warning, "warning");
+    log_entry info_entry(log_level::info, "info");
+    log_entry debug_entry(log_level::debug, "debug");
+
+    EXPECT_TRUE(filter.should_log(critical_entry));
+    EXPECT_TRUE(filter.should_log(error_entry));
+    EXPECT_TRUE(filter.should_log(warning_entry));
+    EXPECT_FALSE(filter.should_log(info_entry));
+    EXPECT_FALSE(filter.should_log(debug_entry));
+}
+
+TEST(LevelFilterTest, GetName) {
+    level_filter filter(log_level::info);
+    EXPECT_EQ(filter.get_name(), "level_filter");
+}
+
+// =============================================================================
+// exact_level_filter
+// =============================================================================
+
+TEST(ExactLevelFilterTest, PassesOnlyExactLevel) {
+    exact_level_filter filter(log_level::error);
+
+    log_entry error_entry(log_level::error, "error");
+    log_entry warning_entry(log_level::warning, "warning");
+    log_entry critical_entry(log_level::critical, "critical");
+
+    EXPECT_TRUE(filter.should_log(error_entry));
+    EXPECT_FALSE(filter.should_log(warning_entry));
+    EXPECT_FALSE(filter.should_log(critical_entry));
+}
+
+TEST(ExactLevelFilterTest, GetName) {
+    exact_level_filter filter(log_level::info);
+    EXPECT_EQ(filter.get_name(), "exact_level_filter");
+}
+
+// =============================================================================
+// regex_filter
+// =============================================================================
+
+TEST(RegexFilterTest, IncludeMatchingMessages) {
+    regex_filter filter("ERROR|FATAL", true);
+
+    log_entry match_entry(log_level::info, "ERROR in module");
+    log_entry no_match_entry(log_level::info, "everything is fine");
+
+    EXPECT_TRUE(filter.should_log(match_entry));
+    EXPECT_FALSE(filter.should_log(no_match_entry));
+}
+
+TEST(RegexFilterTest, ExcludeMatchingMessages) {
+    regex_filter filter("DEBUG|TRACE", false);
+
+    log_entry match_entry(log_level::info, "DEBUG output");
+    log_entry no_match_entry(log_level::info, "normal message");
+
+    EXPECT_FALSE(filter.should_log(match_entry));
+    EXPECT_TRUE(filter.should_log(no_match_entry));
+}
+
+TEST(RegexFilterTest, GetName) {
+    regex_filter filter("test");
+    EXPECT_EQ(filter.get_name(), "regex_filter");
+}
+
+// =============================================================================
+// composite_filter (AND logic)
+// =============================================================================
+
+TEST(CompositeFilterTest, AndLogicAllPass) {
+    composite_filter filter(composite_filter::logic_type::AND);
+    filter.add_filter(std::make_unique<level_filter>(log_level::info));
+    filter.add_filter(std::make_unique<regex_filter>("important", true));
+
+    log_entry entry(log_level::error, "important event");
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(CompositeFilterTest, AndLogicOneFails) {
+    composite_filter filter(composite_filter::logic_type::AND);
+    filter.add_filter(std::make_unique<level_filter>(log_level::error));
+    filter.add_filter(std::make_unique<regex_filter>("important", true));
+
+    log_entry entry(log_level::info, "important event");
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(CompositeFilterTest, AndLogicEmpty) {
+    composite_filter filter(composite_filter::logic_type::AND);
+
+    log_entry entry(log_level::info, "anything");
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+// =============================================================================
+// composite_filter (OR logic)
+// =============================================================================
+
+TEST(CompositeFilterTest, OrLogicOneMatches) {
+    composite_filter filter(composite_filter::logic_type::OR);
+    filter.add_filter(std::make_unique<level_filter>(log_level::error));
+    filter.add_filter(std::make_unique<regex_filter>("critical", true));
+
+    log_entry entry(log_level::info, "critical issue");
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(CompositeFilterTest, OrLogicNoneMatches) {
+    composite_filter filter(composite_filter::logic_type::OR);
+    filter.add_filter(std::make_unique<level_filter>(log_level::error));
+    filter.add_filter(std::make_unique<regex_filter>("critical", true));
+
+    log_entry entry(log_level::info, "normal operation");
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(CompositeFilterTest, OrLogicEmpty) {
+    composite_filter filter(composite_filter::logic_type::OR);
+
+    log_entry entry(log_level::info, "anything");
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(CompositeFilterTest, GetNameAnd) {
+    composite_filter filter(composite_filter::logic_type::AND);
+    EXPECT_EQ(filter.get_name(), "composite_and_filter");
+}
+
+TEST(CompositeFilterTest, GetNameOr) {
+    composite_filter filter(composite_filter::logic_type::OR);
+    EXPECT_EQ(filter.get_name(), "composite_or_filter");
+}
+
+// =============================================================================
+// function_filter
+// =============================================================================
+
+TEST(FunctionFilterTest, CustomPredicate) {
+    function_filter filter([](const log_entry& entry) {
+        return entry.message.to_string().length() > 10;
+    });
+
+    log_entry short_entry(log_level::info, "short");
+    log_entry long_entry(log_level::info, "this is a longer message");
+
+    EXPECT_FALSE(filter.should_log(short_entry));
+    EXPECT_TRUE(filter.should_log(long_entry));
+}
+
+TEST(FunctionFilterTest, GetName) {
+    function_filter filter([](const log_entry&) { return true; });
+    EXPECT_EQ(filter.get_name(), "function_filter");
+}
+
+// =============================================================================
+// field_exists_filter
+// =============================================================================
+
+TEST(FieldExistsFilterTest, PassesWhenFieldExists) {
+    field_exists_filter filter("user_id", true);
+
+    log_entry entry_with_field(log_level::info, "test");
+    entry_with_field.fields = log_fields{};
+    entry_with_field.fields->emplace("user_id", int64_t{42});
+
+    log_entry entry_without_field(log_level::info, "test");
+
+    EXPECT_TRUE(filter.should_log(entry_with_field));
+    EXPECT_FALSE(filter.should_log(entry_without_field));
+}
+
+TEST(FieldExistsFilterTest, PassesWhenFieldNotExists) {
+    field_exists_filter filter("user_id", false);
+
+    log_entry entry_with_field(log_level::info, "test");
+    entry_with_field.fields = log_fields{};
+    entry_with_field.fields->emplace("user_id", int64_t{42});
+
+    log_entry entry_without_field(log_level::info, "test");
+
+    EXPECT_FALSE(filter.should_log(entry_with_field));
+    EXPECT_TRUE(filter.should_log(entry_without_field));
+}
+
+TEST(FieldExistsFilterTest, NoFieldsAtAll) {
+    field_exists_filter filter("user_id", true);
+
+    log_entry entry(log_level::info, "test");
+    // fields is std::nullopt by default
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldExistsFilterTest, GetName) {
+    field_exists_filter filter("test");
+    EXPECT_EQ(filter.get_name(), "field_exists_filter");
+}
+
+// =============================================================================
+// field_value_filter
+// =============================================================================
+
+TEST(FieldValueFilterTest, MatchesExpectedValue) {
+    field_value_filter filter("status", std::string("active"));
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("status", std::string("active"));
+
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldValueFilterTest, DoesNotMatchDifferentValue) {
+    field_value_filter filter("status", std::string("active"));
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("status", std::string("inactive"));
+
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldValueFilterTest, NegateMode) {
+    field_value_filter filter("status", std::string("error"), true);
+
+    log_entry entry_error(log_level::info, "test");
+    entry_error.fields = log_fields{};
+    entry_error.fields->emplace("status", std::string("error"));
+
+    log_entry entry_ok(log_level::info, "test");
+    entry_ok.fields = log_fields{};
+    entry_ok.fields->emplace("status", std::string("ok"));
+
+    EXPECT_FALSE(filter.should_log(entry_error)); // matches, but negated
+    EXPECT_TRUE(filter.should_log(entry_ok));     // doesn't match, negated passes
+}
+
+TEST(FieldValueFilterTest, MissingFieldNonNegate) {
+    field_value_filter filter("status", std::string("active"));
+
+    log_entry entry(log_level::info, "test");
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldValueFilterTest, MissingFieldNegate) {
+    field_value_filter filter("status", std::string("active"), true);
+
+    log_entry entry(log_level::info, "test");
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldValueFilterTest, IntegerValue) {
+    field_value_filter filter("count", int64_t{5});
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("count", int64_t{5});
+
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldValueFilterTest, BooleanValue) {
+    field_value_filter filter("success", true);
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("success", true);
+
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldValueFilterTest, GetName) {
+    field_value_filter filter("test", std::string("val"));
+    EXPECT_EQ(filter.get_name(), "field_value_filter");
+}
+
+// =============================================================================
+// field_range_filter
+// =============================================================================
+
+TEST(FieldRangeFilterTest, IntegerInRange) {
+    field_range_filter filter("count", 1.0, 10.0);
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("count", int64_t{5});
+
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldRangeFilterTest, IntegerAtBoundaryInclusive) {
+    field_range_filter filter("count", 1.0, 10.0, true, true);
+
+    log_entry entry_min(log_level::info, "test");
+    entry_min.fields = log_fields{};
+    entry_min.fields->emplace("count", int64_t{1});
+
+    log_entry entry_max(log_level::info, "test");
+    entry_max.fields = log_fields{};
+    entry_max.fields->emplace("count", int64_t{10});
+
+    EXPECT_TRUE(filter.should_log(entry_min));
+    EXPECT_TRUE(filter.should_log(entry_max));
+}
+
+TEST(FieldRangeFilterTest, IntegerAtBoundaryExclusive) {
+    field_range_filter filter("count", 1.0, 10.0, false, false);
+
+    log_entry entry_min(log_level::info, "test");
+    entry_min.fields = log_fields{};
+    entry_min.fields->emplace("count", int64_t{1});
+
+    log_entry entry_max(log_level::info, "test");
+    entry_max.fields = log_fields{};
+    entry_max.fields->emplace("count", int64_t{10});
+
+    EXPECT_FALSE(filter.should_log(entry_min));
+    EXPECT_FALSE(filter.should_log(entry_max));
+}
+
+TEST(FieldRangeFilterTest, DoubleInRange) {
+    field_range_filter filter("latency", 0.0, 100.0);
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("latency", 45.5);
+
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldRangeFilterTest, OutOfRange) {
+    field_range_filter filter("count", 1.0, 10.0);
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("count", int64_t{15});
+
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldRangeFilterTest, NonNumericFieldFails) {
+    field_range_filter filter("name", 0.0, 100.0);
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("name", std::string("Alice"));
+
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldRangeFilterTest, MissingFieldFails) {
+    field_range_filter filter("count", 0.0, 100.0);
+
+    log_entry entry(log_level::info, "test");
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldRangeFilterTest, GetName) {
+    field_range_filter filter("test", 0.0, 1.0);
+    EXPECT_EQ(filter.get_name(), "field_range_filter");
+}
+
+// =============================================================================
+// field_regex_filter
+// =============================================================================
+
+TEST(FieldRegexFilterTest, MatchesPattern) {
+    field_regex_filter filter("service", "^auth.*");
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("service", std::string("auth-service"));
+
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(FieldRegexFilterTest, DoesNotMatchPattern) {
+    field_regex_filter filter("service", "^auth.*");
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("service", std::string("user-service"));
+
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldRegexFilterTest, ExcludeMode) {
+    field_regex_filter filter("service", "^internal", false);
+
+    log_entry internal_entry(log_level::info, "test");
+    internal_entry.fields = log_fields{};
+    internal_entry.fields->emplace("service", std::string("internal-api"));
+
+    log_entry external_entry(log_level::info, "test");
+    external_entry.fields = log_fields{};
+    external_entry.fields->emplace("service", std::string("public-api"));
+
+    EXPECT_FALSE(filter.should_log(internal_entry));
+    EXPECT_TRUE(filter.should_log(external_entry));
+}
+
+TEST(FieldRegexFilterTest, NonStringFieldFails) {
+    field_regex_filter filter("count", "\\d+");
+
+    log_entry entry(log_level::info, "test");
+    entry.fields = log_fields{};
+    entry.fields->emplace("count", int64_t{42});
+
+    // Non-string fields should not match (include mode)
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldRegexFilterTest, MissingField) {
+    field_regex_filter filter("service", "test", true);
+
+    log_entry entry(log_level::info, "test");
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(FieldRegexFilterTest, GetName) {
+    field_regex_filter filter("test", "pattern");
+    EXPECT_EQ(filter.get_name(), "field_regex_filter");
+}
+
+// =============================================================================
+// category_filter
+// =============================================================================
+
+TEST(CategoryFilterTest, IncludeMatchingCategory) {
+    category_filter filter({"database", "network"}, true);
+
+    log_entry db_entry(log_level::info, "test");
+    db_entry.category = small_string_128("database");
+
+    log_entry net_entry(log_level::info, "test");
+    net_entry.category = small_string_128("network");
+
+    log_entry other_entry(log_level::info, "test");
+    other_entry.category = small_string_128("security");
+
+    EXPECT_TRUE(filter.should_log(db_entry));
+    EXPECT_TRUE(filter.should_log(net_entry));
+    EXPECT_FALSE(filter.should_log(other_entry));
+}
+
+TEST(CategoryFilterTest, ExcludeMatchingCategory) {
+    category_filter filter({"debug", "trace"}, false);
+
+    log_entry debug_entry(log_level::info, "test");
+    debug_entry.category = small_string_128("debug");
+
+    log_entry app_entry(log_level::info, "test");
+    app_entry.category = small_string_128("application");
+
+    EXPECT_FALSE(filter.should_log(debug_entry));
+    EXPECT_TRUE(filter.should_log(app_entry));
+}
+
+TEST(CategoryFilterTest, NoCategoryIncludeMode) {
+    category_filter filter({"database"}, true);
+
+    log_entry entry(log_level::info, "test");
+    // No category set
+    EXPECT_FALSE(filter.should_log(entry));
+}
+
+TEST(CategoryFilterTest, NoCategoryExcludeMode) {
+    category_filter filter({"database"}, false);
+
+    log_entry entry(log_level::info, "test");
+    // No category set - passes in exclude mode
+    EXPECT_TRUE(filter.should_log(entry));
+}
+
+TEST(CategoryFilterTest, GetName) {
+    category_filter filter({});
+    EXPECT_EQ(filter.get_name(), "category_filter");
+}

--- a/tests/unit/formatters_test/CMakeLists.txt
+++ b/tests/unit/formatters_test/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Formatter unit tests (json, logfmt, template, timestamp formatters)
+add_executable(logger_formatters_test formatters_test.cpp)
+
+if(TARGET GTest::gtest_main)
+    target_link_libraries(logger_formatters_test PRIVATE LoggerSystem GTest::gtest_main)
+else()
+    target_link_libraries(logger_formatters_test PRIVATE LoggerSystem gtest_main)
+endif()
+
+add_test(NAME logger_formatters_test COMMAND logger_formatters_test)
+set_target_properties(logger_formatters_test PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)

--- a/tests/unit/formatters_test/formatters_test.cpp
+++ b/tests/unit/formatters_test/formatters_test.cpp
@@ -1,0 +1,532 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file formatters_test.cpp
+ * @brief Unit tests for all log formatter implementations
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/formatters/json_formatter.h>
+#include <kcenon/logger/formatters/logfmt_formatter.h>
+#include <kcenon/logger/formatters/template_formatter.h>
+#include <kcenon/logger/formatters/timestamp_formatter.h>
+#include <kcenon/logger/interfaces/log_entry.h>
+
+#include <chrono>
+#include <string>
+
+using namespace kcenon::logger;
+using log_level = kcenon::common::interfaces::log_level;
+
+// =============================================================================
+// Helper to create test log entries
+// =============================================================================
+
+namespace {
+
+log_entry make_simple_entry(log_level level, const std::string& msg) {
+    return log_entry(level, msg);
+}
+
+log_entry make_entry_with_location(log_level level, const std::string& msg) {
+    return log_entry(level, msg, "test_file.cpp", 42, "test_function");
+}
+
+log_entry make_entry_with_fields(log_level level, const std::string& msg) {
+    log_entry entry(level, msg);
+    entry.thread_id = small_string_64("12345");
+    entry.category = small_string_128("database");
+    entry.fields = log_fields{};
+    entry.fields->emplace("user_id", int64_t{123});
+    entry.fields->emplace("latency_ms", 45.67);
+    entry.fields->emplace("success", true);
+    entry.fields->emplace("service", std::string("auth"));
+    return entry;
+}
+
+} // namespace
+
+// =============================================================================
+// JSON Formatter
+// =============================================================================
+
+class JsonFormatterTest : public ::testing::Test {
+protected:
+    json_formatter formatter_;
+};
+
+TEST_F(JsonFormatterTest, BasicFormat) {
+    auto entry = make_simple_entry(log_level::info, "Hello");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("{"), std::string::npos);
+    EXPECT_NE(result.find("}"), std::string::npos);
+    EXPECT_NE(result.find("\"message\":\"Hello\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, IncludesLevel) {
+    auto entry = make_simple_entry(log_level::error, "Error occurred");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\"level\":\"ERROR\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, IncludesTimestamp) {
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\"timestamp\":\""), std::string::npos);
+    EXPECT_NE(result.find("Z\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, IncludesSourceLocation) {
+    auto entry = make_entry_with_location(log_level::debug, "debug msg");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\"file\":\"test_file.cpp\""), std::string::npos);
+    EXPECT_NE(result.find("\"line\":42"), std::string::npos);
+    EXPECT_NE(result.find("\"function\":\"test_function\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, IncludesCategory) {
+    auto entry = make_simple_entry(log_level::info, "msg");
+    entry.category = small_string_128("network");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\"category\":\"network\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, IncludesStructuredFields) {
+    auto entry = make_entry_with_fields(log_level::info, "test");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\"user_id\":123"), std::string::npos);
+    EXPECT_NE(result.find("\"success\":true"), std::string::npos);
+    EXPECT_NE(result.find("\"service\":\"auth\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, PrettyPrint) {
+    format_options opts;
+    opts.pretty_print = true;
+    json_formatter pretty_fmt(opts);
+
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = pretty_fmt.format(entry);
+
+    // Pretty print should contain newlines
+    EXPECT_NE(result.find("\n"), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, DisableTimestamp) {
+    format_options opts;
+    opts.include_timestamp = false;
+    json_formatter fmt(opts);
+
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result.find("timestamp"), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, DisableLevel) {
+    format_options opts;
+    opts.include_level = false;
+    json_formatter fmt(opts);
+
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result.find("\"level\""), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, GetName) {
+    EXPECT_EQ(formatter_.get_name(), "json_formatter");
+}
+
+TEST_F(JsonFormatterTest, EscapesSpecialChars) {
+    auto entry = make_simple_entry(log_level::info, "line1\nline2\ttab");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\\n"), std::string::npos);
+    EXPECT_NE(result.find("\\t"), std::string::npos);
+}
+
+TEST_F(JsonFormatterTest, OtelContext) {
+    auto entry = make_simple_entry(log_level::info, "traced");
+    entry.otel_ctx = kcenon::logger::otlp::otel_context{};
+    // Use valid 32-char trace_id and 16-char span_id (hex)
+    entry.otel_ctx->trace_id = "0af7651916cd43dd8448eb211c80319c";
+    entry.otel_ctx->span_id = "b7ad6b7169203331";
+    entry.otel_ctx->trace_flags = "01";
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("\"trace_id\":\"0af7651916cd43dd8448eb211c80319c\""), std::string::npos);
+    EXPECT_NE(result.find("\"span_id\":\"b7ad6b7169203331\""), std::string::npos);
+    EXPECT_NE(result.find("\"trace_flags\":\"01\""), std::string::npos);
+}
+
+// =============================================================================
+// Logfmt Formatter
+// =============================================================================
+
+class LogfmtFormatterTest : public ::testing::Test {
+protected:
+    logfmt_formatter formatter_;
+};
+
+TEST_F(LogfmtFormatterTest, BasicFormat) {
+    auto entry = make_simple_entry(log_level::info, "Hello");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("level=info"), std::string::npos);
+    EXPECT_NE(result.find("msg=Hello"), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, IncludesTimestamp) {
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("ts="), std::string::npos);
+    EXPECT_NE(result.find("Z"), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, QuotesSpacesInValues) {
+    auto entry = make_simple_entry(log_level::info, "hello world");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("msg=\"hello world\""), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, IncludesSourceLocation) {
+    auto entry = make_entry_with_location(log_level::error, "error");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("file=test_file.cpp"), std::string::npos);
+    EXPECT_NE(result.find("line=42"), std::string::npos);
+    EXPECT_NE(result.find("function=test_function"), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, IncludesCategory) {
+    auto entry = make_simple_entry(log_level::info, "msg");
+    entry.category = small_string_128("network");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("category=network"), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, IncludesStructuredFields) {
+    auto entry = make_entry_with_fields(log_level::info, "test");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("user_id=123"), std::string::npos);
+    EXPECT_NE(result.find("success=true"), std::string::npos);
+    EXPECT_NE(result.find("service=auth"), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, LevelFormats) {
+    auto entry_trace = make_simple_entry(log_level::trace, "t");
+    EXPECT_NE(formatter_.format(entry_trace).find("level=trace"), std::string::npos);
+
+    auto entry_debug = make_simple_entry(log_level::debug, "d");
+    EXPECT_NE(formatter_.format(entry_debug).find("level=debug"), std::string::npos);
+
+    auto entry_warn = make_simple_entry(log_level::warning, "w");
+    EXPECT_NE(formatter_.format(entry_warn).find("level=warn"), std::string::npos);
+
+    auto entry_crit = make_simple_entry(log_level::critical, "c");
+    EXPECT_NE(formatter_.format(entry_crit).find("level=critical"), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, GetName) {
+    EXPECT_EQ(formatter_.get_name(), "logfmt_formatter");
+}
+
+TEST_F(LogfmtFormatterTest, DisableLevel) {
+    format_options opts;
+    opts.include_level = false;
+    logfmt_formatter fmt(opts);
+
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result.find("level="), std::string::npos);
+}
+
+TEST_F(LogfmtFormatterTest, OtelContext) {
+    auto entry = make_simple_entry(log_level::info, "traced");
+    entry.otel_ctx = kcenon::logger::otlp::otel_context{};
+    entry.otel_ctx->trace_id = "0af7651916cd43dd8448eb211c80319c";
+    entry.otel_ctx->span_id = "b7ad6b7169203331";
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("trace_id=0af7651916cd43dd8448eb211c80319c"), std::string::npos);
+    EXPECT_NE(result.find("span_id=b7ad6b7169203331"), std::string::npos);
+}
+
+// =============================================================================
+// Template Formatter
+// =============================================================================
+
+class TemplateFormatterTest : public ::testing::Test {
+protected:
+};
+
+TEST_F(TemplateFormatterTest, DefaultTemplate) {
+    template_formatter fmt;
+    auto entry = make_simple_entry(log_level::info, "Hello");
+    entry.thread_id = small_string_64("1234");
+    auto result = fmt.format(entry);
+
+    EXPECT_NE(result.find("INFO"), std::string::npos);
+    EXPECT_NE(result.find("Hello"), std::string::npos);
+    EXPECT_NE(result.find("1234"), std::string::npos);
+}
+
+TEST_F(TemplateFormatterTest, CustomTemplate) {
+    template_formatter fmt("{level} - {message}");
+    auto entry = make_simple_entry(log_level::error, "Failed");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result.find("ERROR - Failed"), 0u);
+}
+
+TEST_F(TemplateFormatterTest, PlaceholderTimestampLocal) {
+    template_formatter fmt("{timestamp_local}");
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    // Should contain a local timestamp
+    EXPECT_FALSE(result.empty());
+}
+
+TEST_F(TemplateFormatterTest, PlaceholderLevelLower) {
+    template_formatter fmt("{level_lower}");
+    auto entry = make_simple_entry(log_level::error, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result, "error");
+}
+
+TEST_F(TemplateFormatterTest, PlaceholderFilename) {
+    template_formatter fmt("{filename}:{line}");
+    auto entry = make_entry_with_location(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result, "test_file.cpp:42");
+}
+
+TEST_F(TemplateFormatterTest, PlaceholderFunction) {
+    template_formatter fmt("{function}");
+    auto entry = make_entry_with_location(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result, "test_function");
+}
+
+TEST_F(TemplateFormatterTest, PlaceholderCategory) {
+    template_formatter fmt("{category}");
+    auto entry = make_simple_entry(log_level::info, "test");
+    entry.category = small_string_128("db");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result, "db");
+}
+
+TEST_F(TemplateFormatterTest, PlaceholderMissingOptionalField) {
+    template_formatter fmt("[{thread_id}] {message}");
+    auto entry = make_simple_entry(log_level::info, "test");
+    // No thread_id set
+    auto result = fmt.format(entry);
+
+    EXPECT_NE(result.find("test"), std::string::npos);
+    EXPECT_EQ(result.find("[]"), 0u);
+}
+
+TEST_F(TemplateFormatterTest, WidthFormatting) {
+    template_formatter fmt("{level:10}|");
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    // "INFO" (4 chars) should be padded to 10 chars
+    EXPECT_NE(result.find("INFO      |"), std::string::npos);
+}
+
+TEST_F(TemplateFormatterTest, UnclosedBraceTreatedAsLiteral) {
+    template_formatter fmt("hello {world");
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_NE(result.find("hello {world"), std::string::npos);
+}
+
+TEST_F(TemplateFormatterTest, StructuredFieldPlaceholder) {
+    template_formatter fmt("{user_id}");
+    auto entry = make_entry_with_fields(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result, "123");
+}
+
+TEST_F(TemplateFormatterTest, SetTemplate) {
+    template_formatter fmt("{level}");
+    auto entry = make_simple_entry(log_level::info, "test");
+    EXPECT_EQ(fmt.format(entry), "INFO");
+
+    fmt.set_template("{message}");
+    EXPECT_EQ(fmt.format(std::move(entry)), "test");
+}
+
+TEST_F(TemplateFormatterTest, GetTemplate) {
+    template_formatter fmt("{level} {message}");
+    EXPECT_EQ(fmt.get_template(), "{level} {message}");
+}
+
+TEST_F(TemplateFormatterTest, GetName) {
+    template_formatter fmt;
+    EXPECT_EQ(fmt.get_name(), "template_formatter");
+}
+
+TEST_F(TemplateFormatterTest, OtelPlaceholders) {
+    template_formatter fmt("{trace_id}-{span_id}");
+    auto entry = make_simple_entry(log_level::info, "test");
+    entry.otel_ctx = kcenon::logger::otlp::otel_context{};
+    entry.otel_ctx->trace_id = "0af7651916cd43dd8448eb211c80319c";
+    entry.otel_ctx->span_id = "b7ad6b7169203331";
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result, "0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331");
+}
+
+// =============================================================================
+// Timestamp Formatter
+// =============================================================================
+
+class TimestampFormatterTest : public ::testing::Test {
+protected:
+    timestamp_formatter formatter_;
+};
+
+TEST_F(TimestampFormatterTest, BasicFormat) {
+    auto entry = make_simple_entry(log_level::info, "Hello");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("[INFO]"), std::string::npos);
+    EXPECT_NE(result.find("Hello"), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, IncludesTimestamp) {
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = formatter_.format(entry);
+
+    // Timestamp format: [YYYY-MM-DD HH:MM:SS.mmm]
+    EXPECT_NE(result.find("[20"), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, IncludesSourceLocation) {
+    auto entry = make_entry_with_location(log_level::error, "error msg");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("test_file.cpp:42"), std::string::npos);
+    EXPECT_NE(result.find("test_function()"), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, IncludesThreadId) {
+    auto entry = make_simple_entry(log_level::info, "test");
+    entry.thread_id = small_string_64("9876");
+    auto result = formatter_.format(entry);
+
+    EXPECT_NE(result.find("[thread:9876]"), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, WithColors) {
+    format_options opts;
+    opts.use_colors = true;
+    timestamp_formatter color_fmt(opts);
+
+    auto entry = make_simple_entry(log_level::error, "test");
+    auto result = color_fmt.format(entry);
+
+    // Should contain ANSI escape codes
+    EXPECT_NE(result.find("\033["), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, DisableTimestamp) {
+    format_options opts;
+    opts.include_timestamp = false;
+    timestamp_formatter fmt(opts);
+
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    // Should not start with timestamp brackets
+    EXPECT_EQ(result.find("[20"), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, DisableLevel) {
+    format_options opts;
+    opts.include_level = false;
+    timestamp_formatter fmt(opts);
+
+    auto entry = make_simple_entry(log_level::info, "test");
+    auto result = fmt.format(entry);
+
+    EXPECT_EQ(result.find("[INFO]"), std::string::npos);
+}
+
+TEST_F(TimestampFormatterTest, GetName) {
+    EXPECT_EQ(formatter_.get_name(), "timestamp_formatter");
+}
+
+// =============================================================================
+// Format options set/get
+// =============================================================================
+
+TEST(FormatOptionsTest, SetAndGetOptions) {
+    timestamp_formatter fmt;
+
+    format_options opts;
+    opts.include_timestamp = false;
+    opts.include_level = false;
+    opts.use_colors = true;
+    opts.pretty_print = true;
+
+    fmt.set_options(opts);
+    auto retrieved = fmt.get_options();
+
+    EXPECT_FALSE(retrieved.include_timestamp);
+    EXPECT_FALSE(retrieved.include_level);
+    EXPECT_TRUE(retrieved.use_colors);
+    EXPECT_TRUE(retrieved.pretty_print);
+}

--- a/tests/unit/security_test/path_validator_test.cpp
+++ b/tests/unit/security_test/path_validator_test.cpp
@@ -1,0 +1,154 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file path_validator_test.cpp
+ * @brief Unit tests for path_validator (security path validation)
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/security/path_validator.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace kcenon::logger::security;
+using namespace kcenon::logger;
+
+// =============================================================================
+// is_safe_filename
+// =============================================================================
+
+TEST(PathValidatorTest, IsSafeFilenameValid) {
+    EXPECT_TRUE(path_validator::is_safe_filename("app.log"));
+    EXPECT_TRUE(path_validator::is_safe_filename("my-file_2024.log"));
+    EXPECT_TRUE(path_validator::is_safe_filename("a"));
+    EXPECT_TRUE(path_validator::is_safe_filename("test123"));
+}
+
+TEST(PathValidatorTest, IsSafeFilenameRejectsEmpty) {
+    EXPECT_FALSE(path_validator::is_safe_filename(""));
+}
+
+TEST(PathValidatorTest, IsSafeFilenameRejectsDot) {
+    EXPECT_FALSE(path_validator::is_safe_filename("."));
+}
+
+TEST(PathValidatorTest, IsSafeFilenameRejectsDoubleDot) {
+    EXPECT_FALSE(path_validator::is_safe_filename(".."));
+}
+
+TEST(PathValidatorTest, IsSafeFilenameRejectsSpecialChars) {
+    EXPECT_FALSE(path_validator::is_safe_filename("file name.log"));   // space
+    EXPECT_FALSE(path_validator::is_safe_filename("file/name.log"));   // slash
+    EXPECT_FALSE(path_validator::is_safe_filename("file\\name.log"));  // backslash
+    EXPECT_FALSE(path_validator::is_safe_filename("file:name.log"));   // colon
+    EXPECT_FALSE(path_validator::is_safe_filename("file*name.log"));   // asterisk
+    EXPECT_FALSE(path_validator::is_safe_filename("file?name.log"));   // question mark
+    EXPECT_FALSE(path_validator::is_safe_filename("file<name>.log"));  // angle brackets
+}
+
+// =============================================================================
+// sanitize_filename
+// =============================================================================
+
+TEST(PathValidatorTest, SanitizeFilenameReplacesInvalid) {
+    auto result = path_validator::sanitize_filename("file name?.log");
+    EXPECT_EQ(result.find(' '), std::string::npos);
+    EXPECT_EQ(result.find('?'), std::string::npos);
+    EXPECT_NE(result.find('_'), std::string::npos);
+}
+
+TEST(PathValidatorTest, SanitizeFilenamePreservesValid) {
+    EXPECT_EQ(path_validator::sanitize_filename("app.log"), "app.log");
+    EXPECT_EQ(path_validator::sanitize_filename("my-file_2024.txt"), "my-file_2024.txt");
+}
+
+TEST(PathValidatorTest, SanitizeFilenameEmpty) {
+    EXPECT_EQ(path_validator::sanitize_filename(""), "unnamed");
+}
+
+TEST(PathValidatorTest, SanitizeFilenameDot) {
+    auto result = path_validator::sanitize_filename(".");
+    EXPECT_NE(result, ".");
+}
+
+TEST(PathValidatorTest, SanitizeFilenameDoubleDot) {
+    auto result = path_validator::sanitize_filename("..");
+    EXPECT_NE(result, "..");
+}
+
+TEST(PathValidatorTest, SanitizeFilenameCustomReplacement) {
+    auto result = path_validator::sanitize_filename("file name.log", '-');
+    EXPECT_NE(result.find('-'), std::string::npos);
+    EXPECT_EQ(result.find(' '), std::string::npos);
+}
+
+// =============================================================================
+// validate - basic
+// =============================================================================
+
+TEST(PathValidatorTest, ValidateAcceptsPathWithinBase) {
+    auto base = std::filesystem::temp_directory_path();
+    path_validator validator(base);
+
+    auto result = validator.validate(base / "app.log");
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST(PathValidatorTest, AllowedBaseAccessor) {
+    auto base = std::filesystem::temp_directory_path();
+    path_validator validator(base);
+
+    EXPECT_FALSE(validator.allowed_base().empty());
+}
+
+// =============================================================================
+// safe_join
+// =============================================================================
+
+TEST(PathValidatorTest, SafeJoinRejectsAbsolutePath) {
+    auto base = std::filesystem::temp_directory_path();
+    auto result = path_validator::safe_join(base, "/etc/passwd");
+
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(PathValidatorTest, SafeJoinAcceptsRelativePath) {
+    auto base = std::filesystem::temp_directory_path();
+    auto result = path_validator::safe_join(base, "logs/app.log");
+
+    EXPECT_TRUE(result.has_value());
+}

--- a/tests/unit/utils_test/CMakeLists.txt
+++ b/tests/unit/utils_test/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Utils unit tests (string_utils, time_utils, file_utils)
+add_executable(logger_string_utils_test string_utils_test.cpp)
+add_executable(logger_time_utils_test time_utils_test.cpp)
+add_executable(logger_file_utils_test file_utils_test.cpp)
+
+foreach(_target IN ITEMS logger_string_utils_test logger_time_utils_test logger_file_utils_test)
+    if(TARGET GTest::gtest_main)
+        target_link_libraries(${_target} PRIVATE LoggerSystem GTest::gtest_main)
+    else()
+        target_link_libraries(${_target} PRIVATE LoggerSystem gtest_main)
+    endif()
+
+    set_target_properties(${_target} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+    )
+endforeach()
+
+add_test(NAME logger_string_utils_test COMMAND logger_string_utils_test)
+add_test(NAME logger_time_utils_test COMMAND logger_time_utils_test)
+add_test(NAME logger_file_utils_test COMMAND logger_file_utils_test)

--- a/tests/unit/utils_test/file_utils_test.cpp
+++ b/tests/unit/utils_test/file_utils_test.cpp
@@ -1,0 +1,182 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file file_utils_test.cpp
+ * @brief Unit tests for file utility functions
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/utils/file_utils.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace kcenon::logger::utils;
+using namespace kcenon::logger;
+
+// =============================================================================
+// validate_log_path - path traversal
+// =============================================================================
+
+TEST(FileUtilsTest, ValidateLogPathRejectsTraversal) {
+    auto result = file_utils::validate_log_path("../../../etc/passwd");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(FileUtilsTest, ValidateLogPathRejectsDoubleDotsInMiddle) {
+    auto result = file_utils::validate_log_path("/var/log/../../../etc/shadow");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST(FileUtilsTest, ValidateLogPathAcceptsSimplePath) {
+    auto result = file_utils::validate_log_path("logs/app.log");
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST(FileUtilsTest, ValidateLogPathAcceptsWithoutBase) {
+    auto result = file_utils::validate_log_path("/tmp/test.log");
+    EXPECT_TRUE(result.is_ok());
+}
+
+// =============================================================================
+// sanitize_filename
+// =============================================================================
+
+TEST(FileUtilsTest, SanitizeFilenameRemovesSlashes) {
+    auto result = file_utils::sanitize_filename("path/file.log");
+    EXPECT_EQ(result.find('/'), std::string::npos);
+}
+
+TEST(FileUtilsTest, SanitizeFilenameRemovesBackslashes) {
+    auto result = file_utils::sanitize_filename("path\\file.log");
+    EXPECT_EQ(result.find('\\'), std::string::npos);
+}
+
+TEST(FileUtilsTest, SanitizeFilenameRemovesNullBytes) {
+    std::string input = "file";
+    input += '\0';
+    input += ".log";
+    auto result = file_utils::sanitize_filename(input);
+    EXPECT_EQ(result.find('\0'), std::string::npos);
+}
+
+TEST(FileUtilsTest, SanitizeFilenameReplacesControlChars) {
+    std::string input = "file\x01name.log";
+    auto result = file_utils::sanitize_filename(input);
+    EXPECT_EQ(result.find('\x01'), std::string::npos);
+    EXPECT_NE(result.find('_'), std::string::npos);
+}
+
+TEST(FileUtilsTest, SanitizeFilenameReplacesDangerousChars) {
+    auto result = file_utils::sanitize_filename("file:name?.log");
+    EXPECT_EQ(result.find(':'), std::string::npos);
+    EXPECT_EQ(result.find('?'), std::string::npos);
+}
+
+TEST(FileUtilsTest, SanitizeFilenameEmptyReturnsDefault) {
+    EXPECT_EQ(file_utils::sanitize_filename(""), "unnamed.log");
+}
+
+TEST(FileUtilsTest, SanitizeFilenamePreservesNormalName) {
+    EXPECT_EQ(file_utils::sanitize_filename("app.log"), "app.log");
+}
+
+TEST(FileUtilsTest, SanitizeFilenameTruncatesLongNames) {
+    std::string long_name(300, 'a');
+    long_name += ".log";
+    auto result = file_utils::sanitize_filename(long_name);
+    EXPECT_LE(result.size(), 255u);
+}
+
+// =============================================================================
+// is_absolute
+// =============================================================================
+
+TEST(FileUtilsTest, IsAbsoluteUnixPath) {
+    EXPECT_TRUE(file_utils::is_absolute("/var/log/app.log"));
+}
+
+TEST(FileUtilsTest, IsAbsoluteRelativePath) {
+    EXPECT_FALSE(file_utils::is_absolute("logs/app.log"));
+}
+
+TEST(FileUtilsTest, IsAbsoluteEmpty) {
+    EXPECT_FALSE(file_utils::is_absolute(""));
+}
+
+// =============================================================================
+// get_file_size
+// =============================================================================
+
+TEST(FileUtilsTest, GetFileSizeNonExistentReturnsZero) {
+    EXPECT_EQ(file_utils::get_file_size("/nonexistent/path/file.txt"), 0u);
+}
+
+// =============================================================================
+// is_writable
+// =============================================================================
+
+TEST(FileUtilsTest, IsWritableNonExistentParent) {
+    EXPECT_FALSE(file_utils::is_writable("/nonexistent_dir_xyz/file.txt"));
+}
+
+// =============================================================================
+// generate_temp_filename
+// =============================================================================
+
+TEST(FileUtilsTest, GenerateTempFilenameContainsPrefix) {
+    auto result = file_utils::generate_temp_filename("myapp");
+    EXPECT_NE(result.find("myapp"), std::string::npos);
+}
+
+TEST(FileUtilsTest, GenerateTempFilenameContainsExtension) {
+    auto result = file_utils::generate_temp_filename("test", ".log");
+    EXPECT_NE(result.find(".log"), std::string::npos);
+}
+
+TEST(FileUtilsTest, GenerateTempFilenameDefaultExtension) {
+    auto result = file_utils::generate_temp_filename();
+    EXPECT_NE(result.find(".tmp"), std::string::npos);
+}
+
+TEST(FileUtilsTest, GenerateTempFilenameUniqueness) {
+    auto name1 = file_utils::generate_temp_filename("test");
+    auto name2 = file_utils::generate_temp_filename("test");
+    // Names may differ due to random component (or be same within same second)
+    // Just verify they are valid non-empty strings
+    EXPECT_FALSE(name1.empty());
+    EXPECT_FALSE(name2.empty());
+}

--- a/tests/unit/utils_test/string_utils_test.cpp
+++ b/tests/unit/utils_test/string_utils_test.cpp
@@ -1,0 +1,290 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file string_utils_test.cpp
+ * @brief Unit tests for string utility functions
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/utils/string_utils.h>
+
+using namespace kcenon::logger::utils;
+using log_level = kcenon::common::interfaces::log_level;
+
+// =============================================================================
+// level_to_string
+// =============================================================================
+
+TEST(StringUtilsTest, LevelToStringAllLevels) {
+    EXPECT_EQ(string_utils::level_to_string(log_level::critical), "CRITICAL");
+    EXPECT_EQ(string_utils::level_to_string(log_level::error), "ERROR");
+    EXPECT_EQ(string_utils::level_to_string(log_level::warning), "WARNING");
+    EXPECT_EQ(string_utils::level_to_string(log_level::info), "INFO");
+    EXPECT_EQ(string_utils::level_to_string(log_level::debug), "DEBUG");
+    EXPECT_EQ(string_utils::level_to_string(log_level::trace), "TRACE");
+    EXPECT_EQ(string_utils::level_to_string(log_level::off), "OFF");
+}
+
+// =============================================================================
+// level_to_color
+// =============================================================================
+
+TEST(StringUtilsTest, LevelToColorReturnsAnsiCodes) {
+    EXPECT_FALSE(string_utils::level_to_color(log_level::critical).empty());
+    EXPECT_FALSE(string_utils::level_to_color(log_level::error).empty());
+    EXPECT_FALSE(string_utils::level_to_color(log_level::warning).empty());
+    EXPECT_FALSE(string_utils::level_to_color(log_level::info).empty());
+    EXPECT_FALSE(string_utils::level_to_color(log_level::debug).empty());
+    EXPECT_FALSE(string_utils::level_to_color(log_level::trace).empty());
+    EXPECT_FALSE(string_utils::level_to_color(log_level::off).empty());
+}
+
+TEST(StringUtilsTest, LevelToColorDisabledReturnsEmpty) {
+    EXPECT_EQ(string_utils::level_to_color(log_level::error, false), "");
+    EXPECT_EQ(string_utils::level_to_color(log_level::info, false), "");
+}
+
+TEST(StringUtilsTest, LevelToColorContainsEscapeSequence) {
+    std::string color = string_utils::level_to_color(log_level::error);
+    EXPECT_NE(color.find("\033["), std::string::npos);
+}
+
+// =============================================================================
+// color_reset
+// =============================================================================
+
+TEST(StringUtilsTest, ColorResetReturnsResetSequence) {
+    EXPECT_STREQ(string_utils::color_reset(), "\033[0m");
+}
+
+// =============================================================================
+// escape_json
+// =============================================================================
+
+TEST(StringUtilsTest, EscapeJsonQuotes) {
+    EXPECT_EQ(string_utils::escape_json("say \"hello\""), "say \\\"hello\\\"");
+}
+
+TEST(StringUtilsTest, EscapeJsonBackslash) {
+    EXPECT_EQ(string_utils::escape_json("path\\to\\file"), "path\\\\to\\\\file");
+}
+
+TEST(StringUtilsTest, EscapeJsonSlash) {
+    EXPECT_EQ(string_utils::escape_json("a/b"), "a\\/b");
+}
+
+TEST(StringUtilsTest, EscapeJsonControlChars) {
+    EXPECT_EQ(string_utils::escape_json("line1\nline2"), "line1\\nline2");
+    EXPECT_EQ(string_utils::escape_json("col1\tcol2"), "col1\\tcol2");
+    EXPECT_EQ(string_utils::escape_json("a\rb"), "a\\rb");
+    EXPECT_EQ(string_utils::escape_json("a\bb"), "a\\bb");
+    EXPECT_EQ(string_utils::escape_json("a\fb"), "a\\fb");
+}
+
+TEST(StringUtilsTest, EscapeJsonUnicodeControlChars) {
+    // Control character 0x01 should be escaped as \u0001
+    std::string input(1, '\x01');
+    std::string result = string_utils::escape_json(input);
+    EXPECT_NE(result.find("\\u"), std::string::npos);
+}
+
+TEST(StringUtilsTest, EscapeJsonEmptyString) {
+    EXPECT_EQ(string_utils::escape_json(""), "");
+}
+
+TEST(StringUtilsTest, EscapeJsonPlainText) {
+    EXPECT_EQ(string_utils::escape_json("hello world"), "hello world");
+}
+
+// =============================================================================
+// escape_xml
+// =============================================================================
+
+TEST(StringUtilsTest, EscapeXmlAmpersand) {
+    EXPECT_EQ(string_utils::escape_xml("a&b"), "a&amp;b");
+}
+
+TEST(StringUtilsTest, EscapeXmlAngleBrackets) {
+    EXPECT_EQ(string_utils::escape_xml("<tag>"), "&lt;tag&gt;");
+}
+
+TEST(StringUtilsTest, EscapeXmlQuotes) {
+    EXPECT_EQ(string_utils::escape_xml("say \"hi\""), "say &quot;hi&quot;");
+}
+
+TEST(StringUtilsTest, EscapeXmlApostrophe) {
+    EXPECT_EQ(string_utils::escape_xml("it's"), "it&apos;s");
+}
+
+TEST(StringUtilsTest, EscapeXmlPlainText) {
+    EXPECT_EQ(string_utils::escape_xml("hello"), "hello");
+}
+
+TEST(StringUtilsTest, EscapeXmlEmpty) {
+    EXPECT_EQ(string_utils::escape_xml(""), "");
+}
+
+// =============================================================================
+// extract_filename
+// =============================================================================
+
+TEST(StringUtilsTest, ExtractFilenameFromUnixPath) {
+    EXPECT_EQ(string_utils::extract_filename("/path/to/file.cpp"), "file.cpp");
+}
+
+TEST(StringUtilsTest, ExtractFilenameFromWindowsPath) {
+    EXPECT_EQ(string_utils::extract_filename("C:\\path\\to\\file.cpp"), "file.cpp");
+}
+
+TEST(StringUtilsTest, ExtractFilenameNoPath) {
+    EXPECT_EQ(string_utils::extract_filename("file.cpp"), "file.cpp");
+}
+
+TEST(StringUtilsTest, ExtractFilenameEmpty) {
+    EXPECT_EQ(string_utils::extract_filename(""), "");
+}
+
+TEST(StringUtilsTest, ExtractFilenameTrailingSlash) {
+    // Edge case: trailing slash returns empty substring after last separator
+    EXPECT_EQ(string_utils::extract_filename("/path/to/"), "");
+}
+
+// =============================================================================
+// trim
+// =============================================================================
+
+TEST(StringUtilsTest, TrimBothSides) {
+    EXPECT_EQ(string_utils::trim("  hello  "), "hello");
+}
+
+TEST(StringUtilsTest, TrimLeading) {
+    EXPECT_EQ(string_utils::trim("  hello"), "hello");
+}
+
+TEST(StringUtilsTest, TrimTrailing) {
+    EXPECT_EQ(string_utils::trim("hello  "), "hello");
+}
+
+TEST(StringUtilsTest, TrimTabs) {
+    EXPECT_EQ(string_utils::trim("\thello\t"), "hello");
+}
+
+TEST(StringUtilsTest, TrimNewlines) {
+    EXPECT_EQ(string_utils::trim("\nhello\n"), "hello");
+}
+
+TEST(StringUtilsTest, TrimEmpty) {
+    EXPECT_EQ(string_utils::trim(""), "");
+}
+
+TEST(StringUtilsTest, TrimOnlyWhitespace) {
+    EXPECT_EQ(string_utils::trim("   "), "");
+}
+
+TEST(StringUtilsTest, TrimNoWhitespace) {
+    EXPECT_EQ(string_utils::trim("hello"), "hello");
+}
+
+// =============================================================================
+// to_lower
+// =============================================================================
+
+TEST(StringUtilsTest, ToLowerMixed) {
+    EXPECT_EQ(string_utils::to_lower("Hello World"), "hello world");
+}
+
+TEST(StringUtilsTest, ToLowerAllUpper) {
+    EXPECT_EQ(string_utils::to_lower("HELLO"), "hello");
+}
+
+TEST(StringUtilsTest, ToLowerAlreadyLower) {
+    EXPECT_EQ(string_utils::to_lower("hello"), "hello");
+}
+
+TEST(StringUtilsTest, ToLowerEmpty) {
+    EXPECT_EQ(string_utils::to_lower(""), "");
+}
+
+TEST(StringUtilsTest, ToLowerWithNumbers) {
+    EXPECT_EQ(string_utils::to_lower("ABC123"), "abc123");
+}
+
+// =============================================================================
+// to_upper
+// =============================================================================
+
+TEST(StringUtilsTest, ToUpperMixed) {
+    EXPECT_EQ(string_utils::to_upper("Hello World"), "HELLO WORLD");
+}
+
+TEST(StringUtilsTest, ToUpperAlreadyUpper) {
+    EXPECT_EQ(string_utils::to_upper("HELLO"), "HELLO");
+}
+
+TEST(StringUtilsTest, ToUpperAllLower) {
+    EXPECT_EQ(string_utils::to_upper("hello"), "HELLO");
+}
+
+TEST(StringUtilsTest, ToUpperEmpty) {
+    EXPECT_EQ(string_utils::to_upper(""), "");
+}
+
+// =============================================================================
+// replace_all
+// =============================================================================
+
+TEST(StringUtilsTest, ReplaceAllSingle) {
+    EXPECT_EQ(string_utils::replace_all("hello world", "world", "earth"), "hello earth");
+}
+
+TEST(StringUtilsTest, ReplaceAllMultiple) {
+    EXPECT_EQ(string_utils::replace_all("aaa", "a", "bb"), "bbbbbb");
+}
+
+TEST(StringUtilsTest, ReplaceAllNoMatch) {
+    EXPECT_EQ(string_utils::replace_all("hello", "xyz", "abc"), "hello");
+}
+
+TEST(StringUtilsTest, ReplaceAllEmptyFrom) {
+    EXPECT_EQ(string_utils::replace_all("hello", "", "x"), "hello");
+}
+
+TEST(StringUtilsTest, ReplaceAllEmptyTo) {
+    EXPECT_EQ(string_utils::replace_all("hello world", "world", ""), "hello ");
+}
+
+TEST(StringUtilsTest, ReplaceAllEmptyString) {
+    EXPECT_EQ(string_utils::replace_all("", "a", "b"), "");
+}

--- a/tests/unit/utils_test/time_utils_test.cpp
+++ b/tests/unit/utils_test/time_utils_test.cpp
@@ -1,0 +1,179 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file time_utils_test.cpp
+ * @brief Unit tests for time utility functions
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/utils/time_utils.h>
+
+#include <chrono>
+#include <regex>
+#include <string>
+
+using namespace kcenon::logger::utils;
+
+// =============================================================================
+// format_timestamp
+// =============================================================================
+
+TEST(TimeUtilsTest, FormatTimestampHasExpectedFormat) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_timestamp(now);
+
+    // Pattern: YYYY-MM-DD HH:MM:SS.mmm
+    std::regex pattern(R"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})");
+    EXPECT_TRUE(std::regex_match(result, pattern))
+        << "Timestamp format mismatch: " << result;
+}
+
+TEST(TimeUtilsTest, FormatTimestampNotEmpty) {
+    auto now = std::chrono::system_clock::now();
+    EXPECT_FALSE(time_utils::format_timestamp(now).empty());
+}
+
+TEST(TimeUtilsTest, FormatTimestampEpoch) {
+    auto epoch = std::chrono::system_clock::time_point{};
+    auto result = time_utils::format_timestamp(epoch);
+    // Should produce a valid timestamp string even for epoch
+    EXPECT_FALSE(result.empty());
+}
+
+// =============================================================================
+// format_iso8601
+// =============================================================================
+
+TEST(TimeUtilsTest, FormatISO8601HasExpectedFormat) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_iso8601(now);
+
+    // Pattern: YYYY-MM-DDTHH:MM:SS.mmmZ
+    std::regex pattern(R"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)");
+    EXPECT_TRUE(std::regex_match(result, pattern))
+        << "ISO 8601 format mismatch: " << result;
+}
+
+TEST(TimeUtilsTest, FormatISO8601EndsWithZ) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_iso8601(now);
+    EXPECT_EQ(result.back(), 'Z');
+}
+
+TEST(TimeUtilsTest, FormatISO8601ContainsT) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_iso8601(now);
+    EXPECT_NE(result.find('T'), std::string::npos);
+}
+
+// =============================================================================
+// format_compact
+// =============================================================================
+
+TEST(TimeUtilsTest, FormatCompactHasExpectedFormat) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_compact(now);
+
+    // Pattern: YYYYMMDDHHMMSSmmm (17 digits)
+    std::regex pattern(R"(\d{17})");
+    EXPECT_TRUE(std::regex_match(result, pattern))
+        << "Compact format mismatch: " << result;
+}
+
+TEST(TimeUtilsTest, FormatCompactLength) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_compact(now);
+    EXPECT_EQ(result.length(), 17u);
+}
+
+// =============================================================================
+// format_for_rotation
+// =============================================================================
+
+TEST(TimeUtilsTest, FormatForRotationDateOnly) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_for_rotation(now, false);
+
+    // Pattern: YYYYMMDD (8 digits)
+    std::regex pattern(R"(\d{8})");
+    EXPECT_TRUE(std::regex_match(result, pattern))
+        << "Rotation date format mismatch: " << result;
+    EXPECT_EQ(result.length(), 8u);
+}
+
+TEST(TimeUtilsTest, FormatForRotationWithHour) {
+    auto now = std::chrono::system_clock::now();
+    auto result = time_utils::format_for_rotation(now, true);
+
+    // Pattern: YYYYMMDD_HH
+    std::regex pattern(R"(\d{8}_\d{2})");
+    EXPECT_TRUE(std::regex_match(result, pattern))
+        << "Rotation date+hour format mismatch: " << result;
+    EXPECT_EQ(result.length(), 11u);
+}
+
+// =============================================================================
+// now()
+// =============================================================================
+
+TEST(TimeUtilsTest, NowReturnsReasonableTime) {
+    auto before = std::chrono::system_clock::now();
+    auto result = time_utils::now();
+    auto after = std::chrono::system_clock::now();
+
+    EXPECT_GE(result, before);
+    EXPECT_LE(result, after);
+}
+
+// =============================================================================
+// Consistency checks
+// =============================================================================
+
+TEST(TimeUtilsTest, DifferentFormatsForSameTimepoint) {
+    auto tp = std::chrono::system_clock::now();
+
+    auto timestamp = time_utils::format_timestamp(tp);
+    auto iso8601 = time_utils::format_iso8601(tp);
+    auto compact = time_utils::format_compact(tp);
+
+    // All should be non-empty
+    EXPECT_FALSE(timestamp.empty());
+    EXPECT_FALSE(iso8601.empty());
+    EXPECT_FALSE(compact.empty());
+
+    // They should have different formats
+    EXPECT_NE(timestamp, iso8601);
+    EXPECT_NE(iso8601, compact);
+}

--- a/tests/unit/writers_test/writer_category_test.cpp
+++ b/tests/unit/writers_test/writer_category_test.cpp
@@ -1,0 +1,187 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file writer_category_test.cpp
+ * @brief Unit tests for writer category type traits and to_string
+ * @since 4.0.0
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/interfaces/writer_category.h>
+#include <kcenon/logger/interfaces/log_writer_interface.h>
+
+#include <string>
+
+using namespace kcenon::logger;
+
+// =============================================================================
+// Tag constants
+// =============================================================================
+
+TEST(WriterCategoryTest, SyncTagCategory) {
+    EXPECT_EQ(sync_writer_tag::category, writer_category::synchronous);
+}
+
+TEST(WriterCategoryTest, AsyncTagCategory) {
+    EXPECT_EQ(async_writer_tag::category, writer_category::asynchronous);
+}
+
+TEST(WriterCategoryTest, DecoratorTagCategory) {
+    EXPECT_EQ(decorator_writer_tag::category, writer_category::decorator);
+}
+
+TEST(WriterCategoryTest, CompositeTagCategory) {
+    EXPECT_EQ(composite_writer_tag::category, writer_category::composite);
+}
+
+// =============================================================================
+// to_string
+// =============================================================================
+
+TEST(WriterCategoryTest, ToStringSynchronous) {
+    EXPECT_STREQ(to_string(writer_category::synchronous), "synchronous");
+}
+
+TEST(WriterCategoryTest, ToStringAsynchronous) {
+    EXPECT_STREQ(to_string(writer_category::asynchronous), "asynchronous");
+}
+
+TEST(WriterCategoryTest, ToStringDecorator) {
+    EXPECT_STREQ(to_string(writer_category::decorator), "decorator");
+}
+
+TEST(WriterCategoryTest, ToStringComposite) {
+    EXPECT_STREQ(to_string(writer_category::composite), "composite");
+}
+
+// =============================================================================
+// Type traits
+// =============================================================================
+
+namespace {
+
+// Test classes with different tags
+class test_sync_writer : public log_writer_interface, public sync_writer_tag {
+public:
+    kcenon::common::VoidResult write(const log_entry&) override { return kcenon::common::ok(); }
+    kcenon::common::VoidResult flush() override { return kcenon::common::ok(); }
+    std::string get_name() const override { return "test_sync"; }
+    bool is_healthy() const override { return true; }
+};
+
+class test_async_writer : public log_writer_interface, public async_writer_tag {
+public:
+    kcenon::common::VoidResult write(const log_entry&) override { return kcenon::common::ok(); }
+    kcenon::common::VoidResult flush() override { return kcenon::common::ok(); }
+    std::string get_name() const override { return "test_async"; }
+    bool is_healthy() const override { return true; }
+};
+
+class test_decorator_writer : public log_writer_interface, public decorator_writer_tag {
+public:
+    kcenon::common::VoidResult write(const log_entry&) override { return kcenon::common::ok(); }
+    kcenon::common::VoidResult flush() override { return kcenon::common::ok(); }
+    std::string get_name() const override { return "test_decorator"; }
+    bool is_healthy() const override { return true; }
+};
+
+class test_composite_writer : public log_writer_interface, public composite_writer_tag {
+public:
+    kcenon::common::VoidResult write(const log_entry&) override { return kcenon::common::ok(); }
+    kcenon::common::VoidResult flush() override { return kcenon::common::ok(); }
+    std::string get_name() const override { return "test_composite"; }
+    bool is_healthy() const override { return true; }
+};
+
+class test_untagged_writer : public log_writer_interface {
+public:
+    kcenon::common::VoidResult write(const log_entry&) override { return kcenon::common::ok(); }
+    kcenon::common::VoidResult flush() override { return kcenon::common::ok(); }
+    std::string get_name() const override { return "test_untagged"; }
+    bool is_healthy() const override { return true; }
+};
+
+} // namespace
+
+TEST(WriterCategoryTest, IsSyncWriterTrait) {
+    EXPECT_TRUE(is_sync_writer_v<test_sync_writer>);
+    EXPECT_FALSE(is_sync_writer_v<test_async_writer>);
+    EXPECT_FALSE(is_sync_writer_v<test_decorator_writer>);
+    EXPECT_FALSE(is_sync_writer_v<test_composite_writer>);
+}
+
+TEST(WriterCategoryTest, IsAsyncWriterTrait) {
+    EXPECT_FALSE(is_async_writer_v<test_sync_writer>);
+    EXPECT_TRUE(is_async_writer_v<test_async_writer>);
+    EXPECT_FALSE(is_async_writer_v<test_decorator_writer>);
+    EXPECT_FALSE(is_async_writer_v<test_composite_writer>);
+}
+
+TEST(WriterCategoryTest, IsDecoratorWriterTrait) {
+    EXPECT_FALSE(is_decorator_writer_v<test_sync_writer>);
+    EXPECT_FALSE(is_decorator_writer_v<test_async_writer>);
+    EXPECT_TRUE(is_decorator_writer_v<test_decorator_writer>);
+    EXPECT_FALSE(is_decorator_writer_v<test_composite_writer>);
+}
+
+TEST(WriterCategoryTest, IsCompositeWriterTrait) {
+    EXPECT_FALSE(is_composite_writer_v<test_sync_writer>);
+    EXPECT_FALSE(is_composite_writer_v<test_async_writer>);
+    EXPECT_FALSE(is_composite_writer_v<test_decorator_writer>);
+    EXPECT_TRUE(is_composite_writer_v<test_composite_writer>);
+}
+
+// =============================================================================
+// get_writer_category
+// =============================================================================
+
+TEST(WriterCategoryTest, GetWriterCategorySync) {
+    EXPECT_EQ(get_writer_category<test_sync_writer>(), writer_category::synchronous);
+}
+
+TEST(WriterCategoryTest, GetWriterCategoryAsync) {
+    EXPECT_EQ(get_writer_category<test_async_writer>(), writer_category::asynchronous);
+}
+
+TEST(WriterCategoryTest, GetWriterCategoryDecorator) {
+    EXPECT_EQ(get_writer_category<test_decorator_writer>(), writer_category::decorator);
+}
+
+TEST(WriterCategoryTest, GetWriterCategoryComposite) {
+    EXPECT_EQ(get_writer_category<test_composite_writer>(), writer_category::composite);
+}
+
+TEST(WriterCategoryTest, GetWriterCategoryUntagged) {
+    EXPECT_EQ(get_writer_category<test_untagged_writer>(), writer_category::synchronous);
+}


### PR DESCRIPTION
Closes #566

## Summary
- Add 231 new unit tests across 8 test files targeting previously untested code
- **Utils tests** (79 tests): string_utils (JSON/XML escaping, trim, case conversion, replace_all), time_utils (all timestamp formats), file_utils (path validation, filename sanitization, temp filenames)
- **Formatter tests** (46 tests): json_formatter, logfmt_formatter, template_formatter, timestamp_formatter - covering format output, options, structured fields, OTel context
- **Filter tests** (48 tests): level_filter, exact_level_filter, regex_filter, composite_filter (AND/OR), function_filter, field_exists_filter, field_value_filter, field_range_filter, field_regex_filter, category_filter
- **Error codes tests** (26 tests): logger_error_to_string for all error categories, make_logger_void_result/success helpers, result<T> wrapper
- **Security tests** (15 tests): path_validator (is_safe_filename, sanitize_filename, validate, safe_join)
- **Writer category tests** (17 tests): type traits, tag constants, to_string, get_writer_category
- Raise codecov project target from 55% to 65% to reflect improved baseline

## Test Plan
- [x] All 231 new tests pass locally (macOS, GCC/Clang)
- [ ] All new tests pass in CI (Ubuntu)
- [ ] Coverage percentage increases toward 80%+ target
- [ ] No existing tests broken