### PR TITLE
chore(release): bump version to 1.0.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-04-15
+
 ### Changed
 
 - **BREAKING**: Remove 8 deprecated context methods from `logger` public API; use `context()` unified API instead ([#534](https://github.com/kcenon/logger_system/issues/534))
+- Fix CMake exported target name from `logger_system::logger` to `logger_system::logger_system` in config template ([#606](https://github.com/kcenon/logger_system/issues/606))
+- Align `find_package()` and `target_link_libraries()` documentation with actual CMake target names ([#606](https://github.com/kcenon/logger_system/issues/606))
+
+### Added
+
+- Unit tests for `logger_registry`, `console_writer`, and `standalone_executor` (46 new test cases) ([#607](https://github.com/kcenon/logger_system/issues/607))
 
 ### Performance
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 ##################################################
 project(
     logger_system
-    VERSION 0.1.3
+    VERSION 1.0.0
     DESCRIPTION "High-performance C++20 logging system with asynchronous batching"
     HOMEPAGE_URL "https://github.com/kcenon/logger_system"
     LANGUAGES CXX

--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -114,7 +114,7 @@ set(_UNIFIED_REPO_network_system "network_system")
 # Keep in sync with ecosystem release versions
 set(_UNIFIED_DEFAULT_TAG_common_system "78080b2d85bf73472abf971946bf1537d3f128f2")
 set(_UNIFIED_DEFAULT_TAG_thread_system "v0.3.1")
-set(_UNIFIED_DEFAULT_TAG_logger_system "v0.1.3")
+set(_UNIFIED_DEFAULT_TAG_logger_system "v1.0.0")
 set(_UNIFIED_DEFAULT_TAG_monitoring_system "v0.1.0")
 set(_UNIFIED_DEFAULT_TAG_container_system "v0.1.0")
 set(_UNIFIED_DEFAULT_TAG_database_system "v0.1.0")

--- a/vcpkg-ports/kcenon-logger-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-logger-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-logger-system",
-  "version-semver": "0.1.3",
-  "port-version": 7,
+  "version-semver": "1.0.0",
+  "port-version": 0,
   "description": "High-performance C++20 async logging framework with 4.34M msg/sec throughput, 148ns latency, and modular architecture",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-logger-system",
-  "version-semver": "0.1.3",
-  "port-version": 4,
+  "version-semver": "1.0.0",
+  "port-version": 0,
   "description": "High-performance C++20 async logging library with file rotation and console output",
   "homepage": "https://github.com/kcenon/logger_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Closes #608

## What

### Summary
Bumps version from 0.1.3 to 1.0.0 across all project files and finalizes the CHANGELOG with the v1.0.0 release entry.

### Change Type
- [x] Chore

## Why

### Problem Solved
Version 0.1.3 was still set across the project despite v1.0.0 release readiness being confirmed by the API freeze audit (#606), test coverage improvements (#607), and dependency resolution (common_system, thread_system both at v1.0).

### Related Issues
- Closes #608 (Prepare CHANGELOG and version bump for v1.0.0)
- Part of #604 (Prepare logger_system for v1.0 release)

## Where

### Files Changed
| File | Change |
|------|--------|
| `CMakeLists.txt` | `VERSION 0.1.3` → `1.0.0` |
| `vcpkg.json` | `version-semver` → `1.0.0`, `port-version` → 0 |
| `vcpkg-ports/.../vcpkg.json` | `version-semver` → `1.0.0`, `port-version` → 0 |
| `cmake/UnifiedDependencies.cmake` | Default tag `v0.1.3` → `v1.0.0` |
| `CHANGELOG.md` | New `[1.0.0]` section with breaking changes, fixes, and additions |

## How

### CHANGELOG v1.0.0 Entry Highlights
- **BREAKING**: 8 deprecated context methods removed (#534)
- **Changed**: CMake target name fixed to `logger_system::logger_system` (#606)
- **Added**: 46 new unit tests (#607)
- **Performance**: Lock-free queue and async writer optimizations (#532, #533)

### Breaking Changes
- v1.0.0 removes 8 deprecated context methods (documented in CHANGELOG)
- `SameMajorVersion` compatibility means 0.x consumers must update code