### PR TITLE
chore(release): align residual version strings with v1.0.0 (Doxyfile)

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,7 +1,7 @@
 # Doxyfile for logger_system
 
 PROJECT_NAME           = "Logger System"
-PROJECT_NUMBER         = "0.1.3"
+PROJECT_NUMBER         = "1.0.0"
 PROJECT_BRIEF          = "High-performance C++20 thread-safe logging system with asynchronous capabilities"
 OUTPUT_DIRECTORY       = documents
 GENERATE_HTML          = YES


### PR DESCRIPTION
Part of #604 — align residual version strings to v1.0.0 after the #611 version-cut. Doxyfile PROJECT_NUMBER was still 0.1.3.