### PR TITLE
fix(cmake): forward all template variables before configure_package_config_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -661,6 +661,32 @@ endif()
 # substitutes @BUILD_WITH_COMMON_SYSTEM@ correctly.
 set(BUILD_WITH_COMMON_SYSTEM ON CACHE BOOL "Build with common_system integration")
 
+# Ensure all @VAR@ references in the config template resolve to explicit
+# values.  The variables originate from option()/set(CACHE) calls in
+# logger_features.cmake and this file.  Forwarding them as normal (non-cache)
+# variables here guarantees configure_package_config_file() never substitutes
+# an empty string, regardless of cache evaluation order.
+#
+# Feature flags
+set(LOGGER_USE_DI                  "${LOGGER_USE_DI}")
+set(LOGGER_USE_MONITORING          "${LOGGER_USE_MONITORING}")
+set(LOGGER_USE_EXTERNAL_DI         "${LOGGER_USE_EXTERNAL_DI}")
+set(LOGGER_FORCE_LIGHTWEIGHT       "${LOGGER_FORCE_LIGHTWEIGHT}")
+set(LOGGER_ENABLE_CRASH_HANDLER    "${LOGGER_ENABLE_CRASH_HANDLER}")
+set(LOGGER_ENABLE_STRUCTURED_LOGGING "${LOGGER_ENABLE_STRUCTURED_LOGGING}")
+set(LOGGER_USE_LOCK_FREE_QUEUE     "${LOGGER_USE_LOCK_FREE_QUEUE}")
+set(LOGGER_ENABLE_NETWORK_WRITER   "${LOGGER_ENABLE_NETWORK_WRITER}")
+set(LOGGER_ENABLE_FILE_ROTATION    "${LOGGER_ENABLE_FILE_ROTATION}")
+set(LOGGER_ENABLE_ASYNC            "${LOGGER_ENABLE_ASYNC}")
+set(LOGGER_USE_COMPRESSION         "${LOGGER_USE_COMPRESSION}")
+set(LOGGER_USE_ENCRYPTION          "${LOGGER_USE_ENCRYPTION}")
+set(LOGGER_USE_THREAD_SYSTEM       "${LOGGER_USE_THREAD_SYSTEM}")
+# Performance settings
+set(LOGGER_DEFAULT_BUFFER_SIZE     "${LOGGER_DEFAULT_BUFFER_SIZE}")
+set(LOGGER_DEFAULT_BATCH_SIZE      "${LOGGER_DEFAULT_BATCH_SIZE}")
+set(LOGGER_DEFAULT_QUEUE_SIZE      "${LOGGER_DEFAULT_QUEUE_SIZE}")
+set(LOGGER_MAX_WRITERS             "${LOGGER_MAX_WRITERS}")
+
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/logger_system-config.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/logger_system-config.cmake


### PR DESCRIPTION
## What

### Summary
Forward all 17 `@VAR@` references in `logger_system-config.cmake.in` as explicit normal (non-cache) variables before `configure_package_config_file()`, ensuring no template variable ever resolves to an empty string.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `CMakeLists.txt` — added explicit variable forwarding block (lines 664-689)

## Why

### Problem Solved
The config template references 17 variables defined via `option()` / `set(CACHE)` in `logger_features.cmake` and `CMakeLists.txt`. While CMake's `configure_file()` does resolve cache variables, explicitly forwarding them as normal variables guarantees correct substitution regardless of cache evaluation order, and prevents malformed `set()` calls (e.g., `set(logger_system_USE_DI )`) in the generated config.

### Related Issues
- Closes #593 (Clean up undefined template variables in config cmake template)
- Follows up on #592 which fixed `BUILD_WITH_COMMON_SYSTEM`

### Alternative Approaches Considered
1. **Remove variables from template** — rejected because downstream consumers rely on these feature flags to conditionally find dependencies and configure their builds
2. **Keep as-is (cache-only)** — while technically functional, explicit forwarding is more robust and self-documenting

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `/` | `CMakeLists.txt` | Added variable forwarding block |

### Variables Forwarded
| Category | Variables |
|----------|-----------|
| Feature flags | `LOGGER_USE_DI`, `LOGGER_USE_MONITORING`, `LOGGER_USE_EXTERNAL_DI`, `LOGGER_FORCE_LIGHTWEIGHT`, `LOGGER_ENABLE_CRASH_HANDLER`, `LOGGER_ENABLE_STRUCTURED_LOGGING`, `LOGGER_USE_LOCK_FREE_QUEUE`, `LOGGER_ENABLE_NETWORK_WRITER`, `LOGGER_ENABLE_FILE_ROTATION`, `LOGGER_ENABLE_ASYNC`, `LOGGER_USE_COMPRESSION`, `LOGGER_USE_ENCRYPTION`, `LOGGER_USE_THREAD_SYSTEM` |
| Performance | `LOGGER_DEFAULT_BUFFER_SIZE`, `LOGGER_DEFAULT_BATCH_SIZE`, `LOGGER_DEFAULT_QUEUE_SIZE`, `LOGGER_MAX_WRITERS` |

## How

### Implementation Details
Each cache variable is re-assigned as a normal variable via `set(VAR "${VAR}")` immediately before `configure_package_config_file()`. This is a standard CMake idiom — `configure_file()` prefers normal variables over cache variables, so the forwarding ensures the values are always found during `@VAR@` substitution.

The existing `BUILD_WITH_COMMON_SYSTEM` definition (added in #592) is preserved as-is.

### Testing
- [ ] CI build passes on all platforms (Ubuntu GCC/Clang, macOS, Windows MSVC)
- [ ] Verify generated `logger_system-config.cmake` contains no empty `set()` calls
- [ ] Downstream `find_package(logger_system)` works correctly

### Breaking Changes
None — this only ensures existing variables resolve correctly.