### PR TITLE
fix(network-writer): replace gethostbyname with getaddrinfo

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,19 +21,19 @@ Logger system internal architecture and ecosystem integration overview.
 
 ## Table of Contents
 
-- [Logger Pipeline Architecture](#-logger-pipeline-architecture)
-- [Writer Architecture](#-writer-architecture)
-- [OTLP & Observability Pipeline](#-otlp--observability-pipeline)
-- [Sampling & Analysis Pipeline](#-sampling--analysis-pipeline)
-- [Ecosystem Overview](#-ecosystem-overview)
-- [Project Roles & Responsibilities](#-project-roles--responsibilities)
-- [Dependency Flow & Interface Contracts](#-dependency-flow--interface-contracts)
-- [Integration Patterns](#-integration-patterns)
-- [Performance Characteristics](#-performance-characteristics)
-- [Evolution: Monolithic → Modular](#-evolution-monolithic--modular)
-- [Getting Started](#-getting-started)
-- [Documentation Structure](#-documentation-structure)
-- [Future Roadmap](#-future-roadmap)
+- [Logger Pipeline Architecture](#logger-pipeline-architecture)
+- [Writer Architecture](#writer-architecture)
+- [OTLP & Observability Pipeline](#otlp--observability-pipeline)
+- [Sampling & Analysis Pipeline](#sampling--analysis-pipeline)
+- [Ecosystem Overview](#ecosystem-overview)
+- [Project Roles & Responsibilities](#project-roles--responsibilities)
+- [Dependency Flow & Interface Contracts](#dependency-flow--interface-contracts)
+- [Integration Patterns](#integration-patterns)
+- [Performance Characteristics](#performance-characteristics)
+- [Evolution: Monolithic → Modular → Standalone](#evolution-monolithic--modular--standalone)
+- [Getting Started](#getting-started)
+- [Documentation Structure](#documentation-structure)
+- [Future Roadmap](#future-roadmap)
 
 ## Overview
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -126,7 +126,7 @@ The following legacy writer patterns are **deprecated** and will be removed in v
 
 #### Migration Support
 
-- See [Deprecation Timeline and Legacy Patterns](guides/DECORATOR_MIGRATION.md#deprecation-timeline-and-legacy-patterns) for detailed migration scenarios
+- See [Deprecation Timeline and Legacy Patterns](guides/DECORATOR_MIGRATION.md) for detailed migration scenarios
 - 6+ common migration patterns documented with before/after code
 - Full backward compatibility maintained in v4.x series
 

--- a/src/impl/writers/network_writer.cpp
+++ b/src/impl/writers/network_writer.cpp
@@ -36,7 +36,6 @@
 #include <cstring>
 #include <functional>
 #include <iomanip>
-#include <iostream>
 #include <sstream>
 #include <thread>
 
@@ -335,61 +334,48 @@ bool network_writer::connect() {
         return true;
     }
 
-    // Create socket
+    // Resolve hostname using getaddrinfo (thread-safe, IPv4/IPv6)
     int sock_type = (protocol_ == protocol_type::tcp) ? SOCK_STREAM : SOCK_DGRAM;
-    socket_fd_ = socket(AF_INET, sock_type, 0);
-    if (socket_fd_ < 0) {
-        std::cerr << "Failed to create socket: " << strerror(errno) << std::endl;
+
+    struct addrinfo hints{}, *result = nullptr;
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = sock_type;
+
+    auto port_str = std::to_string(port_);
+    int rv = getaddrinfo(host_.c_str(), port_str.c_str(), &hints, &result);
+    if (rv != 0) {
+        std::lock_guard<std::mutex> lock(stats_mutex_);
+        stats_.connection_failures++;
+        stats_.last_error = std::chrono::system_clock::now();
         return false;
     }
 
-    // Resolve hostname
-    struct hostent* server = gethostbyname(host_.c_str());
-    if (!server) {
-        std::cerr << "Failed to resolve host: " << host_ << std::endl;
-        ::close(socket_fd_);
-        socket_fd_ = -1;
-        return false;
-    }
+    // Try each resolved address until one succeeds
+    for (auto* rp = result; rp != nullptr; rp = rp->ai_next) {
+        socket_fd_ = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (socket_fd_ < 0) {
+            continue;
+        }
 
-    // Setup server address
-    struct sockaddr_in server_addr{};
-    server_addr.sin_family = AF_INET;
-    server_addr.sin_port = htons(port_);
-    std::memcpy(&server_addr.sin_addr.s_addr, server->h_addr, server->h_length);
-
-    // Connect (TCP only)
-    if (protocol_ == protocol_type::tcp) {
-        if (::connect(socket_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
-            std::cerr << "Failed to connect to " << host_ << ":" << port_
-                     << " - " << strerror(errno) << std::endl;
-            ::close(socket_fd_);
-            socket_fd_ = -1;
+        if (::connect(socket_fd_, rp->ai_addr, static_cast<socklen_t>(rp->ai_addrlen)) == 0) {
+            freeaddrinfo(result);
+            connected_ = true;
 
             std::lock_guard<std::mutex> lock(stats_mutex_);
-            stats_.connection_failures++;
-            stats_.last_error = std::chrono::system_clock::now();
-            return false;
+            stats_.last_connected = std::chrono::system_clock::now();
+            return true;
         }
-    } else {
-        // For UDP, just save the server address
-        if (::connect(socket_fd_, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
-            std::cerr << "Failed to set UDP destination: " << strerror(errno) << std::endl;
-            ::close(socket_fd_);
-            socket_fd_ = -1;
-            return false;
-        }
+
+        ::close(socket_fd_);
+        socket_fd_ = -1;
     }
 
-    connected_ = true;
+    freeaddrinfo(result);
 
     std::lock_guard<std::mutex> lock(stats_mutex_);
-    stats_.last_connected = std::chrono::system_clock::now();
-
-    std::cout << "Connected to " << host_ << ":" << port_
-              << " via " << (protocol_ == protocol_type::tcp ? "TCP" : "UDP") << std::endl;
-
-    return true;
+    stats_.connection_failures++;
+    stats_.last_error = std::chrono::system_clock::now();
+    return false;
 }
 
 void network_writer::disconnect() {
@@ -413,7 +399,6 @@ bool network_writer::send_data(const std::string& data) {
     if (sent < 0) {
         if (protocol_ == protocol_type::tcp) {
             // TCP connection lost
-            std::cerr << "Send failed: " << strerror(errno) << std::endl;
             disconnect();
 
             std::lock_guard<std::mutex> lock(stats_mutex_);
@@ -449,7 +434,6 @@ void network_writer::process_buffer() {
 
 void network_writer::attempt_reconnect() {
     if (!connected_ && running_) {
-        std::cout << "Attempting to reconnect to " << host_ << ":" << port_ << std::endl;
         connect();
     }
 }


### PR DESCRIPTION
## What

### Summary
Replaces the deprecated, non-reentrant `gethostbyname()` with the thread-safe, IPv6-ready `getaddrinfo()` in `network_writer::connect()`. Removes all `std::cout`/`std::cerr` calls that bypassed the logging system.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/impl/writers/network_writer.cpp` — `connect()`, `attempt_reconnect()`, `send_data()`

## Why

### Problem Solved
`gethostbyname()` uses a static internal buffer that is not thread-safe. In the async logger context, multiple writer threads or reconnection workers could call `connect()` concurrently, corrupting the shared DNS resolution buffer. Additionally, `std::cout`/`std::cerr` output from a log writer interferes with console writers and test stdout capture.

### Related Issues
- Closes #600

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `src/impl/writers/network_writer.cpp` | Replace `gethostbyname` → `getaddrinfo`, remove stdout/stderr |
| `docs/ARCHITECTURE.md` | Fix pre-existing broken TOC anchors |
| `docs/CHANGELOG.md` | Fix cross-file anchor to non-indexed directory |

## How

### Implementation Details
1. `getaddrinfo()` with `AF_UNSPEC` hint resolves both IPv4 and IPv6 addresses
2. Iterate all resolved addresses (`ai_next` chain) until one succeeds — more robust than single-address resolution
3. Proper `freeaddrinfo()` cleanup on all code paths
4. `socklen_t` cast for cross-platform compatibility
5. All `std::cout`/`std::cerr` removed — errors reported via return values and `connection_stats`
6. Unused `<iostream>` include removed

### Breaking Changes
None — `connect()` return type and behavior unchanged. Status messages previously on stdout are no longer emitted.