### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-API-001"
+doc_title: "API 레퍼런스"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "API"
+---
+
 > **Language:** [English](API_REFERENCE.md) | **한국어**
 
 # API 레퍼런스

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-API-002"
+doc_title: "API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "API"
+---
+
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)
 
 # API Reference

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-001"
+doc_title: "Logger System 아키텍처"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 > **Language:** [English](ARCHITECTURE.md) | **한국어**
 
 # Logger System 아키텍처

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-002"
+doc_title: "Logger System Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 # Logger System Architecture

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-001"
+doc_title: "Logger System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 # Logger System 성능 벤치마크
 
 **언어:** [English](BENCHMARKS.md) | **한국어**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-002"
+doc_title: "Logger System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 # Logger System Performance Benchmarks
 
 **Last Updated**: 2025-11-15

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-001"
+doc_title: "변경 이력 - Logger System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 # 변경 이력 - Logger System
 
 > **언어:** [English](CHANGELOG.md) | **한국어**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-002"
+doc_title: "Changelog - Logger System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 # Changelog - Logger System
 
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)

--- a/docs/CONFIGURATION_STRATEGIES.md
+++ b/docs/CONFIGURATION_STRATEGIES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-001"
+doc_title: "Configuration Strategies Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Configuration Strategies Guide
 
 **logger_system Configuration Strategies** (`include/kcenon/logger/core/strategies/`)

--- a/docs/DEPENDENCY_ARCHITECTURE.md
+++ b/docs/DEPENDENCY_ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-003"
+doc_title: "Dependency Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 # Dependency Architecture
 
 ## Overview

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-FEAT-001"
+doc_title: "Logger System - 상세 기능"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "FEAT"
+---
+
 # Logger System - 상세 기능
 
 **언어:** [English](README.md) | **한국어**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-FEAT-002"
+doc_title: "Logger System Features"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "FEAT"
+---
+
 # Logger System Features
 
 **Last Updated**: 2026-02-08

--- a/docs/LOG_SERVER_AND_CRASH_SAFETY.md
+++ b/docs/LOG_SERVER_AND_CRASH_SAFETY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-002"
+doc_title: "Log Server and Crash-Safe Logger"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Log Server and Crash-Safe Logger
 
 > **Version**: 1.0.0

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-QUAL-001"
+doc_title: "Logger System 프로덕션 품질"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "QUAL"
+---
+
 # Logger System 프로덕션 품질
 
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-QUAL-002"
+doc_title: "Logger System Production Quality"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "QUAL"
+---
+
 # Logger System Production Quality
 
 **Last Updated**: 2025-11-15

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-003"
+doc_title: "Logger System 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 # Logger System 프로젝트 구조
 
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-004"
+doc_title: "Logger System Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 # Logger System Project Structure
 
 **Last Updated**: 2026-02-08

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-003"
+doc_title: "Logger System 문서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** [English](README.md) | **한국어**
 
 # Logger System 문서

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-004"
+doc_title: "Logger System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](README.kr.md)
 
 # Logger System Documentation

--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-SECU-001"
+doc_title: "Security Module Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "SECU"
+---
+
 # Security Module Guide
 
 **logger_system Security Module** (`include/kcenon/logger/security/`)

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-005"
+doc_title: "SOUP List &mdash; logger_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; logger_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/WRITER_GUIDE.md
+++ b/docs/WRITER_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-005"
+doc_title: "Writer Composition and Decorator Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Writer Composition and Decorator Guide
 
 **logger_system Writer Framework** (`include/kcenon/logger/writers/`)

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-004"
+doc_title: "Architecture - Logger System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 # Architecture - Logger System
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/advanced/ASYNC_WRITERS.kr.md
+++ b/docs/advanced/ASYNC_WRITERS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-006"
+doc_title: "비동기 Writer 구현체 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # 비동기 Writer 구현체 가이드
 
 > **Language:** [English](ASYNC_WRITERS.md) | **한국어**

--- a/docs/advanced/ASYNC_WRITERS.md
+++ b/docs/advanced/ASYNC_WRITERS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-007"
+doc_title: "Asynchronous Writer Implementations Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Asynchronous Writer Implementations Guide
 
 > **Language:** **English** | [한국어](ASYNC_WRITERS.kr.md)

--- a/docs/advanced/CI_CD_DASHBOARD.kr.md
+++ b/docs/advanced/CI_CD_DASHBOARD.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-006"
+doc_title: "Logger System CI/CD 대시보드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 > **Language:** [English](CI_CD_DASHBOARD.md) | **한국어**
 
 # Logger System CI/CD 대시보드

--- a/docs/advanced/CI_CD_DASHBOARD.md
+++ b/docs/advanced/CI_CD_DASHBOARD.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-007"
+doc_title: "Logger System CI/CD Dashboard"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 > **Language:** **English** | [한국어](CI_CD_DASHBOARD.kr.md)
 
 # Logger System CI/CD Dashboard

--- a/docs/advanced/CONDITIONAL_COMPILATION_REFACTORING.md
+++ b/docs/advanced/CONDITIONAL_COMPILATION_REFACTORING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-005"
+doc_title: "Conditional Compilation Refactoring Strategy"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 # Conditional Compilation Refactoring Strategy
 
 **Version**: 0.1.0.0

--- a/docs/advanced/CRITICAL_LOGGING_QUICK_START.kr.md
+++ b/docs/advanced/CRITICAL_LOGGING_QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-008"
+doc_title: "크리티컬 로깅 빠른 시작"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** [English](CRITICAL_LOGGING_QUICK_START.md) | **한국어**
 
 # 크리티컬 로깅 빠른 시작

--- a/docs/advanced/CRITICAL_LOGGING_QUICK_START.md
+++ b/docs/advanced/CRITICAL_LOGGING_QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-009"
+doc_title: "Critical Logging Quick Start"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](CRITICAL_LOGGING_QUICK_START.kr.md)
 
 ## Table of Contents

--- a/docs/advanced/CRITICAL_LOG_PREVENTION.kr.md
+++ b/docs/advanced/CRITICAL_LOG_PREVENTION.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-010"
+doc_title: "크리티컬 로그 손실 방지 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** [English](CRITICAL_LOG_PREVENTION.md) | **한국어**
 
 # 크리티컬 로그 손실 방지 가이드

--- a/docs/advanced/CRITICAL_LOG_PREVENTION.md
+++ b/docs/advanced/CRITICAL_LOG_PREVENTION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-011"
+doc_title: "Critical Log Loss Prevention Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](CRITICAL_LOG_PREVENTION.kr.md)
 
 ## Table of Contents

--- a/docs/advanced/CUSTOM_WRITERS.kr.md
+++ b/docs/advanced/CUSTOM_WRITERS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-012"
+doc_title: "커스텀 작성기 생성"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** [English](CUSTOM_WRITERS.md) | **한국어**
 
 # 커스텀 작성기 생성

--- a/docs/advanced/CUSTOM_WRITERS.md
+++ b/docs/advanced/CUSTOM_WRITERS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-013"
+doc_title: "Creating Custom Writers"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](CUSTOM_WRITERS.kr.md)
 
 # Creating Custom Writers

--- a/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.kr.md
+++ b/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-006"
+doc_title: "로거 시스템 아키텍처"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 > **Language:** [English](LOGGER_SYSTEM_ARCHITECTURE.md) | **한국어**
 
 # 로거 시스템 아키텍처

--- a/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.md
+++ b/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-007"
+doc_title: "Logger System Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 > **Language:** **English** | [한국어](LOGGER_SYSTEM_ARCHITECTURE.kr.md)
 
 # Logger System Architecture

--- a/docs/advanced/LOG_LEVEL_SEMANTIC_STANDARD.md
+++ b/docs/advanced/LOG_LEVEL_SEMANTIC_STANDARD.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-014"
+doc_title: "Log Level Semantic Standard"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Log Level Semantic Standard
 
 **Date**: 2025-11-08

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-MIGR-001"
+doc_title: "Migration Guide - Logger System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "MIGR"
+---
+
 # Migration Guide - Logger System
 
 > **Language:** **English** | [한국어](MIGRATION.kr.md)

--- a/docs/advanced/STRUCTURE.kr.md
+++ b/docs/advanced/STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-008"
+doc_title: "Logger System - 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 # Logger System - 프로젝트 구조
 
 **[English](STRUCTURE.md) | 한국어**

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-ARCH-009"
+doc_title: "Logger System - Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "ARCH"
+---
+
 # Logger System - Project Structure
 
 **English | [한국어](STRUCTURE.kr.md)**

--- a/docs/advanced/WRITER_HIERARCHY.md
+++ b/docs/advanced/WRITER_HIERARCHY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-015"
+doc_title: "Writer Hierarchy and Categories"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](WRITER_HIERARCHY.kr.md)
 
 # Writer Hierarchy and Categories

--- a/docs/advanced/WRITER_SELECTION_GUIDE.md
+++ b/docs/advanced/WRITER_SELECTION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-016"
+doc_title: "Writer Selection Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](WRITER_SELECTION_GUIDE.kr.md)
 
 # Writer Selection Guide

--- a/docs/contributing/CONTRIBUTING.kr.md
+++ b/docs/contributing/CONTRIBUTING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-008"
+doc_title: "Logger System 기여하기"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 > **Language:** [English](CONTRIBUTING.md) | **한국어**
 
 # Logger System 기여하기

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-009"
+doc_title: "Contributing to Logger System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 > **Language:** **English** | [한국어](CONTRIBUTING.kr.md)
 
 # Contributing to Logger System

--- a/docs/contributing/TESTING_GUIDE.md
+++ b/docs/contributing/TESTING_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-QUAL-003"
+doc_title: "Testing Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "QUAL"
+---
+
 ## Test Coverage
 
 To enable code coverage measurement:

--- a/docs/contributing/TRANSLATION_SUMMARY.md
+++ b/docs/contributing/TRANSLATION_SUMMARY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PROJ-010"
+doc_title: "Korean Translation Summary"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PROJ"
+---
+
 # Korean Translation Summary
 
 **Date**: 2025-10-20 (Asia/Seoul)

--- a/docs/guides/BEST_PRACTICES.kr.md
+++ b/docs/guides/BEST_PRACTICES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-017"
+doc_title: "Logger System 모범 사례 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** [English](BEST_PRACTICES.md) | **한국어**
 
 # Logger System 모범 사례 가이드

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-018"
+doc_title: "Logger System Best Practices Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](BEST_PRACTICES.kr.md)
 
 # Logger System Best Practices Guide

--- a/docs/guides/DECORATOR_MIGRATION.md
+++ b/docs/guides/DECORATOR_MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-MIGR-002"
+doc_title: "Decorator Pattern Writer Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "MIGR"
+---
+
 # Decorator Pattern Writer Migration Guide
 
 **Version**: 0.4.0.0

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-019"
+doc_title: "Logger System - Frequently Asked Questions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Logger System - Frequently Asked Questions
 
 > **Version:** 0.1.0

--- a/docs/guides/GETTING_STARTED.kr.md
+++ b/docs/guides/GETTING_STARTED.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-020"
+doc_title: "Logger System 시작하기"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** [English](GETTING_STARTED.md) | **한국어**
 
 # Logger System 시작하기

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-021"
+doc_title: "Getting Started with Logger System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 > **Language:** **English** | [한국어](GETTING_STARTED.kr.md)
 
 # Getting Started with Logger System

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-INTR-001"
+doc_title: "Logger System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "INTR"
+---
+
 # Logger System Integration Guide
 
 **English | [한국어](INTEGRATION.kr.md)**

--- a/docs/guides/MIGRATION_GUIDE.kr.md
+++ b/docs/guides/MIGRATION_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-MIGR-003"
+doc_title: "로거 시스템 마이그레이션 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "MIGR"
+---
+
 > **Language:** [English](MIGRATION_GUIDE.md) | **한국어**
 
 # 로거 시스템 마이그레이션 가이드

--- a/docs/guides/MIGRATION_GUIDE.md
+++ b/docs/guides/MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-MIGR-004"
+doc_title: "Logger System Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "MIGR"
+---
+
 > **Language:** **English** | [한국어](MIGRATION_GUIDE.kr.md)
 
 # Logger System Migration Guide

--- a/docs/guides/OPENTELEMETRY.md
+++ b/docs/guides/OPENTELEMETRY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-INTR-002"
+doc_title: "OpenTelemetry Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "INTR"
+---
+
 # OpenTelemetry Integration Guide
 
 > **Version**: 0.3.0.0+

--- a/docs/guides/PERFORMANCE.kr.md
+++ b/docs/guides/PERFORMANCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-003"
+doc_title: "Logger System 성능 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 > **Language:** [English](PERFORMANCE.md) | **한국어**
 
 # Logger System 성능 가이드

--- a/docs/guides/PERFORMANCE.md
+++ b/docs/guides/PERFORMANCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-004"
+doc_title: "Logger System Performance Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 > **Language:** **English** | [한국어](PERFORMANCE.kr.md)
 
 # Logger System Performance Guide

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-022"
+doc_title: "빠른 시작 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # 빠른 시작 가이드
 
 > **Language:** [English](QUICK_START.md) | **한국어**

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-023"
+doc_title: "Quick Start Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Quick Start Guide
 
 > **Language:** **English** | [한국어](QUICK_START.kr.md)

--- a/docs/guides/SECURITY.kr.md
+++ b/docs/guides/SECURITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-SECU-002"
+doc_title: "보안 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "SECU"
+---
+
 > **Language:** [English](SECURITY.md) | **한국어**
 
 # 보안 가이드

--- a/docs/guides/SECURITY.md
+++ b/docs/guides/SECURITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-SECU-003"
+doc_title: "Security Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "SECU"
+---
+
 > **Language:** **English** | [한국어](SECURITY.kr.md)
 
 # Security Guide

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-024"
+doc_title: "Logger System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Logger System Integration Guide
 
 ## Overview

--- a/docs/integration/THREAD_SYSTEM.kr.md
+++ b/docs/integration/THREAD_SYSTEM.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-025"
+doc_title: "thread_system 통합 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # thread_system 통합 가이드
 
 > **Language:** [English](THREAD_SYSTEM.md) | **한국어**

--- a/docs/integration/THREAD_SYSTEM.md
+++ b/docs/integration/THREAD_SYSTEM.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-GUID-026"
+doc_title: "Async Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
 # Async Integration Guide
 
 > **Language:** **English** | [한국어](THREAD_SYSTEM.kr.md)

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-005"
+doc_title: "Logger System - 성능 기준 메트릭"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 # Logger System - 성능 기준 메트릭
 
 **[English](BASELINE.md) | 한국어**

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-006"
+doc_title: "Logger System - Performance Baseline Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 # Logger System - Performance Baseline Metrics
 
 **English | [한국어](BASELINE.kr.md)**

--- a/docs/performance/CI_CD_PERFORMANCE_PROPOSAL.md
+++ b/docs/performance/CI_CD_PERFORMANCE_PROPOSAL.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-007"
+doc_title: "CI/CD 성능 지표 자동화 제안서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 # CI/CD 성능 지표 자동화 제안서
 
 **문서 버전:** 1.0

--- a/docs/performance/DECORATOR_PERFORMANCE.md
+++ b/docs/performance/DECORATOR_PERFORMANCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "LOG-PERF-008"
+doc_title: "Decorator Pattern Performance Characteristics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "logger_system"
+category: "PERF"
+---
+
 # Decorator Pattern Performance Characteristics
 
 ## Overview


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 69 markdown files in `docs/`
- Each file gets a unique `doc_id` (`LOG-{CATEGORY}-{NNN}`), title, version, date, status, project, and category

## Category Breakdown (69 files)
| Category | Count | Description |
|----------|-------|-------------|
| API | 2 | API Reference |
| ARCH | 9 | Architecture |
| FEAT | 2 | Features |
| GUID | 26 | User Guides |
| INTR | 2 | Integration |
| MIGR | 4 | Migration |
| PERF | 8 | Performance |
| PROJ | 10 | Project Info |
| QUAL | 3 | Quality |
| SECU | 3 | Security |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)