### PR TITLE
docs(compliance): add ISO/IEC 27001 control mapping and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Ecosystem Integration](#ecosystem-integration)
 - [C++20 Module Support](#c20-module-support)
 - [Documentation](#documentation)
+- [Compliance](#compliance)
 - [Configuration Templates](#configuration-templates)
 - [Build Configuration](#build-configuration)
 - [Platform Support](#platform-support)
@@ -563,6 +564,16 @@ int main() {
 - 📋 [FAQ](docs/guides/FAQ.md) - Frequently asked questions
 - 🔍 [Troubleshooting](docs/guides/TROUBLESHOOTING.md) - Common build, runtime, and integration issues
 - 📝 [Changelog](docs/CHANGELOG.md) - Release history and changes
+
+---
+
+## Compliance
+
+`logger_system` provides technical primitives that organizations may use as part of an Information Security Management System (ISMS). The library is not itself certified; adopters integrate it into their ISMS and supply the organizational controls (policy, training, risk management).
+
+- 🛡️ [ISO/IEC 27001 Control Mapping](docs/compliance/iso-27001.md) — how audit logger, encrypted writer, path validation, log sanitizer, and retention policies map to Annex A controls
+
+Related standards covered by the same features: ISO/IEC 27701 (privacy), GDPR Art. 32, PCI DSS v4.0 § 10, SOC 2 CC7.2, HIPAA § 164.312(b).
 
 ---
 

--- a/docs/compliance/iso-27001.md
+++ b/docs/compliance/iso-27001.md
@@ -1,0 +1,127 @@
+---
+doc_id: "LOG-COMP-001"
+doc_title: "ISO/IEC 27001 Control Mapping"
+doc_version: "1.0.0"
+doc_date: "2026-04-21"
+doc_status: "Released"
+project: "logger_system"
+category: "Compliance"
+---
+
+# ISO/IEC 27001 Control Mapping
+
+> **Language:** **English**
+
+**Standard**: ISO/IEC 27001:2022 — Information Security Management Systems
+**Scope**: How `logger_system` features support organizations pursuing ISO 27001 certification.
+**Status**: Informational. This document describes technical controls provided by the library; organizational controls (policy, training, risk management) are out of scope and remain the adopter's responsibility.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Applicability](#applicability)
+- [Control Mapping](#control-mapping)
+  - [A.5 Organizational controls](#a5-organizational-controls)
+  - [A.8 Technological controls](#a8-technological-controls)
+- [Configuration Checklist](#configuration-checklist)
+- [Evidence Collection](#evidence-collection)
+- [Related Standards](#related-standards)
+- [References](#references)
+
+## Overview
+
+`logger_system` provides logging primitives that organizations may use to satisfy specific ISO/IEC 27001 Annex A controls. The library itself is not certified; adopters integrate it into an Information Security Management System (ISMS) and demonstrate control effectiveness through configuration, operation, and audit evidence.
+
+Relevant feature areas:
+
+| Feature | Control Families Supported |
+|---------|---------------------------|
+| Audit logger (HMAC-chained) | A.8.15 Logging, A.8.34 Protection during audit |
+| Encrypted writer (AES-256-GCM) | A.8.24 Use of cryptography |
+| Secure key storage | A.8.24 Use of cryptography, A.5.17 Authentication information |
+| Path validation | A.8.3 Information access restriction |
+| Log sanitizer | A.5.34 Privacy and protection of PII, A.8.11 Data masking |
+| Rotating / retention policy | A.8.15 Logging, A.5.33 Protection of records |
+
+## Applicability
+
+This mapping uses ISO/IEC 27001:2022 Annex A control identifiers. Where a control is commonly referenced by its 2013 identifier (for example, A.12.4), the legacy identifier is shown in parentheses for ease of reference.
+
+Controls are marked:
+
+- **Direct** — library provides a technical capability that implements the control.
+- **Supporting** — library provides a primitive that can be composed with other controls.
+- **Out of scope** — control is organizational or architectural and is the adopter's responsibility.
+
+## Control Mapping
+
+### A.5 Organizational controls
+
+| Control | Title | Support | How `logger_system` helps |
+|---------|-------|---------|---------------------------|
+| A.5.17 | Authentication information | Supporting | `secure_key_storage` protects encryption keys with platform secret stores (Keychain, Credential Manager, libsecret). See [SECURITY_GUIDE.md](../SECURITY_GUIDE.md#secure-key-storage). |
+| A.5.33 | Protection of records | Direct | `rotating_file_writer` enforces retention windows; `audit_logger` provides HMAC chains so tampering of archived records is detectable. |
+| A.5.34 | Privacy and protection of PII | Direct | `log_sanitizer` with built-in patterns redacts PII (emails, card numbers, tokens) at write time before persistence. See [SECURITY_GUIDE.md](../SECURITY_GUIDE.md#log-sanitizer). |
+
+### A.8 Technological controls
+
+| Control | Legacy | Title | Support | How `logger_system` helps |
+|---------|--------|-------|---------|---------------------------|
+| A.8.2 | A.9.2 | Privileged access rights | Supporting | Security-critical logger interface allows a separate privileged writer, distinct from application logging paths. |
+| A.8.3 | A.9.4 | Information access restriction | Direct | `path_validation` rejects traversal (`..`), symlink escape, and writes outside the configured log root. Error code 1706 (`path_traversal_detected`). |
+| A.8.11 | — | Data masking | Direct | `log_sanitizer` applies regex-based masking before records reach writers. Custom patterns can be added. |
+| A.8.15 | A.12.4 | Logging | Direct | Structured logging (plain, JSON, logfmt formatters), level filters, ThreadSanitizer-clean concurrent writes, and `audit_logger` for security-relevant events. |
+| A.8.16 | — | Monitoring activities | Supporting | OTLP writer exports telemetry to monitoring backends (`[otlp]` feature). |
+| A.8.24 | A.10.1 | Use of cryptography | Direct | `encrypted_writer` uses AES-256-GCM (authenticated encryption) with keys sourced from `secure_key_storage`. TLS for remote log shipping is the responsibility of the transport writer (`network_writer`). |
+| A.8.28 | — | Secure coding | Supporting | Result-based error handling surfaces failures to callers; CI pipeline runs AddressSanitizer, ThreadSanitizer, and UBSan — see [PRODUCTION_QUALITY.md](../PRODUCTION_QUALITY.md). |
+| A.8.34 | — | Protection of information systems during audit testing | Direct | `audit_logger` produces a tamper-evident HMAC chain; verification API detects modifications or removals of audit records. |
+
+**Explicit non-coverage**:
+
+- A.5.1–A.5.16 (policy, roles, risk): organizational. `logger_system` provides no mechanisms for these.
+- A.7 (physical controls): out of scope for a logging library.
+- A.8.1 (user endpoint devices) and A.8.4 (access to source code): repository and development-environment controls.
+
+## Configuration Checklist
+
+For an ISMS that treats `logger_system` as a technical control, configure at least the following to make the mapping above defensible during audit:
+
+- [ ] **Encryption at rest**: build with `[encryption]` feature and use `encrypted_writer` for any log stream carrying A.5.34 (PII), A.5.12 (confidential), or A.5.33 (records).
+- [ ] **Key storage**: load encryption keys via `secure_key_storage`; do not pass keys as literals or environment variables in production.
+- [ ] **Path validation**: configure a log root and enable `path_validation` on all file writers.
+- [ ] **Sanitization**: enable `log_sanitizer` with organization-specific patterns before any message reaches disk or network writers.
+- [ ] **Audit logging**: use `audit_logger` (not the general logger) for authentication, authorization, configuration-change, and privilege-escalation events. Verify the HMAC chain on a periodic schedule.
+- [ ] **Retention**: configure `rotating_file_writer` with a retention count and maximum file size aligned to the organization's record-retention policy.
+- [ ] **Transport security**: if `network_writer` is used, terminate at a TLS 1.2+ endpoint. `logger_system` does not perform its own TLS termination.
+- [ ] **Time source**: configure a trusted monotonic clock for timestamps; NTP/PTP drift is handled outside the library.
+
+## Evidence Collection
+
+Auditors typically request:
+
+1. **Configuration snapshot** — the `logger_builder` chain or configuration template used in production (e.g., `"production"`, `"high_performance"`).
+2. **Sample audit records** — a non-sensitive excerpt plus the output of the HMAC verification API proving the chain is intact.
+3. **Sanitizer rule set** — the regex patterns active in `log_sanitizer`, mapped to data categories in the organization's PII inventory.
+4. **Retention evidence** — `rotating_file_writer` parameters and a directory listing showing expected rotation behavior.
+5. **CI evidence** — sanitizer runs and code-coverage reports from [PRODUCTION_QUALITY.md](../PRODUCTION_QUALITY.md).
+
+## Related Standards
+
+| Standard | Relationship |
+|----------|-------------|
+| ISO/IEC 27002:2022 | Implementation guidance for the Annex A controls mapped above. |
+| ISO/IEC 27701:2019 | Privacy extension; `log_sanitizer` and `A.5.34` mapping feed into PIMS requirements. |
+| GDPR Art. 32 | Technical measures — `encrypted_writer`, `log_sanitizer`, and `audit_logger` contribute. |
+| PCI DSS v4.0 § 10 | Logging requirements — `audit_logger` HMAC chain addresses § 10.3.4 (tamper detection). |
+| SOC 2 CC7.2 | Detection of security events — supported by `audit_logger` and OTLP export. |
+| HIPAA § 164.312(b) | Audit controls — same evidence as PCI DSS § 10. |
+
+## References
+
+- ISO/IEC 27001:2022, *Information security, cybersecurity and privacy protection — Information security management systems — Requirements*
+- ISO/IEC 27002:2022, *Information security controls*
+- [`docs/SECURITY_GUIDE.md`](../SECURITY_GUIDE.md) — feature reference for security primitives
+- [`docs/API_REFERENCE_SECURITY.md`](../API_REFERENCE_SECURITY.md) — API for encrypted writer, audit logger, sanitizer, and key storage
+- [`docs/PRODUCTION_QUALITY.md`](../PRODUCTION_QUALITY.md) — CI evidence for A.8.28
+
+Part of [common_system#645](https://github.com/kcenon/common_system/issues/645) — ecosystem-wide ISO compliance initiative.


### PR DESCRIPTION
## What

Adds `docs/compliance/iso-27001.md` — a control-by-control mapping showing how `logger_system` security primitives support ISO/IEC 27001:2022 Annex A controls. Updates the README with a new "Compliance" section and TOC entry.

### Change type

- [x] Documentation

### Affected files

- `docs/compliance/iso-27001.md` (new, 127 lines)
- `README.md` (Compliance section + TOC)

## Why

Closes #622

- README already advertises "Compliance Support: GDPR, PCI DSS, ISO 27001, SOC 2" in the feature list, but there has been no dedicated mapping document.
- Enterprise adopters request control-level evidence at procurement — feature claims alone are insufficient.
- Brings `logger_system` to parity with other ecosystem components that publish compliance docs.
- Part of #645 (kcenon/common_system — ecosystem-wide ISO compliance EPIC).

## Where

| Path | Change |
|------|--------|
| `docs/compliance/iso-27001.md` | New file |
| `README.md` | Add Compliance section + TOC entry |

## How

### Technical approach

1. Map `logger_system` features to ISO/IEC 27001:2022 Annex A controls, with legacy 2013 identifiers noted in parentheses.
2. Distinguish **Direct**, **Supporting**, and **Out of scope** controls to avoid overclaiming.
3. Cross-reference existing in-tree docs (`SECURITY_GUIDE.md`, `API_REFERENCE_SECURITY.md`, `PRODUCTION_QUALITY.md`) so the evidence chain is verifiable.
4. Include a Configuration Checklist and Evidence Collection section so the document is auditable, not just aspirational.

### Controls covered

- **A.5 organizational**: A.5.17 (auth information), A.5.33 (protection of records), A.5.34 (PII protection)
- **A.8 technological**: A.8.2, A.8.3, A.8.11, A.8.15, A.8.16, A.8.24, A.8.28, A.8.34

### Test plan

Docs-only change. No code, build, or test impact. Anchor integrity validated by the in-tree markdown anchor hook.

### Breaking changes

None.

## Checklist

- [x] Docs added
- [x] README TOC updated
- [x] Related issue(s) linked (`Closes #622`, `Part of #645`)
- [x] No code changes