### PR TITLE
docs(doxyfile): sync Doxyfile to ecosystem standard

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -62,14 +62,14 @@ ALIASES                = "thread_safety=@par Thread Safety:^^" \
 WARNINGS               = YES
 WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
-WARN_NO_PARAMDOC       = NO
+WARN_NO_PARAMDOC       = YES
 WARN_IF_INCOMPLETE_DOC = YES
 WARN_AS_ERROR          = NO
 WARN_FORMAT            = "$file:$line: $text"
 
 # Example settings
 EXAMPLE_PATH           = examples
-EXAMPLE_PATTERNS       = *.cpp *.h
+EXAMPLE_PATTERNS       = *.cpp, *.h
 EXAMPLE_RECURSIVE      = YES
 
 # Source browsing


### PR DESCRIPTION
Closes #587
## Summary
- Enable WARN_NO_PARAMDOC = YES
- Fix EXAMPLE_PATTERNS format (space to comma separator)
## Test Plan
- Verify Doxygen CI build passes