### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@ Total documents: **71**
 | 52 | LOG-INTR-002 | OpenTelemetry Integration Guide | [OPENTELEMETRY.md](./guides/OPENTELEMETRY.md) | Released |
 | 53 | LOG-QUAL-001 | Logger System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 54 | LOG-QUAL-002 | Logger System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 55 | LOG-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 55 | LOG-QUAL-004 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 56 | LOG-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
 | 57 | LOG-SECU-001 | Security Module Guide | [SECURITY_GUIDE.md](./SECURITY_GUIDE.md) | Released |
 | 58 | LOG-SECU-002 | 보안 가이드 | [SECURITY.kr.md](./guides/SECURITY.kr.md) | Released |
@@ -186,7 +186,7 @@ Total documents: **71**
 |--------|-------|----------|--------|
 | LOG-QUAL-001 | Logger System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | LOG-QUAL-002 | Logger System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| LOG-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| LOG-QUAL-004 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | LOG-QUAL-003 | Testing Guide | [TESTING_GUIDE.md](./contributing/TESTING_GUIDE.md) | Released |
 
 ### Security (3)

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "LOG-QUAL-002"
+doc_id: "LOG-QUAL-004"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `LOG-QUAL-002`
- Assign unique `LOG-QUAL-004` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `LOG-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `LOG-QUAL-004` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `LOG-QUAL-002` to `LOG-QUAL-004`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `LOG-QUAL-004` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (48)