### PR TITLE
docs: add SSOT documentation registry

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -12,6 +12,8 @@ category: "API"
 
 # API 레퍼런스
 
+> **SSOT**: This document is the single source of truth for **API 레퍼런스**.
+
 **버전**: 3.0.0
 **최종 업데이트**: 2025-12-10
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -12,6 +12,8 @@ category: "API"
 
 # API Reference
 
+> **SSOT**: This document is the single source of truth for **API Reference**.
+
 **Version**: 0.5.0.0
 **Last Updated**: 2026-02-08
 

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -12,6 +12,8 @@ category: "ARCH"
 
 # Logger System 아키텍처
 
+> **SSOT**: This document is the single source of truth for **Logger System 아키텍처**.
+
 **버전**: 0.4.0
 **최종 업데이트**: 2026-02-08
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,8 @@ category: "ARCH"
 
 # Logger System Architecture
 
+> **SSOT**: This document is the single source of truth for **Logger System Architecture**.
+
 **Version**: 0.4.0.0
 **Last Updated**: 2026-02-08
 

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Logger System 성능 벤치마크
 
+> **SSOT**: This document is the single source of truth for **Logger System 성능 벤치마크**.
+
 **언어:** [English](BENCHMARKS.md) | **한국어**
 
 **최종 업데이트**: 2025-11-28

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Logger System Performance Benchmarks
 
+> **SSOT**: This document is the single source of truth for **Logger System Performance Benchmarks**.
+
 **Last Updated**: 2025-11-15
 **Version**: 0.3.0.0
 

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 변경 이력 - Logger System
 
+> **SSOT**: This document is the single source of truth for **변경 이력 - Logger System**.
+
 > **언어:** [English](CHANGELOG.md) | **한국어**
 
 Logger System 프로젝트의 모든 주요 변경 사항이 이 파일에 문서화됩니다.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Changelog - Logger System
 
+> **SSOT**: This document is the single source of truth for **Changelog - Logger System**.
+
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)
 
 All notable changes to the Logger System project will be documented in this file.

--- a/docs/CONFIGURATION_STRATEGIES.md
+++ b/docs/CONFIGURATION_STRATEGIES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Configuration Strategies Guide
 
+> **SSOT**: This document is the single source of truth for **Configuration Strategies Guide**.
+
 **logger_system Configuration Strategies** (`include/kcenon/logger/core/strategies/`)
 
 The configuration strategies framework provides a flexible, composable approach to logger configuration using the Strategy Pattern. Strategies allow dynamic adaptation of logger behavior based on environment, performance requirements, or deployment context.

--- a/docs/DEPENDENCY_ARCHITECTURE.md
+++ b/docs/DEPENDENCY_ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Dependency Architecture
 
+> **SSOT**: This document is the single source of truth for **Dependency Architecture**.
+
 ## Overview
 
 logger_system follows a strict unidirectional dependency model using a tiered architecture. The bidirectional dependency risk identified in Issue #252 has been resolved.

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Logger System - 상세 기능
 
+> **SSOT**: This document is the single source of truth for **Logger System - 상세 기능**.
+
 **언어:** [English](README.md) | **한국어**
 
 **최종 업데이트**: 2026-02-08

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Logger System Features
 
+> **SSOT**: This document is the single source of truth for **Logger System Features**.
+
 **Last Updated**: 2026-02-08
 **Version**: 0.4.0.0
 

--- a/docs/LOG_SERVER_AND_CRASH_SAFETY.md
+++ b/docs/LOG_SERVER_AND_CRASH_SAFETY.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Log Server and Crash-Safe Logger
 
+> **SSOT**: This document is the single source of truth for **Log Server and Crash-Safe Logger**.
+
 > **Version**: 1.0.0
 > **Last Updated**: 2025-02-09
 > **Status**: Production Ready

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Logger System 프로덕션 품질
 
+> **SSOT**: This document is the single source of truth for **Logger System 프로덕션 품질**.
+
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**
 
 **최종 업데이트**: 2025-11-28

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Logger System Production Quality
 
+> **SSOT**: This document is the single source of truth for **Logger System Production Quality**.
+
 **Last Updated**: 2025-11-15
 **Version**: 0.3.0.0
 

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Logger System 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Logger System 프로젝트 구조**.
+
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**
 
 **최종 업데이트**: 2025-11-28

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Logger System Project Structure
 
+> **SSOT**: This document is the single source of truth for **Logger System Project Structure**.
+
 **Last Updated**: 2026-02-08
 **Version**: 0.4.0.0
 

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Logger System 문서
 
+> **SSOT**: This document is the single source of truth for **Logger System 문서**.
+
 고성능, 스레드 안전한 C++20 로깅 프레임워크인 Logger System의 종합 문서에 오신 것을 환영합니다.
 
 ## 📚 문서 구조

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 doc_id: "LOG-GUID-004"
-doc_title: "Logger System Documentation"
+doc_title: "Logger System Documentation Registry"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"
 doc_status: "Released"
@@ -8,85 +8,206 @@ project: "logger_system"
 category: "GUID"
 ---
 
-> **Language:** **English** | [한국어](README.kr.md)
+# Logger System — Documentation Registry
 
-# Logger System Documentation
+> **SSOT**: This file is the single source of truth for the documentation index
+> of **logger_system**.
 
-Welcome to the comprehensive documentation for the Logger System - a high-performance, thread-safe C++20 logging framework.
+Total documents: **68**
 
-## 📚 Documentation Structure
+## Document Index
 
-### Core Documentation
-- **[README.md](../README.md)** - Project overview, features, and quick start
-- **[API_REFERENCE.md](API_REFERENCE.md)** - Complete API documentation with examples  
-- **[ARCHITECTURE.md](ARCHITECTURE.md)** - Threading ecosystem architecture
-- **[LOGGER_SYSTEM_ARCHITECTURE.md](LOGGER_SYSTEM_ARCHITECTURE.md)** - Detailed system architecture
-- **[CHANGELOG.md](CHANGELOG.md)** - Version history and release notes
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** - Contribution guidelines
-- **[SECURITY.md](SECURITY.md)** - Security considerations and reporting
+| # | doc_id | Topic | Authority Document | Status |
+|---|--------|-------|-------------------|--------|
+| 1 | LOG-ARCH-001 | Logger System 아키텍처 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| 2 | LOG-ARCH-002 | Logger System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| 3 | LOG-ARCH-003 | Dependency Architecture | [DEPENDENCY_ARCHITECTURE.md](./DEPENDENCY_ARCHITECTURE.md) | Released |
+| 4 | LOG-ARCH-004 | Architecture - Logger System | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| 5 | LOG-ARCH-005 | Conditional Compilation Refactoring Strategy | [CONDITIONAL_COMPILATION_REFACTORING.md](./advanced/CONDITIONAL_COMPILATION_REFACTORING.md) | Released |
+| 6 | LOG-ARCH-006 | 로거 시스템 아키텍처 | [LOGGER_SYSTEM_ARCHITECTURE.kr.md](./advanced/LOGGER_SYSTEM_ARCHITECTURE.kr.md) | Released |
+| 7 | LOG-ARCH-007 | Logger System Architecture | [LOGGER_SYSTEM_ARCHITECTURE.md](./advanced/LOGGER_SYSTEM_ARCHITECTURE.md) | Released |
+| 8 | LOG-ARCH-008 | Logger System - 프로젝트 구조 | [STRUCTURE.kr.md](./advanced/STRUCTURE.kr.md) | Released |
+| 9 | LOG-ARCH-009 | Logger System - Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
+| 10 | LOG-API-001 | API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| 11 | LOG-API-002 | API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| 12 | LOG-FEAT-001 | Logger System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 13 | LOG-FEAT-002 | Logger System Features | [FEATURES.md](./FEATURES.md) | Released |
+| 14 | LOG-GUID-001 | Configuration Strategies Guide | [CONFIGURATION_STRATEGIES.md](./CONFIGURATION_STRATEGIES.md) | Released |
+| 15 | LOG-GUID-002 | Log Server and Crash-Safe Logger | [LOG_SERVER_AND_CRASH_SAFETY.md](./LOG_SERVER_AND_CRASH_SAFETY.md) | Released |
+| 16 | LOG-GUID-003 | Logger System 문서 | [README.kr.md](./README.kr.md) | Released |
+| 17 | LOG-GUID-005 | Writer Composition and Decorator Guide | [WRITER_GUIDE.md](./WRITER_GUIDE.md) | Released |
+| 18 | LOG-GUID-006 | 비동기 Writer 구현체 가이드 | [ASYNC_WRITERS.kr.md](./advanced/ASYNC_WRITERS.kr.md) | Released |
+| 19 | LOG-GUID-007 | Asynchronous Writer Implementations Guide | [ASYNC_WRITERS.md](./advanced/ASYNC_WRITERS.md) | Released |
+| 20 | LOG-GUID-008 | 크리티컬 로깅 빠른 시작 | [CRITICAL_LOGGING_QUICK_START.kr.md](./advanced/CRITICAL_LOGGING_QUICK_START.kr.md) | Released |
+| 21 | LOG-GUID-009 | Critical Logging Quick Start | [CRITICAL_LOGGING_QUICK_START.md](./advanced/CRITICAL_LOGGING_QUICK_START.md) | Released |
+| 22 | LOG-GUID-010 | 크리티컬 로그 손실 방지 가이드 | [CRITICAL_LOG_PREVENTION.kr.md](./advanced/CRITICAL_LOG_PREVENTION.kr.md) | Released |
+| 23 | LOG-GUID-011 | Critical Log Loss Prevention Guide | [CRITICAL_LOG_PREVENTION.md](./advanced/CRITICAL_LOG_PREVENTION.md) | Released |
+| 24 | LOG-GUID-012 | 커스텀 작성기 생성 | [CUSTOM_WRITERS.kr.md](./advanced/CUSTOM_WRITERS.kr.md) | Released |
+| 25 | LOG-GUID-013 | Creating Custom Writers | [CUSTOM_WRITERS.md](./advanced/CUSTOM_WRITERS.md) | Released |
+| 26 | LOG-GUID-014 | Log Level Semantic Standard | [LOG_LEVEL_SEMANTIC_STANDARD.md](./advanced/LOG_LEVEL_SEMANTIC_STANDARD.md) | Released |
+| 27 | LOG-GUID-015 | Writer Hierarchy and Categories | [WRITER_HIERARCHY.md](./advanced/WRITER_HIERARCHY.md) | Released |
+| 28 | LOG-GUID-016 | Writer Selection Guide | [WRITER_SELECTION_GUIDE.md](./advanced/WRITER_SELECTION_GUIDE.md) | Released |
+| 29 | LOG-GUID-017 | Logger System 모범 사례 가이드 | [BEST_PRACTICES.kr.md](./guides/BEST_PRACTICES.kr.md) | Released |
+| 30 | LOG-GUID-018 | Logger System Best Practices Guide | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| 31 | LOG-GUID-019 | Logger System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| 32 | LOG-GUID-020 | Logger System 시작하기 | [GETTING_STARTED.kr.md](./guides/GETTING_STARTED.kr.md) | Released |
+| 33 | LOG-GUID-021 | Getting Started with Logger System | [GETTING_STARTED.md](./guides/GETTING_STARTED.md) | Released |
+| 34 | LOG-GUID-022 | 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| 35 | LOG-GUID-023 | Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| 36 | LOG-GUID-024 | Logger System Integration Guide | [README.md](./integration/README.md) | Released |
+| 37 | LOG-GUID-025 | thread_system 통합 가이드 | [THREAD_SYSTEM.kr.md](./integration/THREAD_SYSTEM.kr.md) | Released |
+| 38 | LOG-GUID-026 | Async Integration Guide | [THREAD_SYSTEM.md](./integration/THREAD_SYSTEM.md) | Released |
+| 39 | LOG-PERF-001 | Logger System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 40 | LOG-PERF-002 | Logger System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 41 | LOG-PERF-003 | Logger System 성능 가이드 | [PERFORMANCE.kr.md](./guides/PERFORMANCE.kr.md) | Released |
+| 42 | LOG-PERF-004 | Logger System Performance Guide | [PERFORMANCE.md](./guides/PERFORMANCE.md) | Released |
+| 43 | LOG-PERF-005 | Logger System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| 44 | LOG-PERF-006 | Logger System - Performance Baseline Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
+| 45 | LOG-PERF-007 | CI/CD 성능 지표 자동화 제안서 | [CI_CD_PERFORMANCE_PROPOSAL.md](./performance/CI_CD_PERFORMANCE_PROPOSAL.md) | Released |
+| 46 | LOG-PERF-008 | Decorator Pattern Performance Characteristics | [DECORATOR_PERFORMANCE.md](./performance/DECORATOR_PERFORMANCE.md) | Released |
+| 47 | LOG-MIGR-001 | Migration Guide - Logger System | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| 48 | LOG-MIGR-002 | Decorator Pattern Writer Migration Guide | [DECORATOR_MIGRATION.md](./guides/DECORATOR_MIGRATION.md) | Released |
+| 49 | LOG-MIGR-003 | 로거 시스템 마이그레이션 가이드 | [MIGRATION_GUIDE.kr.md](./guides/MIGRATION_GUIDE.kr.md) | Released |
+| 50 | LOG-MIGR-004 | Logger System Migration Guide | [MIGRATION_GUIDE.md](./guides/MIGRATION_GUIDE.md) | Released |
+| 51 | LOG-INTR-001 | Logger System Integration Guide | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| 52 | LOG-INTR-002 | OpenTelemetry Integration Guide | [OPENTELEMETRY.md](./guides/OPENTELEMETRY.md) | Released |
+| 53 | LOG-QUAL-001 | Logger System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 54 | LOG-QUAL-002 | Logger System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 55 | LOG-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
+| 56 | LOG-SECU-001 | Security Module Guide | [SECURITY_GUIDE.md](./SECURITY_GUIDE.md) | Released |
+| 57 | LOG-SECU-002 | 보안 가이드 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
+| 58 | LOG-SECU-003 | Security Guide | [SECURITY.md](./guides/SECURITY.md) | Released |
+| 59 | LOG-PROJ-001 | 변경 이력 - Logger System | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 60 | LOG-PROJ-002 | Changelog - Logger System | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 61 | LOG-PROJ-003 | Logger System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 62 | LOG-PROJ-004 | Logger System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 63 | LOG-PROJ-005 | SOUP List &mdash; logger_system | [SOUP.md](./SOUP.md) | Released |
+| 64 | LOG-PROJ-006 | Logger System CI/CD 대시보드 | [CI_CD_DASHBOARD.kr.md](./advanced/CI_CD_DASHBOARD.kr.md) | Released |
+| 65 | LOG-PROJ-007 | Logger System CI/CD Dashboard | [CI_CD_DASHBOARD.md](./advanced/CI_CD_DASHBOARD.md) | Released |
+| 66 | LOG-PROJ-008 | Logger System 기여하기 | [CONTRIBUTING.kr.md](./contributing/CONTRIBUTING.kr.md) | Released |
+| 67 | LOG-PROJ-009 | Contributing to Logger System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 68 | LOG-PROJ-010 | Korean Translation Summary | [TRANSLATION_SUMMARY.md](./contributing/TRANSLATION_SUMMARY.md) | Released |
 
-### Guides (`docs/guides/`)
-Essential guides for getting started and following best practices:
+## Documents by Category
 
-- **[GETTING_STARTED.md](guides/GETTING_STARTED.md)** - Step-by-step setup and basic usage
-- **[BEST_PRACTICES.md](guides/BEST_PRACTICES.md)** - Recommended patterns and best practices
-- **[MIGRATION_GUIDE.md](guides/MIGRATION_GUIDE.md)** - Migrating from older versions  
-- **[PERFORMANCE.md](guides/PERFORMANCE.md)** - Performance analysis and optimization
+### Architecture (9)
 
-### Advanced Topics (`docs/advanced/`)
-Deep-dive documentation for advanced users and contributors:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-ARCH-001 | Logger System 아키텍처 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| LOG-ARCH-002 | Logger System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| LOG-ARCH-003 | Dependency Architecture | [DEPENDENCY_ARCHITECTURE.md](./DEPENDENCY_ARCHITECTURE.md) | Released |
+| LOG-ARCH-004 | Architecture - Logger System | [ARCHITECTURE.md](./advanced/ARCHITECTURE.md) | Released |
+| LOG-ARCH-005 | Conditional Compilation Refactoring Strategy | [CONDITIONAL_COMPILATION_REFACTORING.md](./advanced/CONDITIONAL_COMPILATION_REFACTORING.md) | Released |
+| LOG-ARCH-006 | 로거 시스템 아키텍처 | [LOGGER_SYSTEM_ARCHITECTURE.kr.md](./advanced/LOGGER_SYSTEM_ARCHITECTURE.kr.md) | Released |
+| LOG-ARCH-007 | Logger System Architecture | [LOGGER_SYSTEM_ARCHITECTURE.md](./advanced/LOGGER_SYSTEM_ARCHITECTURE.md) | Released |
+| LOG-ARCH-008 | Logger System - 프로젝트 구조 | [STRUCTURE.kr.md](./advanced/STRUCTURE.kr.md) | Released |
+| LOG-ARCH-009 | Logger System - Project Structure | [STRUCTURE.md](./advanced/STRUCTURE.md) | Released |
 
-- **[CUSTOM_WRITERS.md](advanced/CUSTOM_WRITERS.md)** - Creating custom log writers
-- **[CI_CD_DASHBOARD.md](advanced/CI_CD_DASHBOARD.md)** - Build and continuous integration
+### API Reference (2)
 
-## 🚀 Quick Navigation
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-API-001 | API 레퍼런스 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| LOG-API-002 | API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
 
-### New Users
-1. Start with **[README.md](../README.md)** for project overview
-2. Follow **[GETTING_STARTED.md](guides/GETTING_STARTED.md)** for setup
-3. Reference **[API_REFERENCE.md](API_REFERENCE.md)** for detailed API usage
+### Features (2)
 
-### Existing Users  
-1. Check **[CHANGELOG.md](CHANGELOG.md)** for recent changes
-2. Use **[MIGRATION_GUIDE.md](guides/MIGRATION_GUIDE.md)** when upgrading
-3. Consult **[BEST_PRACTICES.md](guides/BEST_PRACTICES.md)** for optimal usage
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-FEAT-001 | Logger System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| LOG-FEAT-002 | Logger System Features | [FEATURES.md](./FEATURES.md) | Released |
 
-### Contributors
-1. Read **[CONTRIBUTING.md](CONTRIBUTING.md)** for guidelines  
-2. Study **[LOGGER_SYSTEM_ARCHITECTURE.md](LOGGER_SYSTEM_ARCHITECTURE.md)** for implementation details
-3. Explore **[CUSTOM_WRITERS.md](advanced/CUSTOM_WRITERS.md)** for extension patterns
+### Guides (25)
 
-### Performance Engineers
-1. Review **[PERFORMANCE.md](guides/PERFORMANCE.md)** for benchmarks
-2. Check **[LOGGER_SYSTEM_ARCHITECTURE.md](LOGGER_SYSTEM_ARCHITECTURE.md)** for design decisions
-3. Reference **[BEST_PRACTICES.md](guides/BEST_PRACTICES.md)** for optimization tips
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-GUID-001 | Configuration Strategies Guide | [CONFIGURATION_STRATEGIES.md](./CONFIGURATION_STRATEGIES.md) | Released |
+| LOG-GUID-002 | Log Server and Crash-Safe Logger | [LOG_SERVER_AND_CRASH_SAFETY.md](./LOG_SERVER_AND_CRASH_SAFETY.md) | Released |
+| LOG-GUID-003 | Logger System 문서 | [README.kr.md](./README.kr.md) | Released |
+| LOG-GUID-005 | Writer Composition and Decorator Guide | [WRITER_GUIDE.md](./WRITER_GUIDE.md) | Released |
+| LOG-GUID-006 | 비동기 Writer 구현체 가이드 | [ASYNC_WRITERS.kr.md](./advanced/ASYNC_WRITERS.kr.md) | Released |
+| LOG-GUID-007 | Asynchronous Writer Implementations Guide | [ASYNC_WRITERS.md](./advanced/ASYNC_WRITERS.md) | Released |
+| LOG-GUID-008 | 크리티컬 로깅 빠른 시작 | [CRITICAL_LOGGING_QUICK_START.kr.md](./advanced/CRITICAL_LOGGING_QUICK_START.kr.md) | Released |
+| LOG-GUID-009 | Critical Logging Quick Start | [CRITICAL_LOGGING_QUICK_START.md](./advanced/CRITICAL_LOGGING_QUICK_START.md) | Released |
+| LOG-GUID-010 | 크리티컬 로그 손실 방지 가이드 | [CRITICAL_LOG_PREVENTION.kr.md](./advanced/CRITICAL_LOG_PREVENTION.kr.md) | Released |
+| LOG-GUID-011 | Critical Log Loss Prevention Guide | [CRITICAL_LOG_PREVENTION.md](./advanced/CRITICAL_LOG_PREVENTION.md) | Released |
+| LOG-GUID-012 | 커스텀 작성기 생성 | [CUSTOM_WRITERS.kr.md](./advanced/CUSTOM_WRITERS.kr.md) | Released |
+| LOG-GUID-013 | Creating Custom Writers | [CUSTOM_WRITERS.md](./advanced/CUSTOM_WRITERS.md) | Released |
+| LOG-GUID-014 | Log Level Semantic Standard | [LOG_LEVEL_SEMANTIC_STANDARD.md](./advanced/LOG_LEVEL_SEMANTIC_STANDARD.md) | Released |
+| LOG-GUID-015 | Writer Hierarchy and Categories | [WRITER_HIERARCHY.md](./advanced/WRITER_HIERARCHY.md) | Released |
+| LOG-GUID-016 | Writer Selection Guide | [WRITER_SELECTION_GUIDE.md](./advanced/WRITER_SELECTION_GUIDE.md) | Released |
+| LOG-GUID-017 | Logger System 모범 사례 가이드 | [BEST_PRACTICES.kr.md](./guides/BEST_PRACTICES.kr.md) | Released |
+| LOG-GUID-018 | Logger System Best Practices Guide | [BEST_PRACTICES.md](./guides/BEST_PRACTICES.md) | Released |
+| LOG-GUID-019 | Logger System - Frequently Asked Questions | [FAQ.md](./guides/FAQ.md) | Released |
+| LOG-GUID-020 | Logger System 시작하기 | [GETTING_STARTED.kr.md](./guides/GETTING_STARTED.kr.md) | Released |
+| LOG-GUID-021 | Getting Started with Logger System | [GETTING_STARTED.md](./guides/GETTING_STARTED.md) | Released |
+| LOG-GUID-022 | 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| LOG-GUID-023 | Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| LOG-GUID-024 | Logger System Integration Guide | [README.md](./integration/README.md) | Released |
+| LOG-GUID-025 | thread_system 통합 가이드 | [THREAD_SYSTEM.kr.md](./integration/THREAD_SYSTEM.kr.md) | Released |
+| LOG-GUID-026 | Async Integration Guide | [THREAD_SYSTEM.md](./integration/THREAD_SYSTEM.md) | Released |
 
-## 🔧 Documentation Maintenance
+### Performance (8)
 
-This documentation structure was reorganized to:
-- **Eliminate Duplication**: Single source of truth for each topic
-- **Improve Navigation**: Clear categorization and logical flow
-- **Enhance Usability**: Role-based entry points and cross-references
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-PERF-001 | Logger System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| LOG-PERF-002 | Logger System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| LOG-PERF-003 | Logger System 성능 가이드 | [PERFORMANCE.kr.md](./guides/PERFORMANCE.kr.md) | Released |
+| LOG-PERF-004 | Logger System Performance Guide | [PERFORMANCE.md](./guides/PERFORMANCE.md) | Released |
+| LOG-PERF-005 | Logger System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| LOG-PERF-006 | Logger System - Performance Baseline Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
+| LOG-PERF-007 | CI/CD 성능 지표 자동화 제안서 | [CI_CD_PERFORMANCE_PROPOSAL.md](./performance/CI_CD_PERFORMANCE_PROPOSAL.md) | Released |
+| LOG-PERF-008 | Decorator Pattern Performance Characteristics | [DECORATOR_PERFORMANCE.md](./performance/DECORATOR_PERFORMANCE.md) | Released |
 
-### Recent Changes
-- Consolidated multiple API references into single authoritative document
-- Split architecture documentation (ecosystem vs. system-specific)
-- Reorganized guides into logical categories
-- Improved cross-referencing and navigation
+### Migration (4)
 
-## 📖 External Resources
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-MIGR-001 | Migration Guide - Logger System | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| LOG-MIGR-002 | Decorator Pattern Writer Migration Guide | [DECORATOR_MIGRATION.md](./guides/DECORATOR_MIGRATION.md) | Released |
+| LOG-MIGR-003 | 로거 시스템 마이그레이션 가이드 | [MIGRATION_GUIDE.kr.md](./guides/MIGRATION_GUIDE.kr.md) | Released |
+| LOG-MIGR-004 | Logger System Migration Guide | [MIGRATION_GUIDE.md](./guides/MIGRATION_GUIDE.md) | Released |
 
-- **[GitHub Repository](https://github.com/kcenon/logger_system)** - Source code and issues
-- **[Thread System](https://github.com/kcenon/thread_system)** - Foundation interfaces
-- **[Integration Examples](https://github.com/kcenon/integrated_thread_system)** - Complete usage patterns
-- **[Generated Documentation](https://kcenon.github.io/logger_system/)** - Doxygen API docs (GitHub Pages)
+### Integration (2)
 
-## 🤝 Help & Support
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-INTR-001 | Logger System Integration Guide | [INTEGRATION.md](./guides/INTEGRATION.md) | Released |
+| LOG-INTR-002 | OpenTelemetry Integration Guide | [OPENTELEMETRY.md](./guides/OPENTELEMETRY.md) | Released |
 
-- **Issues**: Report bugs and request features on [GitHub Issues](https://github.com/kcenon/logger_system/issues)
-- **Discussions**: Community support and questions on [GitHub Discussions](https://github.com/kcenon/logger_system/discussions)
-- **Security**: Report security issues per [SECURITY.md](SECURITY.md) guidelines
+### Quality (3)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-QUAL-001 | Logger System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| LOG-QUAL-002 | Logger System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| LOG-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
+
+### Security (3)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-SECU-001 | Security Module Guide | [SECURITY_GUIDE.md](./SECURITY_GUIDE.md) | Released |
+| LOG-SECU-002 | 보안 가이드 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
+| LOG-SECU-003 | Security Guide | [SECURITY.md](./guides/SECURITY.md) | Released |
+
+### Project (10)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| LOG-PROJ-001 | 변경 이력 - Logger System | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| LOG-PROJ-002 | Changelog - Logger System | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| LOG-PROJ-003 | Logger System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| LOG-PROJ-004 | Logger System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| LOG-PROJ-005 | SOUP List &mdash; logger_system | [SOUP.md](./SOUP.md) | Released |
+| LOG-PROJ-006 | Logger System CI/CD 대시보드 | [CI_CD_DASHBOARD.kr.md](./advanced/CI_CD_DASHBOARD.kr.md) | Released |
+| LOG-PROJ-007 | Logger System CI/CD Dashboard | [CI_CD_DASHBOARD.md](./advanced/CI_CD_DASHBOARD.md) | Released |
+| LOG-PROJ-008 | Logger System 기여하기 | [CONTRIBUTING.kr.md](./contributing/CONTRIBUTING.kr.md) | Released |
+| LOG-PROJ-009 | Contributing to Logger System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| LOG-PROJ-010 | Korean Translation Summary | [TRANSLATION_SUMMARY.md](./contributing/TRANSLATION_SUMMARY.md) | Released |
 
 ---
 
-*Documentation last updated: [Current Date] - Logger System v2.x*
+*Registry generated for issue [#563](https://github.com/kcenon/logger_system/issues/563).*

--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # Security Module Guide
 
+> **SSOT**: This document is the single source of truth for **Security Module Guide**.
+
 **logger_system Security Module** (`include/kcenon/logger/security/`)
 
 The security module provides defense-in-depth capabilities for logging infrastructure, protecting against common security threats while maintaining compliance requirements.

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP List &mdash; logger_system
 
+> **SSOT**: This document is the single source of truth for **SOUP List &mdash; logger_system**.
+
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
 >
 > This document is the authoritative reference for all external software dependencies.

--- a/docs/WRITER_GUIDE.md
+++ b/docs/WRITER_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Writer Composition and Decorator Guide
 
+> **SSOT**: This document is the single source of truth for **Writer Composition and Decorator Guide**.
+
 **logger_system Writer Framework** (`include/kcenon/logger/writers/`)
 
 The writer framework in logger_system uses the **Decorator Pattern** to enable flexible, composable log processing pipelines. With 18 writer types (5 base writers + 13 processing decorators), you can build high-performance logging configurations achieving **4.34M msg/sec throughput** and **148ns latency**.

--- a/docs/advanced/ARCHITECTURE.md
+++ b/docs/advanced/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture - Logger System
 
+> **SSOT**: This document is the single source of truth for **Architecture - Logger System**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 ## Overview

--- a/docs/advanced/ASYNC_WRITERS.kr.md
+++ b/docs/advanced/ASYNC_WRITERS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 비동기 Writer 구현체 가이드
 
+> **SSOT**: This document is the single source of truth for **비동기 Writer 구현체 가이드**.
+
 > **Language:** [English](ASYNC_WRITERS.md) | **한국어**
 
 ## 개요

--- a/docs/advanced/ASYNC_WRITERS.md
+++ b/docs/advanced/ASYNC_WRITERS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Asynchronous Writer Implementations Guide
 
+> **SSOT**: This document is the single source of truth for **Asynchronous Writer Implementations Guide**.
+
 > **Language:** **English** | [한국어](ASYNC_WRITERS.kr.md)
 
 ## Overview

--- a/docs/advanced/CI_CD_DASHBOARD.kr.md
+++ b/docs/advanced/CI_CD_DASHBOARD.kr.md
@@ -12,6 +12,8 @@ category: "PROJ"
 
 # Logger System CI/CD 대시보드
 
+> **SSOT**: This document is the single source of truth for **Logger System CI/CD 대시보드**.
+
 > 이 문서는 [CI_CD_DASHBOARD.md](CI_CD_DASHBOARD.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/advanced/CI_CD_DASHBOARD.md
+++ b/docs/advanced/CI_CD_DASHBOARD.md
@@ -12,6 +12,8 @@ category: "PROJ"
 
 # Logger System CI/CD Dashboard
 
+> **SSOT**: This document is the single source of truth for **Logger System CI/CD Dashboard**.
+
 ## 🚀 Build Status
 
 ### Main Branch

--- a/docs/advanced/CONDITIONAL_COMPILATION_REFACTORING.md
+++ b/docs/advanced/CONDITIONAL_COMPILATION_REFACTORING.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Conditional Compilation Refactoring Strategy
 
+> **SSOT**: This document is the single source of truth for **Conditional Compilation Refactoring Strategy**.
+
 **Version**: 0.1.0.0
 **Last Updated**: 2025-11-08
 **Status**: Planning Document

--- a/docs/advanced/CRITICAL_LOGGING_QUICK_START.kr.md
+++ b/docs/advanced/CRITICAL_LOGGING_QUICK_START.kr.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # 크리티컬 로깅 빠른 시작
 
+> **SSOT**: This document is the single source of truth for **크리티컬 로깅 빠른 시작**.
+
 > 이 문서는 [CRITICAL_LOGGING_QUICK_START.md](CRITICAL_LOGGING_QUICK_START.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/advanced/CRITICAL_LOGGING_QUICK_START.md
+++ b/docs/advanced/CRITICAL_LOGGING_QUICK_START.md
@@ -35,6 +35,8 @@ category: "GUID"
 
 # Critical Logging Quick Start
 
+> **SSOT**: This document is the single source of truth for **Critical Logging Quick Start**.
+
 **⚠️ Apply Critical Log Loss Prevention in 5 Minutes**
 
 ---

--- a/docs/advanced/CRITICAL_LOG_PREVENTION.kr.md
+++ b/docs/advanced/CRITICAL_LOG_PREVENTION.kr.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # 크리티컬 로그 손실 방지 가이드
 
+> **SSOT**: This document is the single source of truth for **크리티컬 로그 손실 방지 가이드**.
+
 > 이 문서는 [CRITICAL_LOG_PREVENTION.md](CRITICAL_LOG_PREVENTION.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/advanced/CRITICAL_LOG_PREVENTION.md
+++ b/docs/advanced/CRITICAL_LOG_PREVENTION.md
@@ -70,6 +70,8 @@ category: "GUID"
 
 # Critical Log Loss Prevention Guide
 
+> **SSOT**: This document is the single source of truth for **Critical Log Loss Prevention Guide**.
+
 **Version:** 0.1.1.0
 **Author:** kcenon
 **Date:** 2025-01-17

--- a/docs/advanced/CUSTOM_WRITERS.kr.md
+++ b/docs/advanced/CUSTOM_WRITERS.kr.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # 커스텀 작성기 생성
 
+> **SSOT**: This document is the single source of truth for **커스텀 작성기 생성**.
+
 > 이 문서는 [CUSTOM_WRITERS.md](CUSTOM_WRITERS.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/advanced/CUSTOM_WRITERS.md
+++ b/docs/advanced/CUSTOM_WRITERS.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Creating Custom Writers
 
+> **SSOT**: This document is the single source of truth for **Creating Custom Writers**.
+
 This guide explains how to create custom writers for the Logger System to send logs to various destinations.
 
 ## Overview

--- a/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.kr.md
+++ b/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.kr.md
@@ -12,6 +12,8 @@ category: "ARCH"
 
 # 로거 시스템 아키텍처
 
+> **SSOT**: This document is the single source of truth for **로거 시스템 아키텍처**.
+
 **버전**: 3.0.0
 **최종 업데이트**: 2025-12-10
 

--- a/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.md
+++ b/docs/advanced/LOGGER_SYSTEM_ARCHITECTURE.md
@@ -12,6 +12,8 @@ category: "ARCH"
 
 # Logger System Architecture
 
+> **SSOT**: This document is the single source of truth for **Logger System Architecture**.
+
 **Version**: 0.3.0.0
 **Last Updated**: 2025-12-10
 

--- a/docs/advanced/LOG_LEVEL_SEMANTIC_STANDARD.md
+++ b/docs/advanced/LOG_LEVEL_SEMANTIC_STANDARD.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Log Level Semantic Standard
 
+> **SSOT**: This document is the single source of truth for **Log Level Semantic Standard**.
+
 **Date**: 2025-11-08
 **Status**: Approved for Implementation
 **Affects**: logger_system, thread_system

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide - Logger System
 
+> **SSOT**: This document is the single source of truth for **Migration Guide - Logger System**.
+
 > **Language:** **English** | [한국어](MIGRATION.kr.md)
 
 ## Overview

--- a/docs/advanced/STRUCTURE.kr.md
+++ b/docs/advanced/STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Logger System - 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Logger System - 프로젝트 구조**.
+
 **[English](STRUCTURE.md) | 한국어**
 
 ---

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Logger System - Project Structure
 
+> **SSOT**: This document is the single source of truth for **Logger System - Project Structure**.
+
 **English | [한국어](STRUCTURE.kr.md)**
 
 ---

--- a/docs/advanced/WRITER_HIERARCHY.md
+++ b/docs/advanced/WRITER_HIERARCHY.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Writer Hierarchy and Categories
 
+> **SSOT**: This document is the single source of truth for **Writer Hierarchy and Categories**.
+
 This document describes the logger system's writer hierarchy and category classification system introduced in v1.4.0.
 
 ## Overview

--- a/docs/advanced/WRITER_SELECTION_GUIDE.md
+++ b/docs/advanced/WRITER_SELECTION_GUIDE.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Writer Selection Guide
 
+> **SSOT**: This document is the single source of truth for **Writer Selection Guide**.
+
 This guide helps you choose the right writer for your logging needs.
 
 ## Quick Selection Flowchart

--- a/docs/contributing/CONTRIBUTING.kr.md
+++ b/docs/contributing/CONTRIBUTING.kr.md
@@ -12,6 +12,8 @@ category: "PROJ"
 
 # Logger System 기여하기
 
+> **SSOT**: This document is the single source of truth for **Logger System 기여하기**.
+
 > 이 문서는 [CONTRIBUTING.md](CONTRIBUTING.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -12,6 +12,8 @@ category: "PROJ"
 
 # Contributing to Logger System
 
+> **SSOT**: This document is the single source of truth for **Contributing to Logger System**.
+
 Thank you for your interest in contributing to the Logger System! This document provides guidelines and information for contributors.
 
 ## Table of Contents

--- a/docs/contributing/TRANSLATION_SUMMARY.md
+++ b/docs/contributing/TRANSLATION_SUMMARY.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Korean Translation Summary
 
+> **SSOT**: This document is the single source of truth for **Korean Translation Summary**.
+
 **Date**: 2025-10-20 (Asia/Seoul)
 **Task**: Create Korean versions for all markdown files in logger_system/docs/
 

--- a/docs/guides/BEST_PRACTICES.kr.md
+++ b/docs/guides/BEST_PRACTICES.kr.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Logger System 모범 사례 가이드
 
+> **SSOT**: This document is the single source of truth for **Logger System 모범 사례 가이드**.
+
 > 이 문서는 [BEST_PRACTICES.md](BEST_PRACTICES.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/guides/BEST_PRACTICES.md
+++ b/docs/guides/BEST_PRACTICES.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Logger System Best Practices Guide
 
+> **SSOT**: This document is the single source of truth for **Logger System Best Practices Guide**.
+
 ## Table of Contents
 1. [Design Principles](#design-principles)
 2. [Configuration Best Practices](#configuration-best-practices)

--- a/docs/guides/DECORATOR_MIGRATION.md
+++ b/docs/guides/DECORATOR_MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Decorator Pattern Writer Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Decorator Pattern Writer Migration Guide**.
+
 **Version**: 0.4.0.0
 **Last Updated**: 2026-01-22
 

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Logger System - Frequently Asked Questions
 
+> **SSOT**: This document is the single source of truth for **Logger System - Frequently Asked Questions**.
+
 > **Version:** 0.1.0
 > **Last Updated:** 2025-11-11
 > **Audience:** Users, Developers

--- a/docs/guides/GETTING_STARTED.kr.md
+++ b/docs/guides/GETTING_STARTED.kr.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Logger System 시작하기
 
+> **SSOT**: This document is the single source of truth for **Logger System 시작하기**.
+
 > 이 문서는 [GETTING_STARTED.md](GETTING_STARTED.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -12,6 +12,8 @@ category: "GUID"
 
 # Getting Started with Logger System
 
+> **SSOT**: This document is the single source of truth for **Getting Started with Logger System**.
+
 This guide will help you get started with the Logger System quickly.
 
 ## Table of Contents

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Logger System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Logger System Integration Guide**.
+
 **English | [한국어](INTEGRATION.kr.md)**
 
 ---

--- a/docs/guides/MIGRATION_GUIDE.kr.md
+++ b/docs/guides/MIGRATION_GUIDE.kr.md
@@ -12,6 +12,8 @@ category: "MIGR"
 
 # 로거 시스템 마이그레이션 가이드
 
+> **SSOT**: This document is the single source of truth for **로거 시스템 마이그레이션 가이드**.
+
 **버전**: 3.0.0
 **최종 업데이트**: 2025-12-14
 

--- a/docs/guides/MIGRATION_GUIDE.md
+++ b/docs/guides/MIGRATION_GUIDE.md
@@ -12,6 +12,8 @@ category: "MIGR"
 
 # Logger System Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Logger System Migration Guide**.
+
 **Version**: 0.4.0.0
 **Last Updated**: 2026-01-23
 

--- a/docs/guides/OPENTELEMETRY.md
+++ b/docs/guides/OPENTELEMETRY.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # OpenTelemetry Integration Guide
 
+> **SSOT**: This document is the single source of truth for **OpenTelemetry Integration Guide**.
+
 > **Version**: 0.3.0.0+
 > **Status**: Stable
 

--- a/docs/guides/PERFORMANCE.kr.md
+++ b/docs/guides/PERFORMANCE.kr.md
@@ -12,6 +12,8 @@ category: "PERF"
 
 # Logger System 성능 가이드
 
+> **SSOT**: This document is the single source of truth for **Logger System 성능 가이드**.
+
 > 이 문서는 [PERFORMANCE.md](PERFORMANCE.md)의 한국어 번역 버전입니다.
 
 *이 문서의 번역은 진행 중입니다. 자세한 내용은 영문 버전을 참조하세요.*

--- a/docs/guides/PERFORMANCE.md
+++ b/docs/guides/PERFORMANCE.md
@@ -12,6 +12,8 @@ category: "PERF"
 
 # Logger System Performance Guide
 
+> **SSOT**: This document is the single source of truth for **Logger System Performance Guide**.
+
 ## Overview
 
 The Logger System is designed for high-performance logging in multi-threaded applications. This guide covers performance characteristics, benchmarks, and optimization strategies.

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 빠른 시작 가이드
 
+> **SSOT**: This document is the single source of truth for **빠른 시작 가이드**.
+
 > **Language:** [English](QUICK_START.md) | **한국어**
 
 Logger System을 5분 만에 시작하세요.

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Quick Start Guide
 
+> **SSOT**: This document is the single source of truth for **Quick Start Guide**.
+
 > **Language:** **English** | [한국어](QUICK_START.kr.md)
 
 Get up and running with Logger System in 5 minutes.

--- a/docs/guides/SECURITY.kr.md
+++ b/docs/guides/SECURITY.kr.md
@@ -12,6 +12,8 @@ category: "SECU"
 
 # 보안 가이드
 
+> **SSOT**: This document is the single source of truth for **보안 가이드**.
+
 이 문서는 logger_system의 현재 보안 상태를 설명하고 안전한 배포를 위한 지침을 제공합니다.
 
 ## 위협 모델 (범위)

--- a/docs/guides/SECURITY.md
+++ b/docs/guides/SECURITY.md
@@ -12,6 +12,8 @@ category: "SECU"
 
 # Security Guide
 
+> **SSOT**: This document is the single source of truth for **Security Guide**.
+
 This document outlines the current security posture of the logger_system and provides guidance for secure deployments.
 
 ## Threat Model (Scope)

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Logger System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Logger System Integration Guide**.
+
 ## Overview
 
 This directory contains integration guides for using logger_system with other KCENON systems.

--- a/docs/integration/THREAD_SYSTEM.kr.md
+++ b/docs/integration/THREAD_SYSTEM.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # thread_system 통합 가이드
 
+> **SSOT**: This document is the single source of truth for **thread_system 통합 가이드**.
+
 > **Language:** [English](THREAD_SYSTEM.md) | **한국어**
 
 ## 개요

--- a/docs/integration/THREAD_SYSTEM.md
+++ b/docs/integration/THREAD_SYSTEM.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Async Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Async Integration Guide**.
+
 > **Language:** **English** | [한국어](THREAD_SYSTEM.kr.md)
 
 ## Overview

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Logger System - 성능 기준 메트릭
 
+> **SSOT**: This document is the single source of truth for **Logger System - 성능 기준 메트릭**.
+
 **[English](BASELINE.md) | 한국어**
 
 ---

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Logger System - Performance Baseline Metrics
 
+> **SSOT**: This document is the single source of truth for **Logger System - Performance Baseline Metrics**.
+
 **English | [한국어](BASELINE.kr.md)**
 
 ---

--- a/docs/performance/CI_CD_PERFORMANCE_PROPOSAL.md
+++ b/docs/performance/CI_CD_PERFORMANCE_PROPOSAL.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # CI/CD 성능 지표 자동화 제안서
 
+> **SSOT**: This document is the single source of truth for **CI/CD 성능 지표 자동화 제안서**.
+
 **문서 버전:** 1.0
 **작성일:** 2025-11-04
 **프로젝트:** logger_system

--- a/docs/performance/DECORATOR_PERFORMANCE.md
+++ b/docs/performance/DECORATOR_PERFORMANCE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Decorator Pattern Performance Characteristics
 
+> **SSOT**: This document is the single source of truth for **Decorator Pattern Performance Characteristics**.
+
 ## Overview
 
 This document describes the performance characteristics of the decorator pattern implementation in the logger system, specifically the `writer_builder` API compared to manual decorator nesting.


### PR DESCRIPTION
## Summary

- Create `docs/README.md` as the single source of truth documentation index for logger_system
- Add SSOT declarations (`> **SSOT**: ...`) to each authoritative document header
- Registry table lists all 67 documents with doc_id, topic, authority document link, and status
- Documents grouped by category (Architecture, API, Features, Guides, etc.)
- Verified no duplicate doc_id values and all file links are valid

## Test Plan

- [x] All 67 document entries have valid file links
- [x] No duplicate doc_id values within the project
- [x] SSOT declarations added to authoritative documents
- [x] Registry follows the format specified in kcenon/common_system#563

Closes kcenon/common_system#563