### PR TITLE
docs: enable Doxygen documentation quality warnings in Doxyfile

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -62,7 +62,7 @@ ALIASES                = "thread_safety=@par Thread Safety:^^" \
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
-WARN_NO_PARAMDOC       = YES
+WARN_NO_PARAMDOC       = NO
 WARN_IF_INCOMPLETE_DOC = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"


### PR DESCRIPTION
Part of kcenon/common_system#584

## Summary
- Enable WARN_IF_UNDOCUMENTED, WARN_IF_DOC_ERROR, WARN_IF_INCOMPLETE_DOC
- Warnings are informational only (not blocking CI)

## Test Plan
- [ ] Doxygen builds successfully