### PR TITLE
build(cmake): adopt tiered install degradation pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,6 +633,11 @@ if(INSTALL_TARGETS)
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
             INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         )
+
+        export(EXPORT logger_system-targets
+            FILE "${CMAKE_CURRENT_BINARY_DIR}/logger_system-targets.cmake"
+            NAMESPACE logger_system::
+        )
     endif()
 endif()
 
@@ -647,7 +652,20 @@ if(INSTALL_TARGETS)
         # its internal sub-targets (thread_base, etc.) are not in any export set.
         # Skip install(EXPORT) to avoid CMake errors. Consumers building from source
         # already have both logger_system and thread_system available.
-        message(STATUS "Logger System: Skipping install(EXPORT) — local thread_system linked (not IMPORTED)")
+        set(_LOGGER_NON_IMPORTED_DEPS "")
+        foreach(_ts_candidate ${thread_system_TARGET} ThreadSystem thread_system)
+            if(TARGET ${_ts_candidate})
+                get_target_property(_imp ${_ts_candidate} IMPORTED)
+                if(NOT _imp)
+                    list(APPEND _LOGGER_NON_IMPORTED_DEPS "${_ts_candidate}")
+                endif()
+            endif()
+        endforeach()
+        message(STATUS
+            "logger_system: install(EXPORT) skipped — non-IMPORTED deps: "
+            "${_LOGGER_NON_IMPORTED_DEPS}. "
+            "Headers and library are installed. "
+            "Subdirectory consumers: link to 'logger_system' target directly.")
     else()
         install(EXPORT logger_system-targets
             FILE logger_system-targets.cmake


### PR DESCRIPTION
Closes #597

## What

### Summary
Adopts the Tiered Install Degradation pattern in the CMake install section by adding a build-tree `export(EXPORT)` call and improving the diagnostic message when export is skipped.

### Change Type
- [x] Enhancement (improve existing functionality)

### Affected Components
- `CMakeLists.txt` — install section (lines 628-676)

## Why

### Problem Solved
- `add_subdirectory()` consumers cannot use `find_package(logger_system CONFIG)` against the build directory because `export(EXPORT ...)` is never called
- The diagnostic message when export is skipped does not name the specific non-IMPORTED dependency, making debugging harder
- Ecosystem consistency: aligns logger_system with the same Tiered Install Degradation pattern used in monitoring_system and database_system

### Related Issues
- Closes #597 (Adopt Tiered Install Degradation pattern for CMake install rules)
- Cross-ref: kcenon/monitoring_system, kcenon/database_system (same pattern rollout)

## Where

### Files Changed
| File | Change |
|------|--------|
| `CMakeLists.txt` | Added `export(EXPORT ...)` in CAN_EXPORT branch; improved diagnostic message with non-IMPORTED dep enumeration |

### Files Verified Unchanged
| File | Reason |
|------|--------|
| `cmake/logger_system-config.cmake.in` | Already has `EXISTS` guard on line 30 |

## How

### Implementation Details
1. **Build-tree export** (Tier 3): Added `export(EXPORT logger_system-targets ...)` after the existing `install(EXPORT ...)` call in the branch where all deps are IMPORTED. This writes a targets file to the build directory, enabling `find_package()` from the build tree.

2. **Diagnostic improvement**: In the `_LOGGER_HAS_LOCAL_THREAD_SYSTEM=TRUE` branch, added a `foreach` loop that iterates over candidate target names (`${thread_system_TARGET}`, `ThreadSystem`, `thread_system`), checks each with `get_target_property(IMPORTED)`, and collects non-IMPORTED names into `_LOGGER_NON_IMPORTED_DEPS`. The status message now includes these specific dependency names.

### Testing
- [ ] Existing CI passes on all platforms (Ubuntu, macOS, Windows)
- [ ] `cmake --install` in a vcpkg build produces identical output to current
- [ ] Status message names the specific non-IMPORTED dependency

### Breaking Changes
None — additive changes only. Existing install behavior is preserved.