### PR TITLE
docs(tutorials): add tutorials, FAQ and troubleshooting guide

### DIFF
--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -1,0 +1,209 @@
+/**
+@page faq Frequently Asked Questions
+
+@tableofcontents
+
+This page collects the most common questions external developers ask when
+adopting logger_system. For step-by-step walkthroughs see the
+@ref tutorial_basic_logging, @ref tutorial_decorators, and
+@ref tutorial_production tutorials.
+
+@section faq_rotation 1. How do I configure log rotation?
+
+Use `rotating_file_writer` (or `writer_builder::rotating_file`) and supply the
+maximum segment size and the number of segments to retain. logger_system
+performs size-based rotation only; calendar rotation is best handled by an
+external tool such as `logrotate` running on the host.
+
+@code{.cpp}
+auto rotating = kcenon::logger::writer_builder()
+    .rotating_file("logs/app.log",
+                   100 * 1024 * 1024, // 100 MB per segment
+                   10)                // keep 10 historical files
+    .buffered(4096)
+    .async()
+    .build();
+@endcode
+
+Place log files on a dedicated volume to avoid filling the root partition,
+and compress old segments out-of-band to keep the hot path predictable.
+
+@section faq_async_vs_sync 2. What are the tradeoffs between async and sync logging?
+
+| Aspect | Synchronous | Asynchronous |
+|--------|-------------|--------------|
+| Latency on caller | Bound to writer cost | Sub-microsecond enqueue |
+| Throughput | Limited by writer | 4M+ msg/s with batching |
+| Determinism | Strict ordering on the calling thread | Reordered relative to enqueue |
+| Failure surface | Caller sees the error | Worker may drop or block |
+| Best for | Tests, CLIs, audit pipelines | Services, batch jobs |
+
+Choose @em sync when each `log()` call must be durable on return (auditing,
+crash diagnostics). Choose @em async (the default) for everything else.
+You can combine both: build an async chain for general logging and a sync
+critical chain for audit-grade events.
+
+@section faq_custom_writer 3. How do I add a custom writer?
+
+Implement `kcenon::logger::log_writer_interface`. The required surface is
+small: a `write(const log_entry&)` returning `common::VoidResult`, plus
+`flush()` and `get_name()`. Once implemented, your writer plugs into any
+decorator chain or directly into `logger::add_writer()`.
+
+@code{.cpp}
+class my_writer : public kcenon::logger::log_writer_interface {
+public:
+    kcenon::common::VoidResult write(const kcenon::logger::log_entry& e) override;
+    kcenon::common::VoidResult flush() override;
+    std::string get_name() const override { return "my_writer"; }
+};
+@endcode
+
+See @ref custom_writer_example.cpp for a complete reference implementation.
+
+@section faq_monitoring 4. How does logger_system integrate with monitoring_system?
+
+logger_system is Tier 2 in the kcenon ecosystem; `monitoring_system`
+(Tier 3) consumes it via the `monitoring_backend`. Two integration paths
+are supported:
+
+1. @b Backend @b mode. Build with `LOGGER_USE_MONITORING=ON` and the
+   `monitoring_backend` will publish queue depth, drop counts, and writer
+   latency to monitoring_system's metric registry.
+2. @b Adapter @b mode. Implement `kcenon::common::interfaces::IObserver`
+   and forward `logger::metrics()` snapshots into your existing dashboard
+   pipeline (Prometheus, OTLP, etc.).
+
+The two paths are not mutually exclusive: keep the in-process metrics for
+local debugging and ship aggregated counters via OTLP for fleet-wide
+dashboards.
+
+@section faq_thread_safety 5. Is logger_system thread-safe?
+
+Yes. The `logger` class is fully thread-safe, and all built-in writers are
+either inherently thread-safe (`console_writer`, `file_writer`,
+`rotating_file_writer`, `network_writer`, `otlp_writer`) or wrapped in a
+mutex via `thread_safe_writer` when needed. The async pipeline uses a
+lock-free MPSC queue so contention does not scale with thread count.
+
+If you implement a custom writer, you can either:
+
+- Make it thread-safe internally, or
+- Wrap it with `writer_builder::thread_safe()` to inherit a mutex-guarded
+  facade.
+
+@section faq_perf 6. How do I tune logger_system for maximum performance?
+
+In rough order of impact:
+
+1. Use the @em async writer with a large enough queue to absorb your peak
+   burst (typically 32k-256k entries).
+2. Combine `buffered` (4k-16k entries) and `batch` (1k-4k entries) to
+   amortize syscalls.
+3. Filter early. Drop noisy levels at the logger (`set_level`) instead of
+   relying on a downstream filter.
+4. Prefer `log_structured()` over `format()`-style messages on the hot path;
+   it avoids constructing and copying intermediate strings.
+5. Build with `LOGGER_USE_THREAD_SYSTEM=ON` if you already have a tuned
+   thread pool to share.
+6. Pin the worker thread to a non-critical core if your platform allows it.
+
+@section faq_otlp 7. How do I set up OpenTelemetry (OTLP) export?
+
+Build with `LOGGER_ENABLE_OTLP=ON` and link `opentelemetry-cpp` (>= 1.14).
+Construct an `otlp_endpoint`, point it at your collector, and add the
+`otlp_writer` to your logger:
+
+@code{.cpp}
+otlp::otlp_endpoint endpoint;
+endpoint.url      = "http://otel-collector:4318/v1/logs";
+endpoint.protocol = otlp::otlp_protocol::http_protobuf;
+endpoint.headers["x-tenant"] = "checkout";
+
+auto otlp = writer_builder()
+    .otlp(endpoint)
+    .buffered(1024)
+    .async(16384)
+    .build();
+@endcode
+
+For high availability, run a sidecar collector (Vector, OTel Collector,
+Fluent Bit) on each host so transient network issues do not back up the
+in-process queue.
+
+@section faq_decorator_order 8. Is decorator order important, and what is the recommended order?
+
+Yes, ordering changes both correctness and performance. From outermost (the
+caller-facing wrapper) to innermost (the core writer), the recommended order
+is:
+
+1. `async_writer`
+2. `thread_safe_writer` (only when wrapping a non-thread-safe core)
+3. `buffered_writer` / `batch_writer`
+4. `encrypted_writer`
+5. `filtered_writer`
+6. `formatted_writer`
+7. core writer (`file_writer`, `console_writer`, etc.)
+
+Putting `async_writer` inside `buffered_writer` defeats async (the buffer
+flushes on the calling thread). Putting `encrypted_writer` outside the
+buffer wastes CPU because each entry is encrypted individually. See
+@ref tutorial_decorators for a worked example.
+
+@section faq_field_conventions 9. What naming conventions should I use for structured fields?
+
+Adopt a stable, lowercase, snake_case schema and reuse the same key names
+across services. The kcenon convention follows ECS-inspired families:
+
+| Family | Examples |
+|--------|----------|
+| Identity | `user_id`, `tenant_id`, `session_id` |
+| Network  | `source_ip`, `dest_ip`, `port`, `protocol` |
+| Tracing  | `trace_id`, `span_id`, `parent_span_id` |
+| Performance | `duration_ms`, `latency_us`, `bytes_in`, `bytes_out` |
+| Result   | `status_code`, `outcome`, `error_code`, `error_message` |
+| Resource | `service_name`, `service_version`, `host`, `region` |
+
+Stick to scalars (`int`, `double`, `bool`, `string`) on the hot path; nested
+objects force the formatter to do extra work. If you need hierarchical data,
+flatten it into dotted keys (`request.size_bytes`).
+
+@section faq_security 10. How do I encrypt log files or protect sensitive data?
+
+Build with `LOGGER_USE_ENCRYPTION=ON` (the default) to enable the
+`encrypted_writer` and `secure_key_storage`. Generate a 32-byte AES key and
+chain `encrypted` after `buffered` so each cipher block carries enough data
+to be efficient:
+
+@code{.cpp}
+#include <kcenon/logger/security/secure_key_storage.h>
+
+auto key = security::secure_key_storage::generate_key(32).value();
+
+auto secure = writer_builder()
+    .file("audit.log.enc")
+    .encrypted(std::move(key))
+    .buffered(2048)
+    .async()
+    .build();
+@endcode
+
+Additional hardening:
+
+- Store the AES key in a hardware-backed keystore or KMS, not in source.
+- Rotate keys periodically; logger_system supports key rotation via the
+  secure key storage API.
+- Combine encryption with @em redaction in your formatter to scrub PII before
+  it ever reaches the bytes-on-disk layer.
+- Restrict log file permissions to the service user only (`chmod 600`).
+
+@section faq_more More Questions?
+
+- Read the relevant tutorial first: @ref tutorial_basic_logging,
+  @ref tutorial_decorators, or @ref tutorial_production.
+- Browse the @ref examples in `examples/` for runnable, idiomatic snippets.
+- Open a discussion or issue at
+  https://github.com/kcenon/logger_system/issues if your scenario is not
+  covered here.
+
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -136,6 +136,22 @@ digraph architecture {
 }
 @enddot
 
+@section learning Learning Resources
+
+New to logger_system? Start with these guided pages, written for external
+developers integrating the framework for the first time:
+
+| Resource | Audience | Description |
+|----------|----------|-------------|
+| @ref tutorial_basic_logging | Newcomers | Console + file writers, log levels, structured logging. Three runnable snippets. |
+| @ref tutorial_decorators | Intermediate | Decorator pattern, ordering rules, custom decorators. Three composition recipes. |
+| @ref tutorial_production | Advanced | High-throughput, async, rotation, OpenTelemetry export. Three production scenarios. |
+| @ref faq | Reference | Ten of the most common configuration questions, with concise answers. |
+| @ref troubleshooting | Operations | Lost messages, file permissions, queue overflow, performance degradation, decorator pitfalls. |
+
+The @ref examples examples directory contains 16 runnable programs that
+correspond one-to-one with the tutorials.
+
 @section quickstart Quick Start
 
 A minimal example using the logger builder with console and file writers:

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -1,0 +1,189 @@
+/**
+@page troubleshooting Troubleshooting Guide
+
+@tableofcontents
+
+This guide enumerates the most common runtime problems people hit when
+adopting logger_system, the symptoms to look for, and the recommended fixes.
+For configuration questions consult @ref faq; for end-to-end walkthroughs
+see the tutorials linked from the project main page.
+
+@section ts_lost_messages 1. Lost log messages
+
+@subsection ts_lost_symptoms Symptoms
+
+- Entries that you expect to appear in the file or console output are
+  missing.
+- Drop counters reported by `logger::metrics()` are non-zero.
+- Async queue depth is at or near capacity in monitoring dashboards.
+
+@subsection ts_lost_causes Causes
+
+- The async queue overflowed and entries were dropped under back-pressure.
+- The process exited without calling `logger::stop()` (or the destructor
+  was skipped because of `std::abort` / `_exit`).
+- A filter is silently rejecting the entry (custom filters that mutate
+  state can be subtle).
+- The wrong logger instance was used (multiple loggers, mismatched writer).
+
+@subsection ts_lost_fix Fix
+
+1. Always call `logger::stop()` during shutdown. It flushes the queue and
+   joins the worker thread. Wrap your service entry point in an RAII guard
+   if your shutdown path is non-trivial.
+2. Increase the async queue size if drops occur during normal load:
+   @code{.cpp}
+   logger_builder().with_queue_size(131072).build();
+   @endcode
+3. Use `critical_writer` for events that must never be lost. It blocks the
+   producer when the queue is full instead of dropping silently.
+4. Inspect filter implementations and add unit tests covering boundary
+   levels.
+5. Enable metrics export and alert on `dropped_total > 0`.
+
+@section ts_file_perm 2. File permission errors
+
+@subsection ts_perm_symptoms Symptoms
+
+- `logger->add_writer()` succeeds but no file appears on disk.
+- `metrics().last_error` reports `permission_denied` or `path_not_found`.
+- The process logs `failed to open file: /var/log/app.log` to stderr.
+
+@subsection ts_perm_causes Causes
+
+- The service user lacks write permission on the target directory.
+- The configured path uses tilde expansion (`~/logs/app.log`) which the
+  file writer does @em not perform.
+- SELinux / AppArmor policies block writes to the chosen directory.
+- The directory does not exist and `create_parents` was not enabled.
+
+@subsection ts_perm_fix Fix
+
+1. Pre-create the log directory at deployment time and `chown` it to the
+   service user. The CMake install rules can do this for you.
+2. Use absolute paths (e.g. `/var/log/myapp/app.log`) instead of relying on
+   the working directory or shell expansion.
+3. Verify the security context with `ls -lZ` (SELinux) or
+   `aa-status` (AppArmor) and add a policy exception for the log
+   directory.
+4. When using `rotating_file_writer`, ensure the rotation root has enough
+   inodes and free space; rotation will fail silently if `rename(2)` cannot
+   complete.
+
+@section ts_queue_overflow 3. Async queue overflow
+
+@subsection ts_overflow_symptoms Symptoms
+
+- `metrics().queue_depth` is consistently near capacity.
+- Latency spikes on the producing thread when the queue is full.
+- `dropped_total` (or the analogous counter for your queue policy) is
+  growing.
+- In sanitizer builds, you see warnings about `try_enqueue` returning false.
+
+@subsection ts_overflow_causes Causes
+
+- Sustained logging rate exceeds writer drain rate (slow disk, slow OTLP
+  collector, network back-pressure).
+- The worker thread is starved by another high-priority thread.
+- A downstream decorator (e.g. `encrypted_writer` with a large key buffer)
+  is the bottleneck.
+
+@subsection ts_overflow_fix Fix
+
+1. Profile the writer chain. Compare per-decorator latency reported by
+   `metrics().writer_latency_ns` to identify the slow stage.
+2. Increase queue capacity to absorb bursts:
+   @code{.cpp}
+   writer_builder().file("app.log").buffered(8192).async(262144).build();
+   @endcode
+3. Add a `batch_writer` between `buffered` and the core writer to amortize
+   syscalls.
+4. Move expensive decorators (encryption, OTLP serialization) onto a
+   dedicated thread by isolating them in their own async sub-chain.
+5. Lower the logging volume by raising `set_level` for noisy modules or
+   adopting per-component loggers.
+6. As a last resort, switch to `critical_writer` for must-have entries and
+   accept blocking back-pressure on the producer.
+
+@section ts_perf 4. Performance degradation under load
+
+@subsection ts_perf_symptoms Symptoms
+
+- Throughput is well below the documented 4M+ msg/s ceiling.
+- CPU utilization is high but `metrics().writes_per_second` is low.
+- Profiler shows `std::format`, `to_string`, or `mutex::lock` near the top.
+
+@subsection ts_perf_causes Causes
+
+- Logging through `format()` allocates strings on the hot path.
+- The chain contains a `thread_safe_writer` wrapping an already-thread-safe
+  core writer, doubling the lock cost.
+- A buffer or batch size that is too small produces excessive syscalls.
+- The async queue is too small, causing repeated back-off and retries.
+- Building in Debug mode (`-O0`) hides decorator inlining.
+
+@subsection ts_perf_fix Fix
+
+1. Use `log_structured()` for hot paths; it avoids constructing intermediate
+   strings.
+2. Remove redundant `thread_safe_writer` layers. All built-in core writers
+   are already thread-safe.
+3. Increase buffer/batch sizes to 4k-16k entries.
+4. Build in Release mode (`-O2 -DNDEBUG`) for benchmarking.
+5. If you use `LOGGER_USE_THREAD_SYSTEM`, confirm the thread pool has
+   enough workers and is not contending with the rest of the application.
+6. Run the bundled benchmarks (`cmake --preset release -DBUILD_BENCHMARKS=ON`
+   then `./build/benchmarks/logger_bench`) on the target hardware to obtain
+   a realistic baseline.
+
+@section ts_decorator_compose 5. Decorator composition issues
+
+@subsection ts_decocomp_symptoms Symptoms
+
+- Compile errors when chaining decorators (`no matching function for call`).
+- Runtime exceptions with messages like "writer chain not started" or
+  "inner writer is null".
+- Encrypted output that decrypts to garbage.
+- Async writers that appear to do nothing.
+
+@subsection ts_decocomp_causes Causes
+
+- Calling `build()` multiple times on the same `writer_builder` instance.
+- Forgetting to call `start()` on a chain that contains an `async_writer`.
+- Wrapping `async_writer` with `buffered_writer` (the buffer flushes on the
+  caller thread, defeating async).
+- Mixing decorators that expect ownership (`std::unique_ptr`) with shared
+  ownership (`std::shared_ptr`).
+- Using a stale key with `encrypted_writer` after key rotation.
+
+@subsection ts_decocomp_fix Fix
+
+1. Construct a fresh `writer_builder` per chain. Builders are single-use.
+2. Call `logger::start()` after `add_writer()` so the propagation reaches
+   every async layer. If you build a chain manually, downcast and call
+   `async_writer::start()` directly.
+3. Stick to the recommended decorator order documented in
+   @ref tutorial_decorators - in particular, async must always be the
+   outermost layer.
+4. Inspect `get_name()` of the root writer to verify the chain matches what
+   you intended:
+   @code{.cpp}
+   std::cout << chain->get_name() << '\n';
+   // expected: async(buffered(encrypted(file(\"audit.log\"))))
+   @endcode
+5. Manage encryption keys through `secure_key_storage` so rotation events
+   propagate atomically; never copy raw key bytes between writer instances.
+
+@section ts_more More Help
+
+If none of the above fits your symptoms:
+
+- Enable verbose internal logging with `logger::enable_self_diagnostics(true)`.
+  This routes logger_system's own warnings to stderr.
+- Reduce your scenario to a minimal repro using one of the
+  @ref examples examples files.
+- File an issue at
+  https://github.com/kcenon/logger_system/issues with the build options,
+  platform, and the minimal repro attached.
+
+*/

--- a/docs/tutorial_basic_logging.dox
+++ b/docs/tutorial_basic_logging.dox
@@ -1,0 +1,225 @@
+/**
+@page tutorial_basic_logging Tutorial: Basic Logging
+
+@tableofcontents
+
+This tutorial walks through the fundamental usage of logger_system, covering
+logger construction, writer attachment, log levels, and structured logging. By
+the end you will be comfortable wiring up a logger that writes to console and
+file destinations.
+
+@section basic_prereq Prerequisites
+
+- C++20 capable compiler (GCC 11+, Clang 14+, MSVC 2022+, Apple Clang 14+)
+- logger_system installed via CMake `FetchContent`, vcpkg, or as a sibling
+  source tree
+- A linked target depending on `kcenon::logger`
+
+The complete runnable source for the patterns shown here lives in
+@ref basic_usage.cpp.
+
+@section basic_step1 Step 1: Create a Logger
+
+The simplest way to obtain a logger is to construct one directly. Pass `true`
+to enable asynchronous mode (the default) or `false` for fully synchronous
+behaviour.
+
+@code{.cpp}
+#include <kcenon/logger/core/logger.h>
+#include <kcenon/logger/writers/console_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
+
+namespace ci = kcenon::common::interfaces;
+using kcenon::logger::logger;
+using kcenon::logger::console_writer;
+using log_level = ci::log_level;
+
+int main() {
+    // Create an asynchronous logger with the default queue size (8192)
+    auto log = std::make_shared<logger>(true);
+
+    // Attach a console writer (writes to stdout/stderr based on level)
+    log->add_writer(std::make_unique<console_writer>());
+
+    // Async loggers must be started before use
+    log->start();
+
+    log->log(log_level::info, std::string("Application started"));
+
+    log->stop(); // flushes and shuts down background workers
+    return 0;
+}
+@endcode
+
+Asynchronous mode is recommended for almost all production scenarios because
+the calling thread enqueues messages and returns quickly. Synchronous mode is
+useful for unit tests or short-lived utilities where determinism is more
+important than throughput.
+
+@section basic_step2 Step 2: Combine Console and File Writers
+
+A typical service writes human-readable output to the console and persists the
+same stream to a file. The recommended way to compose writers is the
+`writer_builder` fluent API:
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+#include <kcenon/logger/core/logger_builder.h>
+
+using namespace kcenon::logger;
+
+auto console = writer_builder()
+    .console()
+    .build();
+
+auto file = writer_builder()
+    .file("app.log")
+    .buffered(500)   // batch up to 500 entries before flushing
+    .async(20000)    // 20k-entry queue, background thread
+    .build();
+
+auto log = logger_builder()
+    .add_writer(std::move(console))
+    .add_writer(std::move(file))
+    .build();
+@endcode
+
+The builder takes care of decorator ordering for you and produces a single
+`std::unique_ptr<log_writer_interface>` per writer chain. The resulting
+chains can be passed to either `logger::add_writer()` or
+`logger_builder::add_writer()`.
+
+@section basic_step3 Step 3: Choose a Log Level
+
+logger_system uses the canonical six severity levels defined by
+`kcenon::common::interfaces::log_level`:
+
+| Level | Intended Usage |
+|-------|----------------|
+| `trace` | Per-message tracing for debugging hot paths |
+| `debug` | Diagnostic information useful during development |
+| `info`  | High-level lifecycle and progress events |
+| `warning` | Recoverable problems that deserve attention |
+| `error` | Failed operations that the caller can react to |
+| `critical` | Severe failures requiring immediate intervention |
+
+Set the minimum level on the logger to filter out noisy messages globally:
+
+@code{.cpp}
+log->set_level(log_level::info); // drop trace and debug
+log->log(log_level::trace, std::string("not emitted"));
+log->log(log_level::warning, std::string("emitted"));
+@endcode
+
+@section basic_step4 Step 4: Emit Structured Logs
+
+Free-form text is fine for humans, but structured logs are far easier for
+log processing pipelines (Elasticsearch, Loki, Datadog, etc.) to index. Use
+the structured builder returned by `logger::log_structured()`:
+
+@code{.cpp}
+log->log_structured(log_level::info)
+    .message("User login")
+    .field("user_id", 12345)
+    .field("ip", "203.0.113.42")
+    .field("mfa", true)
+    .field("latency_ms", 42.5)
+    .emit();
+@endcode
+
+Each call returns a builder that supports `field(key, value)` for any of the
+common scalar types (`int`, `double`, `bool`, `std::string`, `std::string_view`).
+Call `emit()` exactly once per record. The example
+@ref structured_logging_example.cpp covers JSON and Logfmt formatters as well
+as thread-local context propagation.
+
+@section basic_examples Three Complete Examples
+
+@subsection basic_example_minimal Example 1: Hello, Logger
+
+@code{.cpp}
+#include <kcenon/logger/core/logger.h>
+#include <kcenon/logger/writers/console_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
+
+int main() {
+    using namespace kcenon::logger;
+    namespace ci = kcenon::common::interfaces;
+
+    auto log = std::make_shared<logger>(false); // sync, no start() needed
+    log->add_writer(std::make_unique<console_writer>());
+    log->log(ci::log_level::info, std::string("Hello, logger_system!"));
+    return 0;
+}
+@endcode
+
+@subsection basic_example_file Example 2: Console + Rotating File
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+#include <kcenon/logger/core/logger_builder.h>
+
+using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
+
+auto console = writer_builder().console().build();
+auto rotating = writer_builder()
+    .rotating_file("logs/app.log", 10 * 1024 * 1024, 5) // 10 MB x 5 files
+    .buffered(1024)
+    .async(16384)
+    .build();
+
+auto log = logger_builder()
+    .with_async(true)
+    .add_writer(std::move(console))
+    .add_writer(std::move(rotating))
+    .build();
+
+log->log(ci::log_level::info, std::string("Service ready on port 8080"));
+log->log(ci::log_level::warning, std::string("Cache miss for key user:12345"));
+log->flush();
+@endcode
+
+@subsection basic_example_struct Example 3: Structured Login Audit
+
+@code{.cpp}
+#include <kcenon/logger/core/logger.h>
+#include <kcenon/logger/writers/console_writer.h>
+#include <kcenon/common/interfaces/logger_interface.h>
+
+using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
+
+auto audit = std::make_shared<logger>(true);
+audit->add_writer(std::make_unique<console_writer>());
+audit->start();
+
+audit->log_structured(ci::log_level::info)
+    .message("login_attempt")
+    .field("user_id", 42)
+    .field("result", "success")
+    .field("source_ip", "10.0.0.7")
+    .field("duration_ms", 18.3)
+    .emit();
+
+audit->log_structured(ci::log_level::warning)
+    .message("login_attempt")
+    .field("user_id", 99)
+    .field("result", "invalid_password")
+    .field("source_ip", "10.0.0.9")
+    .emit();
+
+audit->stop();
+@endcode
+
+@section basic_next Next Steps
+
+- @ref tutorial_decorators - learn how decorators compose, in what order, and
+  how to add your own.
+- @ref tutorial_production - production-ready configuration for high
+  throughput, rotation, and OpenTelemetry export.
+- @ref faq - quick answers to common configuration questions.
+- @ref troubleshooting - resolve lost messages, queue overflow, and similar
+  issues.
+
+*/

--- a/docs/tutorial_decorators.dox
+++ b/docs/tutorial_decorators.dox
@@ -1,0 +1,211 @@
+/**
+@page tutorial_decorators Tutorial: Decorator Composition
+
+@tableofcontents
+
+logger_system uses the @em Decorator pattern to layer cross-cutting concerns
+(filtering, buffering, encryption, asynchrony) on top of a small set of core
+writers. This tutorial explains how the decorators interact, what order to
+apply them in, and how to plug in your own.
+
+@section deco_concept Conceptual Model
+
+A "writer chain" is a single `log_writer_interface*` whose `write()` call
+invokes an inner writer, optionally transforming the entry along the way.
+
+@dot
+digraph chain {
+    rankdir=LR;
+    node [shape=box, style="filled,rounded", fontname="Helvetica", fontsize=11];
+    Logger [label="logger", fillcolor="#e8f0fe"];
+    Async  [label="async_writer", fillcolor="#fef7e0"];
+    Buf    [label="buffered_writer", fillcolor="#fef7e0"];
+    Enc    [label="encrypted_writer", fillcolor="#fef7e0"];
+    Filt   [label="filtered_writer", fillcolor="#fef7e0"];
+    File   [label="file_writer (core)", fillcolor="#e6f4ea"];
+    Logger -> Async -> Buf -> Enc -> Filt -> File;
+}
+@enddot
+
+Each layer is a `decorator_writer_base` subclass that owns a
+`std::unique_ptr<log_writer_interface>` and forwards `write()` after applying
+its concern. The chain is built from the @em outside @em in: when you write
+`writer_builder().file("a.log").filtered(f).encrypted(k).buffered(500).async()`
+the file writer ends up at the @em bottom of the chain and `async_writer`
+becomes the outermost wrapper.
+
+@section deco_ordering Ordering Rules
+
+The order in which decorators run matters. Following the recommended order
+yields predictable performance and security guarantees:
+
+| Position (outermost first) | Decorator | Why |
+|----------------------------|-----------|-----|
+| 1 | `async_writer` | Off-loads I/O to a worker thread; should be the first thing the calling thread sees so it returns immediately. |
+| 2 | `thread_safe_writer` | If you need an explicit mutex around a non-thread-safe inner writer, place it just inside the async layer. (Most core writers are already thread-safe.) |
+| 3 | `buffered_writer` / `batch_writer` | Aggregates entries to amortize syscalls. Must be inside the async layer or the worker thread will fight the buffer. |
+| 4 | `encrypted_writer` | Operates on the bytes that will be persisted, so it should run after buffering (more data = better cipher block utilization) but before any post-processing. |
+| 5 | `filtered_writer` | Drops entries based on level/content. Cheap, can sit anywhere, but placing it close to the core writer avoids paying for filtering on suppressed entries when an outer transformation is expensive. |
+| 6 | `formatted_writer` | Converts the structured entry to its on-wire representation. Must be the layer immediately above the core writer if you want bytes-on-disk control. |
+| 7 (core) | `console_writer`, `file_writer`, `rotating_file_writer`, `network_writer`, `otlp_writer`, `composite_writer` | The leaf that performs the real I/O. |
+
+@warning Putting `async_writer` @em inside `buffered_writer` is almost always
+wrong: the buffer will be flushed by the calling thread instead of the
+background worker, defeating the purpose of asynchrony.
+
+@section deco_builder Using writer_builder
+
+The fluent builder applies decorators in the order you call them, with the
+@em first call producing the innermost (core) writer. This means the order in
+your code reads naturally from "what data lives where" outward to "how should
+it be delivered":
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+
+using namespace kcenon::logger;
+
+auto chain = writer_builder()
+    .file("audit.log")          // 1. core writer (innermost)
+    .filtered(make_level_filter(log_level::info))
+    .buffered(1024)             // batch up to 1 KiB worth of entries
+    .async(16384)               // background worker, 16k queue
+    .build();
+@endcode
+
+After `build()`, the resulting `std::unique_ptr<log_writer_interface>` is
+ready to be handed to `logger::add_writer()` or `logger_builder::add_writer()`.
+
+@section deco_examples Three Composition Examples
+
+@subsection deco_example_audit Example 1: Encrypted Audit Trail
+
+Sensitive audit logs that must be encrypted at rest, buffered for throughput,
+and written asynchronously so request handlers are not blocked.
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+#include <kcenon/logger/security/secure_key_storage.h>
+
+using namespace kcenon::logger;
+
+auto key = security::secure_key_storage::generate_key(32).value();
+
+auto audit = writer_builder()
+    .file("audit.log.enc")
+    .encrypted(std::move(key))
+    .buffered(2048)
+    .async(32768)
+    .build();
+@endcode
+
+@subsection deco_example_console Example 2: Filtered Console + Persistent File
+
+Send everything to a rotating file, but only show warnings and errors on the
+console so the operator's terminal stays readable.
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+#include <kcenon/logger/core/logger_builder.h>
+#include <kcenon/logger/interfaces/log_filter_interface.h>
+
+using namespace kcenon::logger;
+namespace ci = kcenon::common::interfaces;
+
+class min_level_filter : public log_filter_interface {
+public:
+    explicit min_level_filter(ci::log_level lvl) : lvl_(lvl) {}
+    bool should_log(const log_entry& e) const override { return e.level >= lvl_; }
+    std::string get_name() const override { return "min_level_filter"; }
+private:
+    ci::log_level lvl_;
+};
+
+auto console = writer_builder()
+    .console()
+    .filtered(std::make_unique<min_level_filter>(ci::log_level::warning))
+    .build();
+
+auto rotating = writer_builder()
+    .rotating_file("logs/app.log", 50 * 1024 * 1024, 10)
+    .buffered(4096)
+    .async(65536)
+    .build();
+
+auto log = logger_builder()
+    .add_writer(std::move(console))
+    .add_writer(std::move(rotating))
+    .build();
+@endcode
+
+@subsection deco_example_custom Example 3: Custom Decorator
+
+Implementing your own decorator is a matter of inheriting from
+`decorator_writer_base`, forwarding `write()`, and overriding `get_name()`.
+The example below tags every entry with a static service name.
+
+@code{.cpp}
+#include <kcenon/logger/writers/decorator_writer_base.h>
+#include <kcenon/logger/types/log_entry.h>
+
+namespace myapp {
+
+class service_tag_writer : public kcenon::logger::decorator_writer_base {
+public:
+    service_tag_writer(std::unique_ptr<kcenon::logger::log_writer_interface> inner,
+                       std::string service)
+        : decorator_writer_base(std::move(inner))
+        , service_(std::move(service)) {}
+
+    kcenon::common::VoidResult write(const kcenon::logger::log_entry& entry) override {
+        auto tagged = entry;
+        // Prepend the service name to the message body.
+        std::string buf = "[" + service_ + "] ";
+        buf.append(entry.message.data(), entry.message.size());
+        tagged.message = std::string_view(buf);
+        return inner().write(tagged);
+    }
+
+    std::string get_name() const override { return "service_tag_writer"; }
+
+private:
+    std::string service_;
+};
+
+} // namespace myapp
+
+// Usage:
+auto chain = std::make_unique<myapp::service_tag_writer>(
+    kcenon::logger::writer_builder().file("svc.log").buffered(512).async().build(),
+    "checkout-svc");
+@endcode
+
+If your decorator needs configuration plumbing or builder support you can also
+expose it through `writer_builder::with_decorator(std::function<...>)` so the
+fluent chain stays uniform with the built-in layers. See
+@ref decorator_usage.cpp for a complete walkthrough including filtering and
+encryption variants.
+
+@section deco_pitfalls Common Pitfalls
+
+- @b Forgetting @b to @b start: `async_writer` requires `start()` before any
+  `write()` call. `logger::start()` propagates to writers added through
+  `add_writer()`. If you build a chain manually, call
+  `dynamic_cast<async_writer*>(chain.get())->start()`.
+- @b Holding @b references @b past @b stop(): once `stop()` returns the worker
+  thread is gone. Subsequent `write()` calls return an error result.
+- @b Mixing @b sync @b and @b async @b in @b one @b chain: only one
+  `async_writer` per chain is supported. Wrap the async layer with another
+  decorator if you need post-processing on the worker thread.
+- @b Filter @b cost: filters are evaluated for every entry. Keep them branch-free
+  and avoid heap allocations on the hot path.
+
+@section deco_next Next Steps
+
+- @ref tutorial_basic_logging - revisit the fundamentals if anything in this
+  page felt advanced.
+- @ref tutorial_production - production hardening and observability.
+- @ref faq - clarifications on async tradeoffs and ordering.
+- @ref troubleshooting - what to do when a decorator chain misbehaves.
+
+*/

--- a/docs/tutorial_production.dox
+++ b/docs/tutorial_production.dox
@@ -1,0 +1,254 @@
+/**
+@page tutorial_production Tutorial: Production Configuration
+
+@tableofcontents
+
+This tutorial covers the configuration choices that matter when running
+logger_system in production: high-throughput async pipelines, log rotation
+and retention, OpenTelemetry export, and the operational hygiene that keeps
+your logging stack reliable under load.
+
+@section prod_goals Production Goals
+
+A well-tuned logger should:
+
+- @b Never @b block the request path. Logging must be effectively zero-cost
+  to the calling thread.
+- @b Survive @b spikes. Bursts of 10x normal load should not lose messages.
+- @b Bound @b disk @b usage. Files must rotate and old segments must expire.
+- @b Be @b observable. Operators need to query, correlate, and alert on logs.
+- @b Fail @b loudly @b but @b safely. Backpressure and disk-full conditions
+  should surface metrics, not crash the process.
+
+@section prod_throughput High-Throughput Configuration
+
+logger_system targets 4M+ messages/sec with sub-microsecond enqueue latency.
+Reaching that ceiling requires the right combination of async, buffered, and
+batched writers.
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+#include <kcenon/logger/core/logger_builder.h>
+
+using namespace kcenon::logger;
+
+auto bulk = writer_builder()
+    .rotating_file("logs/app.log",
+                   100 * 1024 * 1024, // 100 MB per segment
+                   20)                // keep 20 segments (~2 GB)
+    .buffered(8192)                   // 8k entries before flushing
+    .batch(2048)                      // group syscalls into 2k-entry batches
+    .async(131072)                    // 128k async queue
+    .build();
+
+auto log = logger_builder()
+    .with_async(true)
+    .with_queue_size(131072)
+    .add_writer(std::move(bulk))
+    .build();
+@endcode
+
+Tuning checklist:
+
+- @b Queue @b size. Default is 8k entries; raise it for bursty workloads.
+  Each slot is roughly 256 B, so a 128k queue costs ~32 MB of RSS.
+- @b Buffer @b size. Larger buffers mean fewer syscalls and better throughput,
+  at the cost of higher per-entry latency. 4k-16k is a sensible range for
+  file-backed writers.
+- @b Batch @b size. The batch decorator groups physical writes; pair it with
+  a buffered layer for optimal cache and syscall behaviour.
+- @b Backend. Build with `LOGGER_USE_THREAD_SYSTEM=ON` to share a thread
+  pool across multiple subsystems. The default standalone backend uses
+  `std::jthread` and works without external dependencies.
+
+@section prod_async Async Logging
+
+Asynchronous mode is the default and almost always the right choice. The
+calling thread enqueues an entry into a lock-free MPSC queue; a dedicated
+worker thread drains the queue and forwards entries to the inner chain.
+
+@code{.cpp}
+auto async_chain = writer_builder()
+    .file("audit.log")
+    .buffered(2048)
+    .async(32768)
+    .build();
+@endcode
+
+Operational notes:
+
+- Always call `logger::start()` before logging and `logger::stop()` during
+  shutdown. `stop()` flushes the queue, so do not skip it on the happy path.
+- The worker thread is interruptible (`std::jthread`); calling `stop()` from
+  a signal handler is safe as long as you do not also `delete` the logger
+  from the same handler.
+- If `enqueue` returns an error result the queue is full. Decide between
+  @em drop (best-effort logs) and @em block (critical audit) based on the
+  log type. Use `critical_writer` for the latter.
+
+@section prod_rotation Log Rotation
+
+`rotating_file_writer` rotates by file size and keeps a configurable number
+of historical segments. Pair it with a retention policy that matches your
+storage budget.
+
+@code{.cpp}
+auto rotating = writer_builder()
+    .rotating_file(
+        "logs/app.log",        // base path; segments are app.1.log, app.2.log, ...
+        50 * 1024 * 1024,      // 50 MB per segment
+        14)                    // keep 14 segments (~700 MB)
+    .buffered(4096)
+    .async()
+    .build();
+@endcode
+
+Tips:
+
+- Place log files on a dedicated volume so a rogue logger cannot exhaust
+  the system root partition.
+- Compress rotated segments out-of-band (`logrotate`, `cronolog`, or a
+  systemd timer running `gzip`). logger_system intentionally avoids in-process
+  compression to keep the hot path predictable.
+- Combine size-based rotation with daily timestamped paths
+  (`logs/app-%Y-%m-%d.log`) using a wrapper script if you need calendar-aligned
+  shipping.
+
+@section prod_otlp OpenTelemetry Export
+
+When `LOGGER_ENABLE_OTLP=ON`, the `otlp_writer` exports log records to any
+OTLP-compatible collector via HTTP/Protobuf or gRPC. It batches records,
+retries with exponential backoff, and propagates trace/span IDs that the
+structured logger has placed in the entry's context.
+
+@code{.cpp}
+#include <kcenon/logger/builders/writer_builder.h>
+#include <kcenon/logger/otlp/otlp_context.h>
+
+using namespace kcenon::logger;
+
+otlp::otlp_endpoint endpoint;
+endpoint.url = "https://otel-collector.internal:4318/v1/logs";
+endpoint.protocol = otlp::otlp_protocol::http_protobuf;
+endpoint.headers["x-tenant"] = "checkout";
+
+auto otlp = writer_builder()
+    .otlp(endpoint)
+    .buffered(1024)
+    .async(16384)
+    .build();
+@endcode
+
+Operational guidance:
+
+- Run a local collector (Otel Collector, Vector, Fluent Bit) on the same host
+  to absorb network hiccups and batch upstream traffic.
+- Set `service.name` and `service.version` resource attributes via the
+  `otlp_context` so logs join distributed traces correctly.
+- Combine OTLP with a local file writer in a `composite_writer` so you keep a
+  durable copy when the collector is unreachable.
+
+@section prod_examples Three Production Examples
+
+@subsection prod_example_web Example 1: Stateless Web Service
+
+Console for human operators, rotating file for forensic analysis, OTLP for
+SRE dashboards.
+
+@code{.cpp}
+auto console = writer_builder().console().build();
+
+auto rotating = writer_builder()
+    .rotating_file("logs/web.log", 100 * 1024 * 1024, 10)
+    .buffered(4096)
+    .async(32768)
+    .build();
+
+auto otlp = writer_builder()
+    .otlp({.url = "http://localhost:4318/v1/logs",
+           .protocol = otlp::otlp_protocol::http_protobuf})
+    .buffered(1024)
+    .async(16384)
+    .build();
+
+auto log = logger_builder()
+    .add_writer(std::move(console))
+    .add_writer(std::move(rotating))
+    .add_writer(std::move(otlp))
+    .build();
+@endcode
+
+@subsection prod_example_audit Example 2: Compliance / Audit Pipeline
+
+Encrypted at rest, durable on flush, never lossy.
+
+@code{.cpp}
+#include <kcenon/logger/security/secure_key_storage.h>
+
+auto key = security::secure_key_storage::generate_key(32).value();
+
+auto audit = writer_builder()
+    .file("logs/audit.log.enc")
+    .encrypted(std::move(key))
+    .buffered(1024)
+    .critical()             // wait-free, blocking enqueue when full
+    .build();
+
+auto log = logger_builder()
+    .with_async(false)      // sync to guarantee durability per call
+    .add_writer(std::move(audit))
+    .build();
+@endcode
+
+@subsection prod_example_batch Example 3: Batch Job with Bulk Throughput
+
+A nightly ETL job that processes millions of records and needs maximum
+throughput. Keep the console for the operator, dump everything to a high-
+throughput file pipeline.
+
+@code{.cpp}
+auto console = writer_builder().console().build();
+
+auto bulk = writer_builder()
+    .rotating_file("logs/etl.log", 256 * 1024 * 1024, 5)
+    .buffered(16384)
+    .batch(4096)
+    .async(262144)        // 256k async queue
+    .build();
+
+auto log = logger_builder()
+    .with_async(true)
+    .with_queue_size(262144)
+    .add_writer(std::move(console))
+    .add_writer(std::move(bulk))
+    .build();
+
+log->start();
+run_etl(*log);
+log->stop();              // flushes ~256k entries on shutdown
+@endcode
+
+@section prod_metrics Metrics and Self-Observability
+
+Build with the monitoring backend (`LOGGER_USE_MONITORING=ON`) or attach the
+metrics collector exposed by `logger::metrics()` to gain visibility into:
+
+- Queue depth and high-water mark
+- Drop counts (per queue and per filter)
+- Bytes written, syscalls issued, retries triggered
+- Per-writer latency histograms
+
+Export those counters to your monitoring system (Prometheus, OpenTelemetry,
+or `monitoring_system`) and alert on `dropped_total > 0` and
+`queue_high_water > 0.8 * capacity`.
+
+@section prod_next Next Steps
+
+- @ref tutorial_basic_logging - re-read if any of the prerequisites feel
+  unfamiliar.
+- @ref tutorial_decorators - deep dive on the decorator chain semantics.
+- @ref faq - quick references for tuning and integration questions.
+- @ref troubleshooting - field manual for the most common production
+  incidents.
+
+*/


### PR DESCRIPTION
Closes #588

## Summary
- Add three tutorial pages: basic logging, decorator composition, production configuration. Each contains three runnable code examples.
- Add `faq.dox` covering the ten most common adoption questions (rotation, async vs sync, custom writers, monitoring, thread safety, performance, OTLP, decorator order, field conventions, encryption).
- Add `troubleshooting.dox` covering lost messages, file permission errors, async queue overflow, performance degradation, and decorator composition pitfalls.
- Surface the new pages from `mainpage.dox` under a new Learning Resources section.

## Test plan
- [x] Files added under `docs/` and picked up by the existing Doxyfile (no Doxyfile changes required).
- [x] Local Doxygen build (1.16.1) reports zero warnings against the new pages.
- [x] Existing pre-existing warnings unchanged (verified mainpage.dox introduces no new warnings).
- [ ] CI runs Doxygen build and tests.