### PR TITLE
test: raise unit test coverage toward 80%

### DIFF
--- a/tests/unit/core_test/small_string_test.cpp
+++ b/tests/unit/core_test/small_string_test.cpp
@@ -1,0 +1,363 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file small_string_test.cpp
+ * @brief Unit tests for kcenon::logger::small_string
+ *
+ * Exercises both the small (SSO) and heap storage branches of
+ * construction, assignment, append, reserve, and comparison helpers.
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/core/small_string.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+using namespace kcenon::logger;
+
+// Use a compact 16-byte instance so the SSO/heap boundary is easy to
+// exercise from tests without allocating enormous payloads.
+using sstr16 = small_string<16>;
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+TEST(SmallStringTest, DefaultConstructIsEmptyAndSmall) {
+    sstr16 s;
+    EXPECT_TRUE(s.empty());
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_EQ(s.length(), 0u);
+    EXPECT_TRUE(s.is_small());
+    EXPECT_STREQ(s.c_str(), "");
+}
+
+TEST(SmallStringTest, ConstructFromCString) {
+    sstr16 s("hello");
+    EXPECT_EQ(s.size(), 5u);
+    EXPECT_TRUE(s.is_small());
+    EXPECT_EQ(s.to_string(), "hello");
+}
+
+TEST(SmallStringTest, ConstructFromNullCStringYieldsEmpty) {
+    const char* p = nullptr;
+    sstr16 s(p);
+    EXPECT_TRUE(s.empty());
+    EXPECT_TRUE(s.is_small());
+}
+
+TEST(SmallStringTest, ConstructFromStdString) {
+    std::string input("world");
+    sstr16 s(input);
+    EXPECT_EQ(s.size(), input.size());
+    EXPECT_TRUE(s.is_small());
+    EXPECT_EQ(s.to_string(), input);
+}
+
+TEST(SmallStringTest, ConstructFromStringView) {
+    std::string_view sv = "sview";
+    sstr16 s(sv);
+    EXPECT_EQ(s.size(), sv.size());
+    EXPECT_TRUE(s.is_small());
+}
+
+TEST(SmallStringTest, ConstructLongStringUsesHeap) {
+    // SSO capacity for sstr16 is 15 (16 - 1). 40 chars must spill to heap.
+    std::string long_str(40, 'x');
+    sstr16 s(long_str);
+    EXPECT_EQ(s.size(), long_str.size());
+    EXPECT_FALSE(s.is_small());
+    EXPECT_EQ(s.to_string(), long_str);
+}
+
+// =============================================================================
+// Copy / move
+// =============================================================================
+
+TEST(SmallStringTest, CopyConstructSmall) {
+    sstr16 original("abc");
+    sstr16 copy(original);
+
+    EXPECT_EQ(copy.to_string(), "abc");
+    EXPECT_TRUE(copy.is_small());
+    // Original remains valid and unchanged
+    EXPECT_EQ(original.to_string(), "abc");
+}
+
+TEST(SmallStringTest, CopyConstructHeap) {
+    std::string big(64, 'a');
+    sstr16 original(big);
+    sstr16 copy(original);
+
+    EXPECT_EQ(copy.size(), big.size());
+    EXPECT_FALSE(copy.is_small());
+    EXPECT_EQ(copy.to_string(), big);
+    EXPECT_EQ(original.to_string(), big);
+}
+
+TEST(SmallStringTest, MoveConstructHeapLeavesSourceSmall) {
+    std::string big(64, 'b');
+    sstr16 source(big);
+    sstr16 dest(std::move(source));
+
+    EXPECT_EQ(dest.size(), big.size());
+    EXPECT_EQ(dest.to_string(), big);
+    // Source should be reset to an empty small-string state
+    EXPECT_TRUE(source.is_small());
+    EXPECT_TRUE(source.empty());
+}
+
+TEST(SmallStringTest, MoveConstructSmall) {
+    sstr16 source("xy");
+    sstr16 dest(std::move(source));
+
+    EXPECT_EQ(dest.to_string(), "xy");
+    EXPECT_TRUE(dest.is_small());
+    // Small-string moves are essentially copies, so source state is
+    // implementation-defined after move. We only assert on dest.
+}
+
+TEST(SmallStringTest, CopyAssignmentReplacesContent) {
+    sstr16 a("one");
+    sstr16 b("two");
+    a = b;
+    EXPECT_EQ(a.to_string(), "two");
+}
+
+TEST(SmallStringTest, CopyAssignmentSelfIsNoop) {
+    sstr16 a("keep");
+    // Route through a reference to avoid -Wself-assign-overloaded warnings
+    // while still exercising the same-object branch in operator=.
+    sstr16& alias = a;
+    a = alias;
+    EXPECT_EQ(a.to_string(), "keep");
+}
+
+TEST(SmallStringTest, MoveAssignmentSmallToHeap) {
+    sstr16 small_val("tiny");
+    sstr16 heap_val(std::string(40, 'Z'));
+    small_val = std::move(heap_val);
+
+    EXPECT_FALSE(small_val.is_small());
+    EXPECT_EQ(small_val.size(), 40u);
+    EXPECT_TRUE(heap_val.is_small());
+    EXPECT_TRUE(heap_val.empty());
+}
+
+TEST(SmallStringTest, MoveAssignmentHeapToSmall) {
+    sstr16 heap_val(std::string(32, 'Q'));
+    sstr16 small_val("hi");
+    heap_val = std::move(small_val);
+
+    EXPECT_TRUE(heap_val.is_small());
+    EXPECT_EQ(heap_val.to_string(), "hi");
+}
+
+TEST(SmallStringTest, MoveAssignmentSelfIsNoop) {
+    sstr16 a("keep");
+    // Use a reference so compilers don't emit -Wself-move while still
+    // exercising the same-object branch in operator=.
+    sstr16& alias = a;
+    a = std::move(alias);
+    EXPECT_EQ(a.to_string(), "keep");
+}
+
+// =============================================================================
+// Assign / clear
+// =============================================================================
+
+TEST(SmallStringTest, AssignThenReassignSmall) {
+    sstr16 s;
+    s.assign("ab", 2);
+    EXPECT_EQ(s.to_string(), "ab");
+    s.assign("cdef", 4);
+    EXPECT_EQ(s.to_string(), "cdef");
+    EXPECT_TRUE(s.is_small());
+}
+
+TEST(SmallStringTest, AssignTransitionsSmallToHeap) {
+    sstr16 s("abc");
+    std::string big(40, 'g');
+    s.assign(big.data(), big.size());
+    EXPECT_EQ(s.size(), big.size());
+    EXPECT_FALSE(s.is_small());
+    EXPECT_EQ(s.to_string(), big);
+}
+
+TEST(SmallStringTest, AssignShrinksBackToSmall) {
+    sstr16 s(std::string(40, 'g'));
+    s.assign("x", 1);
+    EXPECT_EQ(s.to_string(), "x");
+    EXPECT_TRUE(s.is_small());
+}
+
+TEST(SmallStringTest, ClearResetsSize) {
+    sstr16 s("content");
+    s.clear();
+    EXPECT_TRUE(s.empty());
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_STREQ(s.c_str(), "");
+}
+
+TEST(SmallStringTest, ClearOnHeapKeepsCapacity) {
+    sstr16 s(std::string(40, 'h'));
+    ASSERT_FALSE(s.is_small());
+    s.clear();
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_FALSE(s.is_small()); // heap buffer retained
+}
+
+// =============================================================================
+// Reserve / capacity
+// =============================================================================
+
+TEST(SmallStringTest, ReserveWithinSsoKeepsSmall) {
+    sstr16 s("a");
+    s.reserve(8); // SSO capacity is 15
+    EXPECT_TRUE(s.is_small());
+    EXPECT_GE(s.capacity(), 8u);
+}
+
+TEST(SmallStringTest, ReserveBeyondSsoMovesToHeap) {
+    sstr16 s("abc");
+    s.reserve(64);
+    EXPECT_FALSE(s.is_small());
+    EXPECT_GE(s.capacity(), 64u);
+    EXPECT_EQ(s.to_string(), "abc");
+}
+
+TEST(SmallStringTest, ReserveNoShrink) {
+    sstr16 s(std::string(40, 'q'));
+    size_t before = s.capacity();
+    s.reserve(1);
+    EXPECT_GE(s.capacity(), before);
+}
+
+// =============================================================================
+// Append
+// =============================================================================
+
+TEST(SmallStringTest, AppendStaysInSso) {
+    sstr16 s("ab");
+    s.append("cd", 2);
+    EXPECT_EQ(s.to_string(), "abcd");
+    EXPECT_TRUE(s.is_small());
+}
+
+TEST(SmallStringTest, AppendPromotesToHeap) {
+    sstr16 s("abc");
+    std::string tail(40, 't');
+    s.append(tail.data(), tail.size());
+    EXPECT_FALSE(s.is_small());
+    EXPECT_EQ(s.size(), 3u + tail.size());
+    EXPECT_EQ(s.to_string(), std::string("abc") + tail);
+}
+
+TEST(SmallStringTest, AppendStdStringOverload) {
+    sstr16 s("hi");
+    s.append(std::string("!"));
+    EXPECT_EQ(s.to_string(), "hi!");
+}
+
+TEST(SmallStringTest, AppendCStringOperator) {
+    sstr16 s("a");
+    s += "bc";
+    EXPECT_EQ(s.to_string(), "abc");
+}
+
+TEST(SmallStringTest, AppendStdStringOperator) {
+    sstr16 s("a");
+    s += std::string("b");
+    EXPECT_EQ(s.to_string(), "ab");
+}
+
+TEST(SmallStringTest, AppendOnHeapExtendsHeap) {
+    sstr16 s(std::string(40, 'a'));
+    ASSERT_FALSE(s.is_small());
+    std::string tail(20, 'b');
+    s.append(tail.data(), tail.size());
+    EXPECT_EQ(s.size(), 60u);
+    EXPECT_EQ(s.to_string().substr(0, 40), std::string(40, 'a'));
+    EXPECT_EQ(s.to_string().substr(40), std::string(20, 'b'));
+}
+
+// =============================================================================
+// Conversions and comparison
+// =============================================================================
+
+TEST(SmallStringTest, StringViewConversion) {
+    sstr16 s("view");
+    std::string_view sv = s;
+    EXPECT_EQ(sv.size(), 4u);
+    EXPECT_EQ(sv, std::string_view("view"));
+}
+
+TEST(SmallStringTest, EqualityWithSameContent) {
+    sstr16 a("same");
+    sstr16 b("same");
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a != b);
+}
+
+TEST(SmallStringTest, EqualityBetweenSmallAndHeap) {
+    std::string big(40, 'r');
+    sstr16 a(big);
+    sstr16 b(big);
+    EXPECT_TRUE(a == b);
+}
+
+TEST(SmallStringTest, InequalityDifferentSizes) {
+    sstr16 a("abc");
+    sstr16 b("abcd");
+    EXPECT_TRUE(a != b);
+    EXPECT_FALSE(a == b);
+}
+
+TEST(SmallStringTest, EqualityWithStdString) {
+    sstr16 s("match");
+    EXPECT_TRUE(s == std::string("match"));
+    EXPECT_FALSE(s == std::string("other"));
+}
+
+// =============================================================================
+// Memory statistics
+// =============================================================================
+
+TEST(SmallStringTest, MemoryStatsSmall) {
+    sstr16 s("short");
+    auto stats = s.get_memory_stats();
+    EXPECT_EQ(stats.string_size, 5u);
+    EXPECT_TRUE(stats.is_small);
+    EXPECT_EQ(stats.heap_bytes_used, 0u);
+    EXPECT_GT(stats.total_bytes, 0u);
+}
+
+TEST(SmallStringTest, MemoryStatsHeap) {
+    sstr16 s(std::string(40, 'k'));
+    auto stats = s.get_memory_stats();
+    EXPECT_EQ(stats.string_size, 40u);
+    EXPECT_FALSE(stats.is_small);
+    EXPECT_GT(stats.heap_bytes_used, 0u);
+    EXPECT_GT(stats.total_bytes, stats.heap_bytes_used);
+}
+
+// =============================================================================
+// Public aliases
+// =============================================================================
+
+TEST(SmallStringTest, Alias64Works) {
+    small_string_64 s("payload");
+    EXPECT_EQ(s.to_string(), "payload");
+    EXPECT_TRUE(s.is_small());
+}
+
+TEST(SmallStringTest, Alias128Works) {
+    small_string_128 s("network");
+    EXPECT_EQ(s.to_string(), "network");
+    EXPECT_TRUE(s.is_small());
+}

--- a/tests/unit/utils_test/CMakeLists.txt
+++ b/tests/unit/utils_test/CMakeLists.txt
@@ -1,9 +1,14 @@
-# Utils unit tests (string_utils, time_utils, file_utils)
+# Utils unit tests (string_utils, time_utils, file_utils, error_handling_utils)
 add_executable(logger_string_utils_test string_utils_test.cpp)
 add_executable(logger_time_utils_test time_utils_test.cpp)
 add_executable(logger_file_utils_test file_utils_test.cpp)
+add_executable(logger_error_handling_utils_test error_handling_utils_test.cpp)
 
-foreach(_target IN ITEMS logger_string_utils_test logger_time_utils_test logger_file_utils_test)
+foreach(_target IN ITEMS
+        logger_string_utils_test
+        logger_time_utils_test
+        logger_file_utils_test
+        logger_error_handling_utils_test)
     if(TARGET GTest::gtest_main)
         target_link_libraries(${_target} PRIVATE logger_system GTest::gtest_main)
     else()
@@ -18,3 +23,4 @@ endforeach()
 add_test(NAME logger_string_utils_test COMMAND logger_string_utils_test)
 add_test(NAME logger_time_utils_test COMMAND logger_time_utils_test)
 add_test(NAME logger_file_utils_test COMMAND logger_file_utils_test)
+add_test(NAME logger_error_handling_utils_test COMMAND logger_error_handling_utils_test)

--- a/tests/unit/utils_test/error_handling_utils_test.cpp
+++ b/tests/unit/utils_test/error_handling_utils_test.cpp
@@ -1,0 +1,438 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file error_handling_utils_test.cpp
+ * @brief Unit tests for structured error context and helper wrappers
+ *
+ * Covers error_context construction/formatting, try_write_operation exception
+ * mapping, stream state checks, directory helpers, and destructor-safe
+ * operation wrappers.
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/logger/core/error_codes.h>
+#include <kcenon/logger/utils/error_handling_utils.h>
+
+#include <filesystem>
+#include <fstream>
+#include <ios>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace common = kcenon::common;
+using namespace kcenon::logger;
+using namespace kcenon::logger::utils;
+
+// =============================================================================
+// error_context
+// =============================================================================
+
+TEST(ErrorContextTest, BasicToStringContainsCodeAndMessage) {
+    error_context ctx(logger_error_code::file_write_failed, "disk full");
+
+    std::string text = ctx.to_string();
+    EXPECT_NE(text.find("Failed to write to file"), std::string::npos);
+    EXPECT_NE(text.find("disk full"), std::string::npos);
+}
+
+TEST(ErrorContextTest, OperationAppearsInOutput) {
+    error_context ctx(logger_error_code::file_open_failed, "boom", "open_log_file");
+
+    std::string text = ctx.to_string();
+    EXPECT_NE(text.find("during: open_log_file"), std::string::npos);
+}
+
+TEST(ErrorContextTest, EmptyMessageStillIncludesCode) {
+    error_context ctx(logger_error_code::writer_not_found, "");
+
+    std::string text = ctx.to_string();
+    EXPECT_NE(text.find("Writer not found"), std::string::npos);
+}
+
+TEST(ErrorContextTest, TimestampIsSet) {
+    auto before = std::chrono::system_clock::now();
+    error_context ctx(logger_error_code::unknown_error, "msg");
+    auto after = std::chrono::system_clock::now();
+
+    EXPECT_GE(ctx.timestamp, before);
+    EXPECT_LE(ctx.timestamp, after);
+}
+
+// =============================================================================
+// log_error_context
+// =============================================================================
+
+TEST(LogErrorContextTest, WritesFormattedMessageToStderr) {
+    // Redirect stderr into a stringstream for the duration of the call.
+    std::stringstream captured;
+    std::streambuf* original = std::cerr.rdbuf(captured.rdbuf());
+
+    error_context ctx(logger_error_code::encryption_failed, "crypto", "encrypt");
+    log_error_context(ctx);
+
+    std::cerr.rdbuf(original);
+    std::string output = captured.str();
+
+    EXPECT_NE(output.find("logger_system"), std::string::npos);
+    EXPECT_NE(output.find("crypto"), std::string::npos);
+    EXPECT_NE(output.find("encrypt"), std::string::npos);
+}
+
+// =============================================================================
+// try_write_operation exception mapping
+// =============================================================================
+
+TEST(TryWriteOperationTest, PassesThroughSuccess) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        return common::ok();
+    });
+    EXPECT_FALSE(result.is_err());
+}
+
+TEST(TryWriteOperationTest, PassesThroughExplicitError) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        return make_logger_void_result(
+            logger_error_code::queue_full, "explicit");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result), logger_error_code::queue_full);
+}
+
+TEST(TryWriteOperationTest, MapsFilesystemError) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        throw std::filesystem::filesystem_error(
+            "denied",
+            std::make_error_code(std::errc::permission_denied));
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_permission_denied);
+}
+
+TEST(TryWriteOperationTest, MapsIosBaseFailure) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        throw std::ios_base::failure("stream bad");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+}
+
+TEST(TryWriteOperationTest, MapsSystemErrorToDefault) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        throw std::system_error(
+            std::make_error_code(std::errc::io_error), "sys");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+}
+
+TEST(TryWriteOperationTest, SystemErrorHonorsCustomDefault) {
+    auto result = try_write_operation(
+        []() -> common::VoidResult {
+            throw std::system_error(
+                std::make_error_code(std::errc::io_error), "sys");
+        },
+        logger_error_code::network_send_failed);
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::network_send_failed);
+}
+
+TEST(TryWriteOperationTest, MapsBadAllocToBufferOverflow) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        throw std::bad_alloc();
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::buffer_overflow);
+}
+
+TEST(TryWriteOperationTest, MapsGenericException) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        throw std::runtime_error("boom");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+    EXPECT_NE(get_logger_error_message(result).find("boom"),
+              std::string::npos);
+}
+
+TEST(TryWriteOperationTest, MapsNonStandardException) {
+    auto result = try_write_operation([]() -> common::VoidResult {
+        throw 42;
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+}
+
+// =============================================================================
+// Specialized wrappers
+// =============================================================================
+
+TEST(TryOpenOperationTest, UsesFileOpenFailedAsDefault) {
+    auto result = try_open_operation([]() -> common::VoidResult {
+        throw std::runtime_error("cannot open");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_open_failed);
+}
+
+TEST(TryNetworkOperationTest, UsesNetworkSendFailedAsDefault) {
+    auto result = try_network_operation([]() -> common::VoidResult {
+        throw std::runtime_error("socket closed");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::network_send_failed);
+}
+
+TEST(TryEncryptionOperationTest, UsesEncryptionFailedAsDefault) {
+    auto result = try_encryption_operation([]() -> common::VoidResult {
+        throw std::runtime_error("cipher error");
+    });
+
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::encryption_failed);
+}
+
+// =============================================================================
+// check_condition
+// =============================================================================
+
+TEST(CheckConditionTest, TrueReturnsOk) {
+    auto result = check_condition(true,
+                                  logger_error_code::file_write_failed,
+                                  "should not fire");
+    EXPECT_FALSE(result.is_err());
+}
+
+TEST(CheckConditionTest, FalseReturnsError) {
+    auto result = check_condition(false,
+                                  logger_error_code::file_write_failed,
+                                  "custom message");
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+    EXPECT_EQ(get_logger_error_message(result), "custom message");
+}
+
+// =============================================================================
+// check_stream_state
+// =============================================================================
+
+TEST(CheckStreamStateTest, GoodStreamReturnsOk) {
+    std::stringstream ss;
+    ss << "ok";
+    auto result = check_stream_state(ss, "write");
+    EXPECT_FALSE(result.is_err());
+}
+
+TEST(CheckStreamStateTest, FailedStreamReturnsError) {
+    std::stringstream ss;
+    ss.setstate(std::ios::failbit);
+    auto result = check_stream_state(ss, "read");
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+    EXPECT_NE(get_logger_error_message(result).find("read"),
+              std::string::npos);
+}
+
+TEST(CheckStreamStateTest, BadStreamReturnsError) {
+    std::stringstream ss;
+    ss.setstate(std::ios::badbit);
+    auto result = check_stream_state(ss, "write");
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_write_failed);
+}
+
+// =============================================================================
+// check_file_exists
+// =============================================================================
+
+TEST(CheckFileExistsTest, ReturnsOkForExistingFile) {
+    auto tmp = std::filesystem::temp_directory_path() /
+               "logger_error_util_exists.tmp";
+    {
+        std::ofstream ofs(tmp);
+        ofs << "hi";
+    }
+
+    auto result = check_file_exists(tmp);
+    EXPECT_FALSE(result.is_err());
+
+    std::error_code ec;
+    std::filesystem::remove(tmp, ec);
+}
+
+TEST(CheckFileExistsTest, ReturnsErrorForMissingFile) {
+    auto tmp = std::filesystem::temp_directory_path() /
+               "logger_error_util_missing_file.tmp";
+    // Ensure it does not exist
+    std::error_code ec;
+    std::filesystem::remove(tmp, ec);
+
+    auto result = check_file_exists(tmp);
+    ASSERT_TRUE(result.is_err());
+    EXPECT_EQ(get_logger_error_code(result),
+              logger_error_code::file_open_failed);
+}
+
+// =============================================================================
+// ensure_directory_exists
+// =============================================================================
+
+TEST(EnsureDirectoryExistsTest, EmptyPathReturnsOk) {
+    auto result = ensure_directory_exists(std::filesystem::path{});
+    EXPECT_FALSE(result.is_err());
+}
+
+TEST(EnsureDirectoryExistsTest, ExistingDirectoryReturnsOk) {
+    auto base = std::filesystem::temp_directory_path() /
+                "logger_error_util_dir_existing";
+    std::filesystem::create_directories(base);
+
+    auto result = ensure_directory_exists(base);
+    EXPECT_FALSE(result.is_err());
+
+    std::error_code ec;
+    std::filesystem::remove_all(base, ec);
+}
+
+TEST(EnsureDirectoryExistsTest, CreatesMissingDirectory) {
+    auto base = std::filesystem::temp_directory_path() /
+                "logger_error_util_dir_new" /
+                "nested" /
+                "child";
+    std::error_code ec;
+    std::filesystem::remove_all(
+        std::filesystem::temp_directory_path() /
+            "logger_error_util_dir_new",
+        ec);
+
+    auto result = ensure_directory_exists(base);
+    EXPECT_FALSE(result.is_err());
+    EXPECT_TRUE(std::filesystem::exists(base));
+
+    std::filesystem::remove_all(
+        std::filesystem::temp_directory_path() /
+            "logger_error_util_dir_new",
+        ec);
+}
+
+// =============================================================================
+// safe_destructor_operation
+// =============================================================================
+
+TEST(SafeDestructorOperationTest, SwallowsStandardException) {
+    // Redirect stderr so test output stays clean.
+    std::stringstream captured;
+    std::streambuf* original = std::cerr.rdbuf(captured.rdbuf());
+
+    int ran = 0;
+    EXPECT_NO_THROW(
+        safe_destructor_operation("cleanup", [&ran]() {
+            ++ran;
+            throw std::runtime_error("boom");
+        })
+    );
+
+    std::cerr.rdbuf(original);
+    EXPECT_EQ(ran, 1);
+    EXPECT_NE(captured.str().find("cleanup"), std::string::npos);
+}
+
+TEST(SafeDestructorOperationTest, SwallowsNonStandardException) {
+    std::stringstream captured;
+    std::streambuf* original = std::cerr.rdbuf(captured.rdbuf());
+
+    EXPECT_NO_THROW(
+        safe_destructor_operation("shutdown", []() {
+            throw 7;
+        })
+    );
+
+    std::cerr.rdbuf(original);
+    EXPECT_NE(captured.str().find("shutdown"), std::string::npos);
+}
+
+TEST(SafeDestructorOperationTest, RunsOperationWhenNoException) {
+    int ran = 0;
+    EXPECT_NO_THROW(
+        safe_destructor_operation("ok_op", [&ran]() { ++ran; })
+    );
+    EXPECT_EQ(ran, 1);
+}
+
+// =============================================================================
+// safe_destructor_result_operation
+// =============================================================================
+
+TEST(SafeDestructorResultOperationTest, LogsErrorResult) {
+    std::stringstream captured;
+    std::streambuf* original = std::cerr.rdbuf(captured.rdbuf());
+
+    EXPECT_NO_THROW(
+        safe_destructor_result_operation("flush", []() -> common::VoidResult {
+            return make_logger_void_result(
+                logger_error_code::flush_timeout, "timed out");
+        })
+    );
+
+    std::cerr.rdbuf(original);
+    std::string output = captured.str();
+    EXPECT_NE(output.find("flush"), std::string::npos);
+    EXPECT_NE(output.find("timed out"), std::string::npos);
+}
+
+TEST(SafeDestructorResultOperationTest, SwallowsException) {
+    std::stringstream captured;
+    std::streambuf* original = std::cerr.rdbuf(captured.rdbuf());
+
+    EXPECT_NO_THROW(
+        safe_destructor_result_operation(
+            "close", []() -> common::VoidResult {
+                throw std::runtime_error("ouch");
+            })
+    );
+
+    std::cerr.rdbuf(original);
+    EXPECT_NE(captured.str().find("close"), std::string::npos);
+}
+
+TEST(SafeDestructorResultOperationTest, SilentOnSuccess) {
+    std::stringstream captured;
+    std::streambuf* original = std::cerr.rdbuf(captured.rdbuf());
+
+    EXPECT_NO_THROW(
+        safe_destructor_result_operation(
+            "ok", []() -> common::VoidResult {
+                return common::ok();
+            })
+    );
+
+    std::cerr.rdbuf(original);
+    EXPECT_TRUE(captured.str().empty());
+}


### PR DESCRIPTION
## What

### Summary
Adds two previously missing unit-test suites to close obvious gaps in the
coverage picture called out by issue #613: `error_handling_utils` (zero
prior coverage) and `small_string` (previously only probed via one
`log_entry` test).

### Change Type
- [x] Test (unit tests only)

### Affected Components
- `tests/unit/utils_test/error_handling_utils_test.cpp` (new)
- `tests/unit/utils_test/CMakeLists.txt` (wire up new target)
- `tests/unit/core_test/small_string_test.cpp` (new; picked up by the
  existing `GLOB` in the `core_test` CMakeLists)

## Why

### Problem Solved
Issue #613 asks for raising logger test coverage from ~65% toward 80%.
Two header-only utility components were contributing zero direct test
coverage:

- `utils/error_handling_utils.h` drives exception-to-error-code mapping
  for every writer and is invoked from destructors across file,
  network, encryption, and batch paths. It had no unit tests.
- `core/small_string.h` is the SSO container used for every log
  message, thread id, and category. It had only a single incidental
  assertion inside `log_entry_test`.

### Related Issues
- Relates to #613 (test coverage uplift)

## Who

### Reviewers
- @kcenon

## When

### Urgency
- [x] Normal

### Target Release
v1.0.x coverage series.

## Where

### Files Changed
| File | Type |
|------|------|
| `tests/unit/utils_test/error_handling_utils_test.cpp` | New test |
| `tests/unit/core_test/small_string_test.cpp` | New test |
| `tests/unit/utils_test/CMakeLists.txt` | Register new target |

No production code is modified. No public APIs change.

## How

### Implementation Details
- `error_handling_utils_test.cpp` exercises:
  - `error_context` formatting (code, message, operation, timestamp)
  - `log_error_context` stderr output capture
  - `try_write_operation` mapping for `filesystem_error`,
    `ios_base::failure`, `system_error`, `bad_alloc`,
    generic `std::exception`, and non-standard throws
  - Custom default error code for `system_error`
  - `try_open_operation`, `try_network_operation`,
    `try_encryption_operation` default codes
  - `check_condition` true/false branches
  - `check_stream_state` fail/bad bit paths
  - `check_file_exists` present/missing
  - `ensure_directory_exists` empty-path, existing, and newly-created
    nested directories
  - `safe_destructor_operation` / `safe_destructor_result_operation`
    swallowing standard + non-standard exceptions and logging error
    results without throwing
- `small_string_test.cpp` uses a compact `small_string<16>` instance to
  exercise both the SSO and heap storage branches:
  - Default / C-string / `std::string` / `string_view` construction
  - Null C-string input
  - Copy and move (small and heap)
  - Copy/move assignment across small<->heap boundaries
  - Self-copy and self-move via an alias reference (avoids
    `-Wself-move` / `-Wself-assign`)
  - `assign` transitioning both directions and shrinking back to SSO
  - `clear` (resets size, keeps heap capacity)
  - `reserve` (within SSO, crosses to heap, no-shrink)
  - `append` and `operator+=` across SSO and heap branches
  - `std::string_view` conversion, equality with peers and
    `std::string`
  - `get_memory_stats` returning consistent values for both storage
    modes
  - `small_string_64` / `small_string_128` public aliases

### Testing Done
- Added 40+ new test cases across the two files.
- Local build not attempted: the project's `build/` directory is
  read-only in this sandbox, so verification is deferred to CI per
  `CLAUDE.md` guidance on missing local toolchains.

### Test Plan for Reviewers
1. `cmake -B build -DBUILD_TESTS=ON`
2. `cmake --build build`
3. `ctest --test-dir build --output-on-failure -R "error_handling_utils|small_string|core_unit"`

### Breaking Changes
None. Test-only addition.

### Rollback Plan
Revert this PR; no production code is affected.

## Notes
- This PR is intentionally scoped to two untested headers. It is
  unlikely on its own to push the line-coverage number all the way
  from ~65% to 80%, so the linked issue uses `Relates to #613`
  rather than `Closes #613`. Remaining coverage uplift (rotating
  writer edge cases, async drain under shutdown, structured-field
  formatter permutations, CI gate and README badge) is left for
  follow-up PRs so each change stays reviewable.
