### PR TITLE
fix(build): link OpenSSL::Crypto for HMAC integrity policy

### DIFF
--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -304,6 +304,19 @@ else()
 endif()
 
 ##################################################
+# OpenSSL for HMAC integrity policy (rotating_file_writer)
+##################################################
+# rotating_file_writer's hmac_sha256_integrity_policy uses OpenSSL EVP_MAC
+# unconditionally (independent of LOGGER_USE_ENCRYPTION). Link libcrypto
+# whenever OpenSSL is available so those symbols resolve, and link it PUBLIC so
+# downstream consumers (e.g. network_system tests) pick up libcrypto with the
+# correct link order (after liblogger).
+find_package(OpenSSL QUIET)
+if(OpenSSL_FOUND)
+    target_link_libraries(logger_system PUBLIC OpenSSL::Crypto)
+endif()
+
+##################################################
 # OpenSSL (encryption)
 ##################################################
 if(LOGGER_USE_ENCRYPTION)


### PR DESCRIPTION
## What
Link `OpenSSL::Crypto` PUBLIC whenever OpenSSL is found, independent of `LOGGER_USE_ENCRYPTION`.

## Why
`rotating_file_writer`'s `hmac_sha256_integrity_policy::compute_hmac` uses OpenSSL `EVP_MAC` unconditionally, but OpenSSL was only linked under `LOGGER_USE_ENCRYPTION`. With encryption off, the HMAC code compiles into liblogger but libcrypto is not linked, leaving undefined references (`EVP_MAC_fetch`, `EVP_MAC_CTX_new`, `OSSL_PARAM_construct_utf8_string`, ...). These propagate to consumers — network_system integration tests fail to link `network_messaging_server_lifecycle_test`.

## Where
`cmake/targets.cmake` — `find_package(OpenSSL QUIET)` + `target_link_libraries(logger_system PUBLIC OpenSSL::Crypto)` before the existing encryption block.

## How (verification)
PUBLIC linkage places libcrypto after liblogger on consumers' link lines (correct GNU ld order). Verified against logger's own CI; resolves the network_system integration-test link failure once this lands on logger's default branch (network builds logger from its default branch).

Relates to #639 (ecosystem build robustness).