### PR TITLE
fix(ci): isolate CMAKE_MODULE_PATH when building local dependencies

### DIFF
--- a/cmake/UnifiedDependencies.cmake
+++ b/cmake/UnifiedDependencies.cmake
@@ -365,8 +365,21 @@ macro(_unified_resolve_local DEP_NAME IS_REQUIRED)
             set(USE_UNIT_TEST OFF CACHE BOOL "" FORCE)
         endif()
 
+        # Isolate CMAKE_MODULE_PATH for the dependency's own configure. A
+        # source-built dependency (e.g. common_system) uses bare
+        # include(<module>) for its template modules (options, dependencies,
+        # targets, ...). Without isolation those resolve to THIS project's
+        # same-named modules inherited via CMAKE_MODULE_PATH, cross-wiring the
+        # dependency's build to the consumer's CMake logic (e.g. consuming the
+        # consumer's targets.cmake, which checks for the consumer's include
+        # tree). The dependency re-populates the path from its own CMakeLists,
+        # so empty-and-restore lets each side resolve its own modules. CMake
+        # builtin modules live in CMAKE_ROOT and are unaffected.
+        set(_unified_saved_module_path "${CMAKE_MODULE_PATH}")
+        set(CMAKE_MODULE_PATH "")
         # Use EXCLUDE_FROM_ALL to prevent installation of local dependencies
         add_subdirectory("${_local_path}" "${CMAKE_BINARY_DIR}/_local/${DEP_NAME}" EXCLUDE_FROM_ALL)
+        set(CMAKE_MODULE_PATH "${_unified_saved_module_path}")
 
         # Post-load handling
         if(${DEP_NAME} STREQUAL "logger_system")


### PR DESCRIPTION
## What

Isolate `CMAKE_MODULE_PATH` around source-built local dependencies in
`_unified_resolve_local`, fixing the `Sanitizer Tests` workflow (address /
thread / undefined) at Configure.

Change type: **fix(ci)** — build dependency resolution.

## Why

The three sanitizer jobs began failing on the v1.0.0 release-merge to main
(#647); the same logger code passed on the preceding develop PR. The trigger
is external: common_system v1.0.0 (#696) began using bare `include(<module>)`
for its template modules (`options`, `dependencies`, `targets`, ...). When
common_system is built from source via `add_subdirectory`, logger_system's
`cmake/` is on `CMAKE_MODULE_PATH` ahead of common's (common APPENDs its own
path), so those bare includes resolve to **logger's** same-named modules:

- `include(dependencies)` re-ran `unified_find_dependency(common_system)`,
  recursing into a duplicate `add_subdirectory`:
  `the binary directory .../_local/common_system is already used to build a
  source directory` / `REQUIRED dependency 'common_system' not found`.
- Past that, `include(targets)` ran logger's `targets.cmake` against common's
  source dir: `Logger System: Required directory missing: include/kcenon/logger`.

These are layered symptoms of one root cause: the consumer's module path
leaking into the dependency's configure.

## Where

`cmake/UnifiedDependencies.cmake` — `_unified_resolve_local`: save
`CMAKE_MODULE_PATH`, set it empty before the dependency's `add_subdirectory`,
and restore it after (13 lines incl. comment). The dependency re-populates the
path from its own `CMakeLists`; CMake builtin modules (in `CMAKE_ROOT`) are
unaffected. This isolates every source-built local dependency, not just
common_system.

## How (verification)

`Sanitizer Tests` checks out common_system at `ref: main` (which carries the
trigger), so it reproduces the failure faithfully. Verified by dispatching
`Sanitizer Tests` on this branch: all three jobs reach and pass Configure and
proceed to build/run.

The underlying common_system module-path ordering is also worth correcting at
the source (prepend its own path); that is tracked separately and benefits all
local consumers. This consumer-side isolation is independently correct.

Relates to #648 (release blocker — restores the CI green precondition for the
signed v1.0.0 tag), Relates to #639 (v1.0 readiness tracker).
