### PR TITLE
docs(guide): complete build and troubleshooting links

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,8 @@ int main() {
 ### Getting Started
 - 📖 [Getting Started Guide](docs/guides/GETTING_STARTED.md) - Step-by-step setup and basic usage
 - 🚀 [Quick Start Examples](examples/) - Hands-on examples
-- 🔧 [Quick Start Guide](docs/guides/QUICK_START.md) - Detailed build and startup instructions<!-- TODO: docs/guides/BUILD_GUIDE.md does not exist -->
+- 🔧 [Quick Start Guide](docs/guides/QUICK_START.md) - Detailed build and startup instructions
+- 🛠️ [Build Guide](docs/guides/BUILD.md) - Complete CMake options, presets, and optional features
 
 ### Core Documentation
 - 📘 [Features](docs/FEATURES.md) - Comprehensive feature documentation
@@ -560,7 +561,7 @@ int main() {
 ### Development
 - 🤝 [Contributing Guide](docs/contributing/CONTRIBUTING.md) - How to contribute
 - 📋 [FAQ](docs/guides/FAQ.md) - Frequently asked questions
-- 🔍 [Troubleshooting](docs/guides/FAQ.md) - Common issues and solutions<!-- TODO: docs/guides/TROUBLESHOOTING.md does not exist; FAQ lacks a dedicated troubleshooting section -->
+- 🔍 [Troubleshooting](docs/guides/TROUBLESHOOTING.md) - Common build, runtime, and integration issues
 - 📝 [Changelog](docs/CHANGELOG.md) - Release history and changes
 
 ---
@@ -649,7 +650,7 @@ cmake -DLOGGER_ENABLE_COVERAGE=ON     # Code coverage
 cmake -DLOGGER_WARNINGS_AS_ERRORS=ON  # Treat warnings as errors
 ```
 
-[🔧 Complete Build Options →](docs/guides/QUICK_START.md)<!-- TODO: docs/guides/BUILD_GUIDE.md does not exist -->
+[🔧 Complete Build Options →](docs/guides/BUILD.md)
 
 ---
 

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -629,7 +629,9 @@ option(LOGGER_ENABLE_COVERAGE "코드 커버리지 활성화" OFF)
 
 - [아키텍처 개요](ARCHITECTURE.md) / [아키텍처 (한국어)](ARCHITECTURE.kr.md) - 시스템 설계 및 아키텍처
 - [API 레퍼런스](API_REFERENCE.md) - 완전한 API 문서
-- [빠른 시작 가이드](guides/QUICK_START.md) - 빌드 및 시작 지침<!-- TODO: guides/BUILD_GUIDE.md does not exist -->
+- [빠른 시작 가이드](guides/QUICK_START.md) - 빌드 및 시작 지침
+- [Build Guide](guides/BUILD.md) - 전체 CMake 옵션, 프리셋, 선택적 기능
+- [Troubleshooting Guide](guides/TROUBLESHOOTING.md) - 빌드 및 런타임 공통 이슈
 - [기여 가이드](contributing/CONTRIBUTING.md) - 기여 가이드라인
 
 ---

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -672,5 +672,7 @@ option(LOGGER_ENABLE_COVERAGE "Enable code coverage" OFF)
 
 - [Architecture Overview](ARCHITECTURE.md) - System design and architecture
 - [API Reference](API_REFERENCE.md) - Complete API documentation
-- [Quick Start Guide](guides/QUICK_START.md) - Build and startup instructions<!-- TODO: guides/BUILD_GUIDE.md does not exist -->
+- [Quick Start Guide](guides/QUICK_START.md) - Build and startup instructions
+- [Build Guide](guides/BUILD.md) - Complete CMake options, presets, and optional features
+- [Troubleshooting Guide](guides/TROUBLESHOOTING.md) - Common build and runtime issues
 - [Contributing Guide](contributing/CONTRIBUTING.md) - Contribution guidelines

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ category: "GUID"
 > **SSOT**: This file is the single source of truth for the documentation index
 > of **logger_system**.
 
-Total documents: **71**
+Total documents: **73**
 
 ## Document Index
 
@@ -92,6 +92,8 @@ Total documents: **71**
 | 71 | LOG-PROJ-010 | Korean Translation Summary | [TRANSLATION_SUMMARY.md](./contributing/TRANSLATION_SUMMARY.md) | Released |
 | 72 | LOG-GUID-027 | Getting Started Tutorial (long-form) | [GETTING_STARTED.md](./GETTING_STARTED.md) | Released |
 | 73 | LOG-PROJ-011 | Ecosystem Integration Map | [ECOSYSTEM.md](./ECOSYSTEM.md) | Released |
+| 74 | LOG-GUID-028 | Logger System Build Guide | [BUILD.md](./guides/BUILD.md) | Released |
+| 75 | LOG-GUID-029 | Logger System Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
 
 ## Documents by Category
 
@@ -123,7 +125,7 @@ Total documents: **71**
 | LOG-FEAT-001 | Logger System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
 | LOG-FEAT-002 | Logger System Features | [FEATURES.md](./FEATURES.md) | Released |
 
-### Guides (25)
+### Guides (27)
 
 | doc_id | Topic | Document | Status |
 |--------|-------|----------|--------|
@@ -152,6 +154,8 @@ Total documents: **71**
 | LOG-GUID-024 | Logger System Integration Guide | [README.md](./integration/README.md) | Released |
 | LOG-GUID-025 | thread_system 통합 가이드 | [THREAD_SYSTEM.kr.md](./integration/THREAD_SYSTEM.kr.md) | Released |
 | LOG-GUID-026 | Async Integration Guide | [THREAD_SYSTEM.md](./integration/THREAD_SYSTEM.md) | Released |
+| LOG-GUID-028 | Logger System Build Guide | [BUILD.md](./guides/BUILD.md) | Released |
+| LOG-GUID-029 | Logger System Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
 
 ### Performance (8)
 

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -1,0 +1,303 @@
+---
+doc_id: "LOG-GUID-028"
+doc_title: "Logger System Build Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-18"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
+# Logger System Build Guide
+
+> **SSOT**: This document is the single source of truth for **Logger System Build Guide**.
+
+> **Language:** **English**
+
+This guide provides complete build instructions for `logger_system`, including
+prerequisites, CMake options, optional features, and presets.
+
+For a 5-minute smoke-test walkthrough, see
+[Quick Start Guide](QUICK_START.md). For getting started in code, see
+[Getting Started Guide](GETTING_STARTED.md).
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Source Layout](#source-layout)
+3. [Standard Build](#standard-build)
+4. [CMake Presets](#cmake-presets)
+5. [CMake Options](#cmake-options)
+6. [Optional Features](#optional-features)
+7. [Installing](#installing)
+8. [Consuming from Another Project](#consuming-from-another-project)
+9. [Platform Notes](#platform-notes)
+10. [Next Steps](#next-steps)
+
+---
+
+## Prerequisites
+
+| Requirement | Minimum Version |
+|-------------|-----------------|
+| CMake       | 3.20 (3.28+ for C++20 modules) |
+| C++ compiler | GCC 11+, Clang 14+, Apple Clang 14+, MSVC 2022+ |
+| Git         | any recent version |
+
+Required dependency:
+
+- [`common_system`](https://github.com/kcenon/common_system) - must be cloned
+  alongside `logger_system` in the same parent directory.
+
+Optional dependencies (enabled per-feature below):
+
+- OpenSSL - required when `LOGGER_USE_ENCRYPTION=ON` (default ON).
+- [`thread_system`](https://github.com/kcenon/thread_system) - required when
+  `LOGGER_USE_THREAD_SYSTEM=ON` (default OFF). Standalone `std::jthread` is
+  used otherwise.
+- [`opentelemetry-cpp`](https://github.com/open-telemetry/opentelemetry-cpp)
+  1.14+ - required when `LOGGER_ENABLE_OTLP=ON` (default OFF).
+- Google Test 1.17 - required when `BUILD_TESTS=ON` (default ON).
+- Google Benchmark 1.9.5 - required when `BUILD_BENCHMARKS=ON` (default OFF).
+
+---
+
+## Source Layout
+
+`logger_system` expects a peer-directory layout so CMake can locate optional
+sibling projects:
+
+```
+workspace/
+  common_system/        # required
+  thread_system/        # optional
+  logger_system/        # this project
+```
+
+Clone them side by side:
+
+```bash
+git clone https://github.com/kcenon/common_system.git
+git clone https://github.com/kcenon/thread_system.git   # optional
+git clone https://github.com/kcenon/logger_system.git
+cd logger_system
+```
+
+---
+
+## Standard Build
+
+```bash
+# Configure (Release build with tests)
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+# Compile
+cmake --build build -j
+
+# Run unit tests
+ctest --test-dir build --output-on-failure
+```
+
+Helper scripts are also provided:
+
+```bash
+# Linux / macOS
+./scripts/dependency.sh
+./scripts/build.sh
+
+# Windows
+./scripts/dependency.bat
+./scripts/build.bat
+```
+
+The build produces:
+
+- Static library `liblogger_system.a` (or `logger_system.lib` on MSVC)
+- CMake package files for downstream `find_package(logger_system)`
+- Test executables under `build/bin/` when `BUILD_TESTS=ON`
+
+---
+
+## CMake Presets
+
+Presets wrap the common configurations documented in `CMakePresets.json`:
+
+| Preset        | Purpose                                      |
+|---------------|----------------------------------------------|
+| `default`     | Release, tests on, warnings-as-errors off    |
+| `debug`       | `-DCMAKE_BUILD_TYPE=Debug`                   |
+| `release`     | `-DCMAKE_BUILD_TYPE=Release`                 |
+| `asan`        | AddressSanitizer + UBSan                     |
+| `tsan`        | ThreadSanitizer                              |
+| `ubsan`       | UndefinedBehaviorSanitizer                   |
+| `ci`          | Configuration used by the CI pipeline        |
+| `vcpkg`       | Uses the vcpkg toolchain file                |
+
+Example:
+
+```bash
+cmake --preset debug
+cmake --build --preset debug
+```
+
+---
+
+## CMake Options
+
+### Core Features
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `BUILD_TESTS` | `ON` | Build unit tests (Google Test) |
+| `BUILD_BENCHMARKS` | `OFF` | Build micro-benchmarks (Google Benchmark) |
+| `LOGGER_USE_DI` | `ON` | Dependency-injection-style writer composition |
+| `LOGGER_USE_MONITORING` | `ON` | Metrics and monitoring backend |
+| `LOGGER_ENABLE_ASYNC` | `ON` | Async writer implementations |
+| `LOGGER_ENABLE_CRASH_HANDLER` | `ON` | Crash-safe flush on signal/abort |
+
+### Advanced Features
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `LOGGER_ENABLE_STRUCTURED_LOGGING` | `OFF` | JSON / key-value structured logs |
+| `LOGGER_ENABLE_NETWORK_WRITER` | `OFF` | TCP/UDP network writer |
+| `LOGGER_ENABLE_FILE_ROTATION` | `ON` | Rotating file writer |
+| `LOGGER_USE_MODULES` | `OFF` | Experimental C++20 modules (CMake 3.28+) |
+| `LOGGER_USE_THREAD_SYSTEM` | `OFF` | Use `thread_system` pool for async I/O |
+| `LOGGER_USE_ENCRYPTION` | `ON` | AES-256 encrypted writer (requires OpenSSL) |
+| `LOGGER_ENABLE_OTLP` | `OFF` | OpenTelemetry log export |
+
+### Performance Tuning
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `LOGGER_DEFAULT_BUFFER_SIZE` | `16384` | Default per-writer buffer size (bytes) |
+| `LOGGER_DEFAULT_BATCH_SIZE` | `200` | Default batch-writer flush size |
+| `LOGGER_DEFAULT_QUEUE_SIZE` | `20000` | Default async queue depth |
+
+### Quality Assurance
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `LOGGER_ENABLE_SANITIZERS` | `OFF` | Enable sanitizer instrumentation |
+| `LOGGER_ENABLE_COVERAGE` | `OFF` | Emit coverage flags (gcov / llvm-cov) |
+| `LOGGER_WARNINGS_AS_ERRORS` | `OFF` | Treat compiler warnings as errors |
+
+See [Performance Guide](PERFORMANCE.md) for how these values affect throughput
+and latency in practice.
+
+---
+
+## Optional Features
+
+### Encryption (OpenSSL)
+
+```bash
+cmake -S . -B build -DLOGGER_USE_ENCRYPTION=ON
+```
+
+Install OpenSSL via your package manager (`apt install libssl-dev`,
+`brew install openssl@3`, or vcpkg `openssl`). See
+[Security Guide](SECURITY.md) for key-management details.
+
+### `thread_system` Integration
+
+```bash
+cmake -S . -B build -DLOGGER_USE_THREAD_SYSTEM=ON
+```
+
+When enabled, async writers submit work to the `thread_system` thread pool
+rather than spawning `std::jthread`s. See
+[Integration Guide](INTEGRATION.md).
+
+### OpenTelemetry Export
+
+```bash
+cmake -S . -B build -DLOGGER_ENABLE_OTLP=ON
+```
+
+Requires `opentelemetry-cpp` 1.14+ available via vcpkg or a system install.
+See [OpenTelemetry Guide](OPENTELEMETRY.md).
+
+### C++20 Modules (Experimental)
+
+```bash
+cmake -S . -B build -DLOGGER_USE_MODULES=ON
+```
+
+Requires CMake 3.28+, Clang 16+ or GCC 14+. The header-based interface remains
+the primary, supported API.
+
+---
+
+## Installing
+
+```bash
+cmake --install build --prefix /opt/logger_system
+```
+
+The install step writes headers, the static library, and CMake package files:
+
+```
+<prefix>/include/kcenon/logger/
+<prefix>/lib/liblogger_system.a
+<prefix>/lib/cmake/logger_system/logger_system-config.cmake
+```
+
+---
+
+## Consuming from Another Project
+
+### With `find_package`
+
+```cmake
+find_package(logger_system CONFIG REQUIRED)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE kcenon::logger)
+```
+
+### With `FetchContent`
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+    common_system
+    GIT_REPOSITORY https://github.com/kcenon/common_system.git
+    GIT_TAG        v0.2.0
+)
+FetchContent_Declare(
+    logger_system
+    GIT_REPOSITORY https://github.com/kcenon/logger_system.git
+    GIT_TAG        v0.1.0
+)
+FetchContent_MakeAvailable(common_system logger_system)
+
+add_executable(my_app main.cpp)
+target_link_libraries(my_app PRIVATE kcenon::logger)
+```
+
+Pin to a release tag; do not track `main`.
+
+---
+
+## Platform Notes
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| Ubuntu 22.04+ (GCC 11+ / Clang 14+) | Supported | Primary CI target |
+| macOS 13+ (Apple Clang 14+) | Supported | Primary CI target |
+| Windows 11 (MSVC 2022) | Supported | Primary CI target |
+| MinGW | Limited | Tests and benchmarks disabled |
+| UWP / Xbox | Not supported | Use a different logging backend |
+
+---
+
+## Next Steps
+
+- Encountered a build error? See [Troubleshooting Guide](TROUBLESHOOTING.md).
+- Want to measure throughput? See [Performance Guide](PERFORMANCE.md).
+- Ready to write code? See [Getting Started Guide](GETTING_STARTED.md).

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,0 +1,310 @@
+---
+doc_id: "LOG-GUID-029"
+doc_title: "Logger System Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-18"
+doc_status: "Released"
+project: "logger_system"
+category: "GUID"
+---
+
+# Logger System Troubleshooting Guide
+
+> **SSOT**: This document is the single source of truth for **Logger System
+> Troubleshooting Guide**.
+
+> **Language:** **English**
+
+Quick reference for diagnosing common build, configuration, and runtime
+issues in `logger_system`. For general usage questions, see the
+[FAQ](FAQ.md); for build options, see the [Build Guide](BUILD.md).
+
+---
+
+## Table of Contents
+
+1. [Build Errors](#build-errors)
+2. [Linker Errors](#linker-errors)
+3. [Runtime Issues](#runtime-issues)
+4. [Performance Issues](#performance-issues)
+5. [Integration Issues](#integration-issues)
+6. [Platform-Specific Issues](#platform-specific-issues)
+7. [Getting More Help](#getting-more-help)
+
+---
+
+## Build Errors
+
+### `common_system` not found
+
+Symptom:
+
+```
+CMake Error: Could not find a package configuration file provided by "common_system"
+```
+
+Cause: `common_system` was not cloned next to `logger_system`, or it was not
+built/installed.
+
+Fix:
+
+```bash
+cd ..   # parent of logger_system
+git clone https://github.com/kcenon/common_system.git
+cd logger_system
+cmake -S . -B build
+```
+
+See [Build Guide - Source Layout](BUILD.md#source-layout).
+
+### C++20 feature not available
+
+Symptom (GCC/Clang):
+
+```
+error: 'std::jthread' was not declared in this scope
+error: 'std::format' was not declared in this scope
+```
+
+Cause: Compiler does not meet the C++20 baseline (GCC 11+, Clang 14+,
+Apple Clang 14+, MSVC 2022+).
+
+Fix: Upgrade the compiler, or switch to a compatible preset:
+
+```bash
+cmake -S . -B build -DCMAKE_CXX_COMPILER=g++-11
+```
+
+### OpenSSL headers missing
+
+Symptom:
+
+```
+fatal error: 'openssl/evp.h' file not found
+```
+
+Cause: `LOGGER_USE_ENCRYPTION=ON` (the default) but OpenSSL is not installed.
+
+Fix (either install OpenSSL or disable encryption):
+
+```bash
+# Ubuntu/Debian
+sudo apt install libssl-dev
+
+# macOS
+brew install openssl@3
+
+# Or disable the feature
+cmake -S . -B build -DLOGGER_USE_ENCRYPTION=OFF
+```
+
+### `opentelemetry-cpp` not found
+
+Symptom:
+
+```
+CMake Error: Could not find a package configuration file provided by "opentelemetry-cpp"
+```
+
+Cause: `LOGGER_ENABLE_OTLP=ON` but `opentelemetry-cpp` 1.14+ is not available.
+
+Fix: Install via vcpkg (`vcpkg install opentelemetry-cpp`) or disable OTLP:
+
+```bash
+cmake -S . -B build -DLOGGER_ENABLE_OTLP=OFF
+```
+
+### C++20 modules build fails
+
+Symptom (CMake 3.27 or older):
+
+```
+Error: C++20 module support requires CMake 3.28 or newer
+```
+
+Fix: Either upgrade CMake and use a modules-capable compiler
+(Clang 16+ / GCC 14+), or disable modules:
+
+```bash
+cmake -S . -B build -DLOGGER_USE_MODULES=OFF
+```
+
+The header-based interface is the supported primary API.
+
+---
+
+## Linker Errors
+
+### Undefined references to `kcenon::logger::logger_builder`
+
+Symptom:
+
+```
+undefined reference to `kcenon::logger::logger_builder::build()'
+```
+
+Cause: Application does not link the logger library, or links it before its
+own object files (order matters on some GNU linkers).
+
+Fix:
+
+```cmake
+target_link_libraries(my_app PRIVATE kcenon::logger)
+```
+
+Place the logger target after the consuming target in the link line.
+
+### Multiple definitions when mixing static and shared builds
+
+Cause: Both a system-installed and a `FetchContent`-built copy of
+`logger_system` are linked into the same binary.
+
+Fix: Choose one source. If using `FetchContent`, remove the system install
+from `CMAKE_PREFIX_PATH`.
+
+### Missing OpenSSL symbols at link time
+
+Cause: Encryption is enabled but OpenSSL libraries are not in the link line
+(can happen with custom toolchains that bypass CMake).
+
+Fix: Ensure `find_package(OpenSSL REQUIRED)` succeeds and link
+`OpenSSL::SSL OpenSSL::Crypto`, or disable `LOGGER_USE_ENCRYPTION`.
+
+---
+
+## Runtime Issues
+
+### `logger_builder::build()` returns an error
+
+Check the `Result` before using it:
+
+```cpp
+auto result = kcenon::logger::logger_builder()
+    .add_writer("file", std::make_unique<file_writer>("app.log"))
+    .build();
+
+if (result.is_err()) {
+    std::cerr << "build failed: " << result.error().message << "\n";
+    return 1;
+}
+auto logger = std::move(result.value());
+```
+
+Common causes:
+
+- No writers were added.
+- A file path is not writable.
+- Buffer or queue size is out of range.
+
+### No output appears in the console
+
+Possible causes:
+
+1. Minimum level is above the messages being logged. Lower it:
+   ```cpp
+   .with_min_level(kcenon::logger::log_level::trace)
+   ```
+2. Async writer did not flush before exit. Always call:
+   ```cpp
+   logger->flush();
+   ```
+3. A crash or signal terminated the process before the async queue drained.
+   Enable the crash handler (`LOGGER_ENABLE_CRASH_HANDLER=ON`, default) or use
+   the `crash_safe` writer variant.
+
+### File writer produces an empty or truncated file
+
+- Confirm `flush()` is called before the process exits.
+- Check permissions on the target directory.
+- When using rotating file writer, verify the per-file size limit and max
+  file count are sensible (very small limits rotate before flush).
+
+### Messages are lost under high load
+
+Async writer queue is full and the configured policy drops messages.
+
+Fix (pick one):
+
+- Increase queue depth:
+  ```cpp
+  .with_queue_size(100000)
+  ```
+- Use a blocking overflow policy instead of drop.
+- Use a batching writer to reduce per-message overhead.
+
+See [Performance Guide](PERFORMANCE.md).
+
+### Crash or deadlock on program exit
+
+Typical cause: static-destruction order between the logger and a writer's
+owned resources.
+
+Fix: Destroy the logger explicitly before `main` returns, or hold it in a
+local `std::unique_ptr`.
+
+---
+
+## Performance Issues
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| High latency per `log()` call | Synchronous writer | Use async writer chain |
+| Throughput plateaus early | Small queue / batch size | Increase `LOGGER_DEFAULT_QUEUE_SIZE`, `LOGGER_DEFAULT_BATCH_SIZE` |
+| High CPU with few logs | Formatter running on hot path | Defer formatting to async writer |
+| Sporadic latency spikes | File rotation mid-flush | Pre-size log files, reduce rotation frequency |
+
+See [Performance Guide](PERFORMANCE.md) and
+[Benchmarks](../BENCHMARKS.md).
+
+---
+
+## Integration Issues
+
+### `thread_system` pool not used
+
+Ensure both the build option and runtime wiring are in place:
+
+```bash
+cmake -S . -B build -DLOGGER_USE_THREAD_SYSTEM=ON
+```
+
+See [Integration Guide](INTEGRATION.md) for constructor wiring.
+
+### OTLP exporter fails with connection refused
+
+- Verify the collector endpoint is reachable.
+- Confirm the correct transport (HTTP vs gRPC) is selected.
+- Check TLS settings if the collector requires them.
+
+See [OpenTelemetry Guide](OPENTELEMETRY.md).
+
+---
+
+## Platform-Specific Issues
+
+### MinGW
+
+Tests and benchmarks are disabled on MinGW; the library itself builds. Use
+a Windows MSVC build for test coverage.
+
+### macOS: `std::format` unavailable
+
+Apple Clang 14 has partial C++20 support. If `std::format` is not found,
+upgrade Xcode command-line tools, or build with `clang++` from Homebrew.
+
+### Windows: `dll not found` at runtime
+
+When building shared OpenSSL, ensure the DLLs are on `PATH` or co-located
+with the executable.
+
+---
+
+## Getting More Help
+
+- [FAQ](FAQ.md) - conceptual and usage questions.
+- [Build Guide](BUILD.md) - every CMake option, preset, and install step.
+- [Performance Guide](PERFORMANCE.md) - tuning async, batch, and queue sizes.
+- [Security Guide](SECURITY.md) - encryption, key storage, and auditing.
+- [GitHub Issues](https://github.com/kcenon/logger_system/issues) - search
+  before filing; include compiler version, CMake version, OS, and the exact
+  error message.


### PR DESCRIPTION
## What

### Summary
Fill the missing `docs/guides/BUILD.md` and `docs/guides/TROUBLESHOOTING.md`
pages that were referenced from `README.md` and `docs/PROJECT_STRUCTURE.md`,
then wire them into the top-level README and the documentation registry so
all previously broken guide links resolve.

### Change Type
- [x] Documentation

### Affected Components
- `README.md`
- `docs/guides/BUILD.md` (new)
- `docs/guides/TROUBLESHOOTING.md` (new)
- `docs/PROJECT_STRUCTURE.md`
- `docs/PROJECT_STRUCTURE.kr.md`
- `docs/README.md` (documentation registry)

## Why

The README advertised a build guide and a troubleshooting guide that did
not exist. The link targets fell back to `QUICK_START.md` and `FAQ.md`
with inline TODO comments. New users hitting those links landed on pages
that did not answer the question ("how do I build with feature X?",
"why does my build fail with error Y?"). Broken/fallback guide links also
signal an unmaintained project.

Closes #614

## Who

### Reviewers
- Repository maintainers

## When

### Urgency
- [x] Normal - documentation completeness

## Where

### New Files
| File | Purpose |
|------|---------|
| `docs/guides/BUILD.md` | Prerequisites, CMake options, presets, optional features, install, downstream consumption |
| `docs/guides/TROUBLESHOOTING.md` | Build/link/runtime/performance/integration/platform issue catalogue |

### Updated References
| File | Change |
|------|--------|
| `README.md` | Add Build Guide link; point Troubleshooting to dedicated page; replace fallback "Complete Build Options" link |
| `docs/PROJECT_STRUCTURE.md` | Add Build Guide and Troubleshooting Guide under See Also |
| `docs/PROJECT_STRUCTURE.kr.md` | Same as above (Korean) |
| `docs/README.md` | Register `LOG-GUID-028` and `LOG-GUID-029`, bump total and Guides count |

## How

### Implementation Highlights
1. Wrote a dedicated build guide that expands on `QUICK_START.md` with the
   full CMake option matrix (core, advanced, performance tuning, QA) and
   preset list from `CMakePresets.json`.
2. Wrote a troubleshooting guide organised by failure mode: build errors,
   linker errors, runtime, performance, integration, platform-specific.
3. Removed the `<!-- TODO: ... does not exist -->` inline markers from
   `README.md` and `docs/PROJECT_STRUCTURE*.md`.
4. Registered both new documents in `docs/README.md` (main index + Guides
   category section) and updated the total document count from 71 to 73.

### Testing Done
- Verified all new cross-references resolve to existing anchors
  (`BUILD.md#source-layout`, `TROUBLESHOOTING.md`, `FAQ.md`,
  `PERFORMANCE.md`, `SECURITY.md`, `INTEGRATION.md`, `OPENTELEMETRY.md`).
- Confirmed no residual `BUILD_GUIDE.md does not exist` or
  `TROUBLESHOOTING.md does not exist` TODO markers remain.

### Breaking Changes
None. Documentation-only change.