### PR TITLE
build(vcpkg): bump vcpkg-registry baseline to resolve common-system port-version 3

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "50d89f5b1962e811dfb779bc46fa3d251db42ce7",
+      "baseline": "1be52cbd3f11369cf9eb983c02c4404df3155cc3",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## What

`vcpkg-configuration.json`의 git registry baseline을 `kcenon/vcpkg-registry` 현재 HEAD로 갱신한다.

- `50d89f5b1962e811dfb779bc46fa3d251db42ce7` → `1be52cbd3f11369cf9eb983c02c4404df3155cc3`

## Why

baseline `50d89f5b`(2026-03-26) 시점의 `versions/baseline.json`은 `kcenon-common-system` v0.2.0을 **port-version 0**으로 해소한다. port-version 0의 portfile SHA512(`7385ba3a...`)는 GitHub이 재생성한 현재 archive tarball 해시(`ac458878...`)와 불일치하여, `<os>/<compiler>` 빌드 매트릭스 4종이 `unexpected hash` 다운로드 실패로 깨진다.

레지스트리 HEAD `1be52cbd`는 이미 fix-forward 되어 `common-system`을 port-version 3(portfile SHA512 `ac458878...`, 실제 archive와 일치)으로 해소한다. baseline 1줄 갱신으로 레지스트리 변경 없이 정상 port를 가져온다.

## Where

- `vcpkg-configuration.json` — git registry baseline 1줄

## How

- `1be52cbd` 시점 `baseline.json`이 `kcenon-common-system` → port-version 3을 가리킴을 확인
- port-version 3 git-tree(`023f95ca`)의 portfile SHA512 = `ac458878...`
- `common_system` v0.2.0 archive 실측 SHA512(2026-05-21) = `ac458878...` (일치 확인)
- 빌드 매트릭스 최종 검증은 develop→main 릴리스 PR 시점 CI에서 수행됨(프로젝트 branching 정책상 develop PR은 빌드 워크플로 미트리거)

Closes #638
Relates to #636
