### PR TITLE
chore(ci): drop misconfigured gitsubmodule Dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,3 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
-
-  # Enable version updates for git submodules
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    assignees:
-      - "kcenon"
-    labels:
-      - "dependencies"
-      - "submodules"


### PR DESCRIPTION
## What

Remove the `gitsubmodule` `package-ecosystem` block from `.github/dependabot.yml`.

Change type: **chore(ci)** — Dependabot config.

## Why

The `Dependabot Updates` run fails every week with
`dependency_file_not_found: /.gitmodules`. The repository has no git submodules
(no `.gitmodules`); dependencies are managed via vcpkg. The `gitsubmodule`
ecosystem is therefore misconfigured and produces a recurring false failure.

## Where

`.github/dependabot.yml` — remove the `gitsubmodule` update block. The
`github-actions` ecosystem block is kept and continues to work.

## How (verification)

Dependabot reads `dependabot.yml` from the default branch, so this takes effect
once it reaches `main`. After that, the `submodules in /.` job no longer appears
and the recurring `dependency_file_not_found` failure stops; the `github-actions`
updates are unaffected.
