### PR TITLE
docs: add @file Doxygen blocks to public API headers

### DIFF
--- a/include/kcenon/logger/adapters/common_logger_adapter.h
+++ b/include/kcenon/logger/adapters/common_logger_adapter.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file common_logger_adapter.h
+ * @brief Log level conversion between logger_system and common_system.
+ *
+ * @see common_system_adapter.h
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/logger/adapters/common_system_adapter.h
+++ b/include/kcenon/logger/adapters/common_system_adapter.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file common_system_adapter.h
+ * @brief Adapter exposing kcenon::logger as common::interfaces::ILogger.
+ *
+ * @see logger_adapter.h For standalone usage
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/logger/adapters/logger_adapter.h
+++ b/include/kcenon/logger/adapters/logger_adapter.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file logger_adapter.h
+ * @brief Standalone logger adapter for use without common_system DI.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/logger.h>

--- a/include/kcenon/logger/core/error_codes.h
+++ b/include/kcenon/logger/core/error_codes.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file error_codes.h
+ * @brief Error codes specific to the logger system.
+ *
+ */
+
 #pragma once
 
 #include <string>

--- a/include/kcenon/logger/core/filtered_logger.h
+++ b/include/kcenon/logger/core/filtered_logger.h
@@ -1,5 +1,12 @@
 // BSD 3-Clause License
 
+/**
+ * @file filtered_logger.h
+ * @brief Logger wrapper that applies compile-time and runtime log filtering.
+ *
+ * @see log_filter_interface.h
+ */
+
 #pragma once
 
 #include <memory>

--- a/include/kcenon/logger/core/log_context.h
+++ b/include/kcenon/logger/core/log_context.h
@@ -1,5 +1,11 @@
 // BSD 3-Clause License
 
+/**
+ * @file log_context.h
+ * @brief Structured log context with key-value metadata for correlation.
+ *
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/logger/core/logger_config.h
+++ b/include/kcenon/logger/core/logger_config.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file logger_config.h
+ * @brief Configuration structure for logger with validation.
+ *
+ * @see logger_config_builder.h For fluent construction
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/logger/core/logger_config_builder.h
+++ b/include/kcenon/logger/core/logger_config_builder.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file logger_config_builder.h
+ * @brief Fluent builder for logger_config.
+ *
+ * @see logger_config.h
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/logger_config.h>

--- a/include/kcenon/logger/core/small_string.h
+++ b/include/kcenon/logger/core/small_string.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file small_string.h
+ * @brief Small String Optimization (SSO) for short log messages.
+ *
+ */
+
 #pragma once
 
 #include <cstring>

--- a/include/kcenon/logger/formatters/base_formatter.h
+++ b/include/kcenon/logger/formatters/base_formatter.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file base_formatter.h
+ * @brief Base implementation for log formatters with pattern support.
+ *
+ */
+
 #pragma once
 
 #include "../interfaces/log_formatter_interface.h"

--- a/include/kcenon/logger/interfaces/log_filter_interface.h
+++ b/include/kcenon/logger/interfaces/log_filter_interface.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file log_filter_interface.h
+ * @brief Interface for log filters used by filtered_logger.
+ *
+ * @see filtered_logger.h
+ */
+
 #pragma once
 
 #include <string>

--- a/include/kcenon/logger/interfaces/log_sink_interface.h
+++ b/include/kcenon/logger/interfaces/log_sink_interface.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file log_sink_interface.h
+ * @brief Interface for log sinks that receive formatted output.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/common/patterns/result.h>

--- a/include/kcenon/logger/interfaces/log_writer_interface.h
+++ b/include/kcenon/logger/interfaces/log_writer_interface.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file log_writer_interface.h
+ * @brief Base interface for all log writers and decorators.
+ *
+ * @see writers/ For concrete implementations
+ */
+
 #pragma once
 
 #include <string>

--- a/include/kcenon/logger/safety/crash_safe_logger.h
+++ b/include/kcenon/logger/safety/crash_safe_logger.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file crash_safe_logger.h
+ * @brief Logger with crash recovery and emergency flush capabilities.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/logger.h>

--- a/include/kcenon/logger/security/audit_logger.h
+++ b/include/kcenon/logger/security/audit_logger.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file audit_logger.h
+ * @brief Secure audit logging with tamper detection.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/security/secure_key_storage.h>

--- a/include/kcenon/logger/security/path_validator.h
+++ b/include/kcenon/logger/security/path_validator.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file path_validator.h
+ * @brief File path validation to prevent path traversal vulnerabilities.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/error_codes.h>

--- a/include/kcenon/logger/security/secure_key_storage.h
+++ b/include/kcenon/logger/security/secure_key_storage.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file secure_key_storage.h
+ * @brief RAII wrapper for encryption keys with secure memory management.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/error_codes.h>

--- a/include/kcenon/logger/security/signal_manager.h
+++ b/include/kcenon/logger/security/signal_manager.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file signal_manager.h
+ * @brief Signal-safe write wrapper for cross-platform signal handling.
+ *
+ * @see signal_manager_interface.h
+ */
+
 #pragma once
 
 #include "signal_manager_interface.h"

--- a/include/kcenon/logger/security/signal_manager_interface.h
+++ b/include/kcenon/logger/security/signal_manager_interface.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file signal_manager_interface.h
+ * @brief Interface for signal handler management.
+ *
+ */
+
 #pragma once
 
 #include <cstddef>

--- a/include/kcenon/logger/utils/error_handling_utils.h
+++ b/include/kcenon/logger/utils/error_handling_utils.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file error_handling_utils.h
+ * @brief Structured error context for debugging log system failures.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/error_codes.h>

--- a/include/kcenon/logger/utils/file_utils.h
+++ b/include/kcenon/logger/utils/file_utils.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file file_utils.h
+ * @brief File utility functions for path validation and sanitization.
+ *
+ */
+
 #pragma once
 
 #include <kcenon/logger/core/error_codes.h>

--- a/include/kcenon/logger/utils/string_utils.h
+++ b/include/kcenon/logger/utils/string_utils.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file string_utils.h
+ * @brief String utility functions for log formatting and conversion.
+ *
+ */
+
 #pragma once
 
 #include <string>

--- a/include/kcenon/logger/utils/time_utils.h
+++ b/include/kcenon/logger/utils/time_utils.h
@@ -2,6 +2,12 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file time_utils.h
+ * @brief Time utility functions for timestamp formatting.
+ *
+ */
+
 #pragma once
 
 #include <chrono>

--- a/include/kcenon/logger/writers/batch_writer.h
+++ b/include/kcenon/logger/writers/batch_writer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file batch_writer.h
+ * @brief Batch writer that accumulates log entries and writes them in batches.
+ *
+ * @see log_writer_interface.h
+ */
+
 #pragma once
 
 #include "queued_writer_base.h"

--- a/include/kcenon/logger/writers/console_writer.h
+++ b/include/kcenon/logger/writers/console_writer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file console_writer.h
+ * @brief Console writer for logging to stdout/stderr.
+ *
+ * @see log_writer_interface.h
+ */
+
 #pragma once
 
 #include "../interfaces/log_writer_interface.h"

--- a/include/kcenon/logger/writers/file_writer.h
+++ b/include/kcenon/logger/writers/file_writer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file file_writer.h
+ * @brief File writer for logging to files with optional buffering.
+ *
+ * @see rotating_file_writer.h For size/time-based rotation
+ */
+
 #pragma once
 
 #include "../interfaces/log_writer_interface.h"

--- a/include/kcenon/logger/writers/network_writer.h
+++ b/include/kcenon/logger/writers/network_writer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file network_writer.h
+ * @brief Network writer for sending logs over TCP/UDP.
+ *
+ * @see log_writer_interface.h
+ */
+
 #pragma once
 
 #include "base_writer.h"

--- a/include/kcenon/logger/writers/rotating_file_writer.h
+++ b/include/kcenon/logger/writers/rotating_file_writer.h
@@ -2,6 +2,13 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file rotating_file_writer.h
+ * @brief Rotating file writer with size and time-based rotation.
+ *
+ * @see file_writer.h For the base file writer
+ */
+
 #pragma once
 
 #include "file_writer.h"


### PR DESCRIPTION
## Summary

Add `@file` Doxygen documentation blocks to 28 public API headers that were missing them, achieving 100% `@file` coverage across all headers in logger_system.

### Directories Updated
- `adapters/` — common_logger_adapter, common_system_adapter, logger_adapter
- `core/` — error_codes, filtered_logger, log_context, logger_config, logger_config_builder, small_string
- `formatters/` — base_formatter
- `interfaces/` — log_filter_interface, log_sink_interface, log_writer_interface
- `safety/` — crash_safe_logger
- `security/` — audit_logger, path_validator, secure_key_storage, signal_manager, signal_manager_interface
- `utils/` — error_handling_utils, file_utils, string_utils, time_utils
- `writers/` — batch_writer, console_writer, file_writer, network_writer, rotating_file_writer

Closes #568

## Test Plan
- [ ] Verify Doxygen generation produces no warnings on updated headers
- [ ] Confirm existing CI checks pass