### PR TITLE
fix(cmake): correct exported target name in config and documentation

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -151,8 +151,8 @@ cmake --build . --target install
 
 프로젝트에서 사용:
 ```cmake
-find_package(LoggerSystem REQUIRED)
-target_link_libraries(your_app PRIVATE LoggerSystem::logger)
+find_package(logger_system REQUIRED)
+target_link_libraries(your_app PRIVATE logger_system::logger_system)
 ```
 
 ### 의존성과 함께 빌드

--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ cmake --build . --target install
 
 **Using in Your Project**:
 ```cmake
-find_package(LoggerSystem REQUIRED)
-target_link_libraries(your_app PRIVATE LoggerSystem::logger)
+find_package(logger_system REQUIRED)
+target_link_libraries(your_app PRIVATE logger_system::logger_system)
 ```
 
 ### Requirements

--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -60,6 +60,7 @@ set(_UNIFIED_TARGET_MAP_thread_system
 )
 
 set(_UNIFIED_TARGET_MAP_logger_system
+    "logger_system::logger_system"
     "logger"
     "logger_system::logger"
     "logger_system"

--- a/cmake/logger_system-config.cmake.in
+++ b/cmake/logger_system-config.cmake.in
@@ -33,7 +33,7 @@ endif()
 
 # Set variables for compatibility
 set(logger_system_FOUND TRUE)
-set(logger_system_LIBRARIES logger_system::logger)
+set(logger_system_LIBRARIES logger_system::logger_system)
 
 # Provide the features that were enabled during build
 set(logger_system_USE_DI @LOGGER_USE_DI@)

--- a/docs/advanced/STRUCTURE.md
+++ b/docs/advanced/STRUCTURE.md
@@ -492,12 +492,10 @@ monitoring_system (OPTIONAL)
 
 ```cmake
 # Main library
-LoggerSystem::logger          # Header-only or compiled library
+logger_system::logger_system  # Compiled library (via find_package(logger_system))
 
-# Component targets (internal)
-LoggerSystem::core            # Core logger components
-LoggerSystem::writers         # Writer implementations
-LoggerSystem::formatters      # Formatter implementations
+# Note: Component-level targets are not currently exported.
+# All components are linked into the single logger_system target.
 ```
 
 ### Feature Flags

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -45,14 +45,14 @@ Add the following to your `CMakeLists.txt`:
 include(FetchContent)
 
 FetchContent_Declare(
-    LoggerSystem
+    logger_system
     GIT_REPOSITORY https://github.com/kcenon/logger_system.git
     GIT_TAG v0.1.0  # Pin to a specific release tag; do NOT use main
 )
-FetchContent_MakeAvailable(LoggerSystem)
+FetchContent_MakeAvailable(logger_system)
 
 # Link to your target
-target_link_libraries(your_target PRIVATE LoggerSystem::logger)
+target_link_libraries(your_target PRIVATE logger_system::logger_system)
 ```
 
 ### Building from Source
@@ -80,8 +80,8 @@ sudo cmake --install .
 If you've installed the logger system:
 
 ```cmake
-find_package(LoggerSystem REQUIRED)
-target_link_libraries(your_target PRIVATE LoggerSystem::logger)
+find_package(logger_system REQUIRED)
+target_link_libraries(your_target PRIVATE logger_system::logger_system)
 ```
 
 ## Basic Usage

--- a/docs/guides/INTEGRATION.md
+++ b/docs/guides/INTEGRATION.md
@@ -62,7 +62,7 @@ common_system (interfaces) ← logger_system implements ILogger
 **CMake Configuration**:
 ```cmake
 find_package(common_system CONFIG REQUIRED)
-target_link_libraries(LoggerSystem PUBLIC kcenon::common_system)
+target_link_libraries(logger_system PUBLIC kcenon::common_system)
 ```
 
 ### Optional Dependencies
@@ -332,10 +332,10 @@ cmake_minimum_required(VERSION 3.16)
 project(MyApp)
 
 # Find logger_system
-find_package(LoggerSystem CONFIG REQUIRED)
+find_package(logger_system CONFIG REQUIRED)
 
 add_executable(myapp main.cpp)
-target_link_libraries(myapp PRIVATE LoggerSystem::logger)
+target_link_libraries(myapp PRIVATE logger_system::logger_system)
 ```
 
 #### Full Ecosystem Integration
@@ -346,7 +346,7 @@ project(MyApp)
 # Find all systems
 find_package(common_system CONFIG REQUIRED)
 find_package(thread_system CONFIG REQUIRED)
-find_package(LoggerSystem CONFIG REQUIRED)
+find_package(logger_system CONFIG REQUIRED)
 find_package(monitoring_system CONFIG QUIET)
 
 add_executable(myapp main.cpp)
@@ -355,7 +355,7 @@ add_executable(myapp main.cpp)
 target_link_libraries(myapp PRIVATE
     kcenon::common_system      # Foundation
     kcenon::thread_system      # Core systems
-    LoggerSystem::logger       # Service systems
+    logger_system::logger_system  # Service systems
 )
 
 # Optional monitoring integration
@@ -633,7 +633,7 @@ sudo cmake --install build
 target_link_libraries(MyApp PRIVATE
     kcenon::common_system      # Foundation (first)
     kcenon::thread_system      # Core systems
-    LoggerSystem::logger       # Service systems
+    logger_system::logger_system  # Service systems
     kcenon::monitoring_system  # Optional systems (last)
 )
 ```

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -138,10 +138,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # logger_system 찾기
-find_package(LoggerSystem REQUIRED)
+find_package(logger_system REQUIRED)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE LoggerSystem::logger)
+target_link_libraries(my_app PRIVATE logger_system::logger_system)
 ```
 
 또는 FetchContent 사용:

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -138,10 +138,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find logger_system
-find_package(LoggerSystem REQUIRED)
+find_package(logger_system REQUIRED)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE LoggerSystem::logger)
+target_link_libraries(my_app PRIVATE logger_system::logger_system)
 ```
 
 Or using FetchContent:


### PR DESCRIPTION
Closes #606

## What

### Summary
Corrects the CMake exported target name from `logger_system::logger` to `logger_system::logger_system` across the config template and all documentation. This ensures consumers using `find_package(logger_system)` get the correct target reference.

### Change Type
- [x] Bugfix (fixes an issue)
- [x] Documentation

## Why

### Problem Solved
The CMake config template (`logger_system-config.cmake.in`) set `logger_system_LIBRARIES` to `logger_system::logger`, but the actual IMPORTED target created by `install(EXPORT ... NAMESPACE logger_system::)` for the `logger_system` library is `logger_system::logger_system`. Consumers using the `${logger_system_LIBRARIES}` variable would fail to link.

### Related Issues
- Closes #606 (Audit public API freeze for v1.0)
- Part of #604 (Prepare logger_system for v1.0 release)

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `cmake/` | 2 | Config fix, target map update |
| `README.md`, `README.kr.md` | 2 | Usage example correction |
| `docs/guides/` | 4 | CMake examples alignment |
| `docs/advanced/` | 1 | Target documentation |

## How

### Implementation Details
1. **Config fix**: `logger_system-config.cmake.in` line 36 — changed `logger_system::logger` to `logger_system::logger_system`
2. **Target map**: Added `logger_system::logger_system` to `_UNIFIED_TARGET_MAP_logger_system` as first entry for priority resolution
3. **Documentation**: Updated all `find_package()` and `target_link_libraries()` examples from `LoggerSystem`/`LoggerSystem::logger` to `logger_system`/`logger_system::logger_system`

### API Freeze Audit Results
| Criteria | Status |
|----------|--------|
| Deprecated APIs | Clean — no `[[deprecated]]` markers in public headers |
| Throw statements | 9 total, all defensive (Result<T> accessors, constructor validation, re-throw) |
| CMake exports | Fixed — target correctly exported as `logger_system::logger_system` |
| `find_package()` config | Complete with dependency resolution and feature flags |

### Test Plan
- CI build verifies CMake configuration compiles correctly
- Consumers using `find_package(logger_system)` + `${logger_system_LIBRARIES}` will now resolve to the correct target

### Breaking Changes
None — this fixes an already-broken `logger_system_LIBRARIES` variable. Direct `logger_system::logger_system` usage was already correct.