### PR TITLE
fix(vcpkg): define BUILD_WITH_COMMON_SYSTEM and correct usage target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -657,6 +657,10 @@ if(INSTALL_TARGETS)
     endif()
 endif()
 
+# common_system is a mandatory dependency; ensure the config template
+# substitutes @BUILD_WITH_COMMON_SYSTEM@ correctly.
+set(BUILD_WITH_COMMON_SYSTEM ON CACHE BOOL "Build with common_system integration")
+
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/logger_system-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config.cmake
@@ -669,14 +673,12 @@ write_basic_package_version_file(
     COMPATIBILITY SameMajorVersion
 )
 
-# Install adapter headers if BUILD_WITH_COMMON_SYSTEM is enabled
-if(BUILD_WITH_COMMON_SYSTEM)
-    install(FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/logger/adapters/common_logger_adapter.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/logger/adapters
-        COMPONENT Development
-    )
-endif()
+# Install adapter headers (common_system is always required)
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/kcenon/logger/adapters/common_logger_adapter.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/logger/adapters
+    COMPONENT Development
+)
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config.cmake

--- a/vcpkg-ports/kcenon-logger-system/usage
+++ b/vcpkg-ports/kcenon-logger-system/usage
@@ -1,6 +1,6 @@
 The package kcenon-logger-system provides CMake targets:
 
     find_package(logger_system CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE logger_system::LoggerSystem)
+    target_link_libraries(main PRIVATE logger_system::logger)
 
 Available features: encryption, otlp


### PR DESCRIPTION
## What

### Summary
Fixes three vcpkg packaging issues that prevented downstream consumers from correctly
finding `common_system` and linking `logger_system`.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `CMakeLists.txt` — cache variable definition + adapter header install
- `vcpkg-ports/kcenon-logger-system/usage` — target name correction

## Why

### Problem Solved
1. **`BUILD_WITH_COMMON_SYSTEM` undefined** — The config template
   (`logger_system-config.cmake.in`) substitutes `@BUILD_WITH_COMMON_SYSTEM@` but the
   variable was never defined as a cache variable, resulting in an empty substitution.
   This caused `find_dependency(common_system REQUIRED)` to be skipped entirely, breaking
   downstream builds that depend on common_system types (e.g., `Result<T>`).

2. **Adapter headers conditionally installed on undefined variable** — The
   `common_logger_adapter.h` install was gated on `BUILD_WITH_COMMON_SYSTEM`, which was
   always falsy due to issue #1. Since common_system is mandatory, this condition is
   unnecessary.

3. **Wrong target name in usage file** — The usage file referenced
   `logger_system::LoggerSystem`, but the actual exported target (set via `EXPORT_NAME logger`
   on line 346) is `logger_system::logger`.

### Related Issues
- Closes #591

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `CMakeLists.txt` | Define `BUILD_WITH_COMMON_SYSTEM` cache var; make adapter install unconditional |
| `vcpkg-ports/kcenon-logger-system/usage` | Fix target name |

## How

### Implementation Details
1. Added `set(BUILD_WITH_COMMON_SYSTEM ON CACHE BOOL ...)` before
   `configure_package_config_file()` so the template substitution produces `ON`
2. Removed the `if(BUILD_WITH_COMMON_SYSTEM)` guard around adapter header installation
   since common_system is always required
3. Changed `logger_system::LoggerSystem` to `logger_system::logger` in the usage file

### Breaking Changes
None — these are all correctness fixes for the install/packaging layer.