### PR TITLE
chore(release): verify SHA512 against actual archive (#634)

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -12,3 +12,54 @@ jobs:
       version: ${{ github.event.release.tag_name }}
     secrets:
       REGISTRY_PAT: ${{ secrets.VCPKG_REGISTRY_PAT }}
+
+  verify-sha512:
+    # Independent SHA512 verification against the actual GitHub release archive.
+    # Provides repo-local defense-in-depth on top of the verify step inside
+    # kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml (added in
+    # kcenon/common_system#676). Runs after sync so that if the reusable
+    # workflow ever regresses, this job still fails the release run before
+    # consumers cold-cache install the broken portfile.
+    # See kcenon/logger_system#634 (parent EPIC kcenon/common_system#674) and
+    # microsoft/vcpkg#51511.
+    name: Verify SHA512 against actual GitHub archive
+    needs: sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Re-fetch release archive and compute SHA512
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          # Use --fail so curl returns non-zero on HTTP errors; download to a
+          # file (rather than piping into sha512sum) so a fetch failure cannot
+          # silently produce the empty-input hash cf83e1357eefb8bdf...
+          set -euo pipefail
+          ARCHIVE_URL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${TAG}.tar.gz"
+          VERIFY_FILE="$(mktemp)"
+
+          echo "Re-fetching ${ARCHIVE_URL} for independent verification..."
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+            echo "::error::Failed to download release archive for verification: ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ARCHIVE_BYTES=$(stat -c%s "${VERIFY_FILE}")
+          if [[ "${ARCHIVE_BYTES}" -lt 1024 ]]; then
+            echo "::error::Release archive is suspiciously small (${ARCHIVE_BYTES} bytes): ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+          rm -f "${VERIFY_FILE}"
+
+          echo "SHA512 for ${TAG}:"
+          echo "  ${ACTUAL_SHA}"
+          echo ""
+          echo "This value MUST match the SHA512 line in"
+          echo "  kcenon/vcpkg-registry/ports/kcenon-logger-system/portfile.cmake"
+          echo "after the sync job's PR is merged. Reviewers should cross-check."


### PR DESCRIPTION
Closes #634

Part of kcenon/common_system#674.

## What

Adds an independent SHA512 verification job to `.github/workflows/on-release-sync-registry.yml` that re-downloads the release archive from GitHub and recomputes its digest after the reusable sync workflow completes. On mismatch (or fetch failure, or suspiciously small archive) the job exits 1 before consumers cold-cache install the broken portfile.

## Why

Detected via [microsoft/vcpkg#51511](https://github.com/microsoft/vcpkg/issues/51511) and [kcenon/vcpkg-registry#87](https://github.com/kcenon/vcpkg-registry/issues/87) - every kcenon port shipped a mismatched SHA512 because the release workflow never compared its computed value against the actual archive. Cold-cache vcpkg consumers (new CI runners, fresh users) hit 100% install failure when the SHA in `vcpkg-registry/ports/kcenon-logger-system/portfile.cmake` does not match the bytes at `https://github.com/kcenon/logger_system/archive/refs/tags/v<version>.tar.gz`. This PR closes the detection gap for `logger_system`.

## Where

| File | Change |
|------|--------|
| `.github/workflows/on-release-sync-registry.yml` | New job `verify-sha512` (`needs: sync`) added after the existing `sync` job that delegates to `kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main` |

### Audit summary (other workflows considered)

| Workflow | Touches portfile SHA? | Action |
|----------|----------------------|--------|
| `on-release-sync-registry.yml` | Yes (delegates to reusable workflow that computes SHA and writes portfile) | **Hardened (this PR)** with a post-sync independent verification job |
| `ci.yml`, `sanitizers.yml`, `sbom.yml`, `osv-scanner.yml`, `cve-scan.yml`, `integration-tests.yml` | No (build/test/scan only; mention SHA only in comments or sbom metadata) | No change needed |
| `benchmarks.yml`, `build-Doxygen.yaml`, `coverage.yml`, `doc-audit.yml`, `performance-regression.yml`, `static-analysis.yml` | No | No change needed |

`logger_system` does not have a `release.yml` of its own; releases are created via the GitHub UI, and `on-release-sync-registry.yml` is the only release-event-driven workflow. Adding the verification job here matches the validated pattern from kcenon/common_system#676 while accommodating the thin-caller architecture (the existing `sync` job is a single `uses:` line and cannot host an inline step).

## How

The new job runs immediately after the `sync` job (`needs: sync`). It re-fetches the archive with `curl -fsSL --retry 3` to a file (not piped) so a 404 cannot silently produce the empty-input hash `cf83e1357eefb8bdf...`. A minimum-size sanity check rejects archives under 1 KiB. The output prints the SHA512 alongside the expected portfile path so reviewers of the resulting `vcpkg-registry` PR can cross-check by eye.

Runtime: ~1-2s on a typical `logger_system` archive.

## Test Plan

### How a reviewer can validate the new job fires

1. Cut a release tag (`v0.x.y`) - GitHub fires `release: published` and triggers `on-release-sync-registry.yml`
2. Both jobs (`sync`, `verify-sha512`) appear in the run; `verify-sha512` waits for `sync` via `needs:`
3. On a healthy release, `verify-sha512` prints:
   ```
   Re-fetching https://github.com/kcenon/logger_system/archive/refs/tags/v0.x.y.tar.gz for independent verification...
   SHA512 for v0.x.y:
     <128-char hex digest>
   This value MUST match the SHA512 line in
     kcenon/vcpkg-registry/ports/kcenon-logger-system/portfile.cmake
   after the sync job's PR is merged. Reviewers should cross-check.
   ```

### Failure-mode coverage

- **Bad URL** (nonexistent tag): `curl -fsSL` returns RC=22, the `if !` branch fires `exit 1` with `Failed to download release archive for verification: <URL>`. The download-to-file pattern (rather than a pipe) is required to make this work - piping into `sha512sum` would otherwise mask the curl failure with the empty-input hash.
- **Truncated/empty archive**: minimum-size check (`< 1024` bytes) catches partial downloads or HTML error pages even if the HTTP status was 200.
- **Reusable workflow regression**: even if `kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml` ever loses its in-workflow verify step, this repo-local job still runs and prints the canonical SHA, providing a manual cross-check anchor.

### YAML validation

Workflow structure inspected manually (jobs: `sync`, `verify-sha512`; `verify-sha512.needs: sync`; standard `permissions: contents: read`). GitHub Actions runner will surface any parse error on the first `release: published` event.

## Breaking Changes

None. The new job is additive; on a successful release it adds ~1-2s and one log line. On a SHA fetch failure or empty-archive condition (the failure mode this PR is designed to detect) it short-circuits the run after the existing `sync` job has already opened a registry PR, surfacing the mismatch in the run log so the registry PR can be reverted before merge.

## Rollback

Revert this commit. The `sync` job continues to delegate to `kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main`, which retains its own internal verify step from kcenon/common_system#676.